### PR TITLE
[codex] fix: clear SonarQube findings

### DIFF
--- a/emt/power_groups/rapl.py
+++ b/emt/power_groups/rapl.py
@@ -231,6 +231,12 @@ class RAPLSoC(PowerGroup):
     @classmethod
     def is_available(cls):
         """A check for availability of a readable RAPL interface."""
+
+        def can_read(path: Path) -> bool:
+            with open(path, "r") as file:
+                file.read(1)
+            return True
+
         try:
             if not os.path.exists(cls.RAPL_DIR):
                 return False
@@ -238,11 +244,9 @@ class RAPLSoC(PowerGroup):
                 if "rapl" not in zone or zone.count(":") != 1:
                     continue
                 zone_path = Path(cls.RAPL_DIR, zone)
-                with open(Path(zone_path, "name"), "r"):
-                    pass
-                with open(Path(zone_path, "energy_uj"), "r"):
-                    pass
-                return True
+                return can_read(Path(zone_path, "name")) and can_read(
+                    Path(zone_path, "energy_uj")
+                )
             return False
         except OSError:
             return False

--- a/scripts/verification_workload.py
+++ b/scripts/verification_workload.py
@@ -9,29 +9,40 @@ import time
 import os
 
 
+def deterministic_value(row: int, col: int, iteration: int) -> float:
+    """Return a stable pseudo-varying value without using a PRNG."""
+    return ((row * 31 + col * 17 + iteration * 13) % 1000) / 1000.0
+
+
 def cpu_intensive_work(duration_seconds: float = 10.0):
     """Perform CPU-intensive matrix operations for a fixed duration."""
-    import random
-
     print(f"PID: {os.getpid()}", flush=True)
     print(f"Starting CPU workload for {duration_seconds} seconds...", flush=True)
 
     start = time.perf_counter()
     iterations = 0
+    checksum = 0.0
 
     # Matrix size - adjust for desired CPU load
     size = 200
 
     while time.perf_counter() - start < duration_seconds:
-        # Create random matrices
-        a = [[random.random() for _ in range(size)] for _ in range(size)]
-        b = [[random.random() for _ in range(size)] for _ in range(size)]
+        # Create deterministic matrices so verification is repeatable.
+        a = [
+            [deterministic_value(i, k, iterations) for k in range(size)]
+            for i in range(size)
+        ]
+        b = [
+            [deterministic_value(k, j, iterations + 1) for j in range(size)]
+            for k in range(size)
+        ]
 
         # Matrix multiplication (CPU intensive)
         result = [
             [sum(a[i][k] * b[k][j] for k in range(size)) for j in range(size)]
             for i in range(size)
         ]
+        checksum += sum(sum(row) for row in result)
 
         iterations += 1
 
@@ -44,7 +55,11 @@ def cpu_intensive_work(duration_seconds: float = 10.0):
             )
 
     elapsed = time.perf_counter() - start
-    print(f"Completed {iterations} iterations in {elapsed:.2f} seconds", flush=True)
+    print(
+        f"Completed {iterations} iterations in {elapsed:.2f} seconds "
+        f"(checksum {checksum:.2f})",
+        flush=True,
+    )
     return iterations
 
 

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -32,6 +32,7 @@ sys.path.insert(0, str(PROJECT_ROOT))
 WORKLOAD_SCRIPT = Path(__file__).parent / "verification_workload.py"
 RUST_BINARY = PROJECT_ROOT / "target" / "release" / "energy-monitoring-tool"
 DEFAULT_OUTPUT_PATH = PROJECT_ROOT / ".artifacts" / "verification_results.json"
+RUST_VERIFY_TMP_DIR = PROJECT_ROOT / ".artifacts" / "tmp"
 PYTHON = sys.executable
 RAPL_ROOT = Path("/sys/class/powercap")
 ACCURACY_TOLERANCE_PERCENT = 2.0
@@ -340,7 +341,8 @@ def measure_rust_cli(
             f"Rust binary not found at {RUST_BINARY}. Run: cargo build --release"
         )
 
-    output_file = Path(f"/tmp/rust_verify_{iteration}_{os.getpid()}.json")
+    RUST_VERIFY_TMP_DIR.mkdir(parents=True, exist_ok=True)
+    output_file = RUST_VERIFY_TMP_DIR / f"rust_verify_{iteration}_{os.getpid()}.json"
     rust_duration = int(workload_duration) + 2
 
     start = time.perf_counter()
@@ -433,23 +435,11 @@ def _parse_json_str(s: str) -> dict[str, Any] | None:
 # ── Orchestrator ─────────────────────────────────────────────────────────────
 
 SETTLE_SECONDS = 3  # pause between phases to let system idle
+Method = tuple[str, Callable[[float, int], Result]]
 
 
-def run_verification(
-    num_iterations: int,
-    workload_duration: float,
-    output_path: Path = DEFAULT_OUTPUT_PATH,
-    use_sudo: bool = False,
-) -> None:
-    rapl_entries = assert_rapl_available()
-    metadata = collect_run_metadata(
-        rapl_entries,
-        num_iterations,
-        workload_duration,
-        output_path,
-        use_sudo,
-    )
-    methods: list[tuple[str, Callable[[float, int], Result]]] = [
+def build_verification_methods(use_sudo: bool) -> list[Method]:
+    return [
         ("Python EMT", measure_python_emt),
         (
             "Rust CLI",
@@ -461,6 +451,15 @@ def run_verification(
         ),
     ]
 
+
+def print_verification_header(
+    methods: list[Method],
+    num_iterations: int,
+    workload_duration: float,
+    rapl_entries: list[Path],
+    metadata: dict[str, Any],
+    use_sudo: bool,
+) -> None:
     print("=" * 70)
     print("Energy Monitoring Tool — Verification")
     print(f"Methods: {', '.join(n for n, _ in methods)}")
@@ -470,41 +469,60 @@ def run_verification(
     print_metadata_summary(metadata)
     print("=" * 70)
 
-    all_results: dict[str, list[Result]] = {name: [] for name, _ in methods}
 
-    for name, fn in methods:
-        print(f"\n{'─'*70}")
-        print(f"Phase: {name}")
-        print(f"{'─'*70}")
+def measure_method(
+    name: str,
+    fn: Callable[[float, int], Result],
+    num_iterations: int,
+    workload_duration: float,
+) -> list[Result]:
+    print(f"\n{'─'*70}")
+    print(f"Phase: {name}")
+    print(f"{'─'*70}")
 
-        for i in range(1, num_iterations + 1):
-            print(f"\n  [{name}] Iteration {i}/{num_iterations} …")
-            try:
-                r = fn(workload_duration, i)
-                all_results[name].append(r)
-                print(f"    → {r.total_energy_j:.2f} J  (duration {r.duration:.1f}s)")
-            except (
-                OSError,
-                RuntimeError,
-                ValueError,
-                subprocess.SubprocessError,
-            ) as error:
-                print(f"    ✗ Error: {error}")
+    results = []
+    for iteration in range(1, num_iterations + 1):
+        print(f"\n  [{name}] Iteration {iteration}/{num_iterations} …")
+        try:
+            result = fn(workload_duration, iteration)
+            results.append(result)
+            print(
+                f"    → {result.total_energy_j:.2f} J  "
+                f"(duration {result.duration:.1f}s)"
+            )
+        except (
+            OSError,
+            RuntimeError,
+            ValueError,
+            subprocess.SubprocessError,
+        ) as error:
+            print(f"    ✗ Error: {error}")
 
-            # pause between iterations
-            time.sleep(1)
+        time.sleep(1)
 
-        # pause between phases
-        print(f"\n  Settling for {SETTLE_SECONDS}s …")
-        time.sleep(SETTLE_SECONDS)
+    print(f"\n  Settling for {SETTLE_SECONDS}s …")
+    time.sleep(SETTLE_SECONDS)
+    return results
 
-    # ── Summary ──────────────────────────────────────────────────────────
+
+def run_methods(
+    methods: list[Method],
+    num_iterations: int,
+    workload_duration: float,
+) -> dict[str, list[Result]]:
+    return {
+        name: measure_method(name, fn, num_iterations, workload_duration)
+        for name, fn in methods
+    }
+
+
+def print_method_statistics(all_results: dict[str, list[Result]]) -> dict[str, float]:
     print()
     print("=" * 70)
     print("RESULTS")
     print("=" * 70)
 
-    means = {}
+    means: dict[str, float] = {}
     for name, results in all_results.items():
         if not results:
             continue
@@ -516,22 +534,27 @@ def run_verification(
         print(f"    Mean:  {mean_e:>10.2f} J")
         print(f"    Stdev: {std_e:>10.2f} J")
         print(f"    Range: [{min(energies):.2f} – {max(energies):.2f}] J")
+    return means
 
-    # Pairwise comparison
+
+def print_pairwise_comparison(means: dict[str, float]) -> None:
     names = list(means.keys())
-    if len(names) >= 2:
-        print(f"\n  {'─'*50}")
-        print(f"  Pairwise comparison:")
-        for i in range(len(names)):
-            for j in range(i + 1, len(names)):
-                a, b = names[i], names[j]
-                ref = means[a]
-                if ref > 0:
-                    diff = ((means[b] - ref) / ref) * 100
-                    status = "✅" if abs(diff) < 20 else "⚠️"
-                    print(f"    {status} {a} vs {b}: {diff:+.1f}%")
+    if len(names) < 2:
+        return
 
-    # Per-iteration table
+    print("\n  " + "─" * 50)
+    print("  Pairwise comparison:")
+    for i in range(len(names)):
+        for j in range(i + 1, len(names)):
+            a, b = names[i], names[j]
+            ref = means[a]
+            if ref > 0:
+                diff = ((means[b] - ref) / ref) * 100
+                status = "✅" if abs(diff) < 20 else "⚠️"
+                print(f"    {status} {a} vs {b}: {diff:+.1f}%")
+
+
+def print_iteration_table(all_results: dict[str, list[Result]]) -> None:
     print(f"\n  {'Iter':<5}", end="")
     for name in all_results:
         print(f"  {name:>15}", end="")
@@ -552,20 +575,29 @@ def run_verification(
                 print(f"  {'—':>15}", end="")
         print()
 
-    analysis = build_acceptance_analysis(all_results)
-    python_vs_rust = analysis.get("python_vs_rust")
-    if python_vs_rust is not None:
-        status = "✅ PASS" if python_vs_rust["within_tolerance"] else "⚠️ FAIL"
-        relative_diff = python_vs_rust["relative_diff_percent"]
-        rel_text = f"{relative_diff:.2f}%" if relative_diff is not None else "n/a"
-        print(f"\n  {'─'*50}")
-        print("  Acceptance criterion — Python EMT vs Rust CLI:")
-        print(
-            f"    {status} relative difference {rel_text} "
-            f"(tolerance ±{analysis['tolerance_percent']:.2f}%)"
-        )
 
-    # Save JSON
+def print_acceptance_summary(analysis: dict[str, Any]) -> None:
+    python_vs_rust = analysis.get("python_vs_rust")
+    if python_vs_rust is None:
+        return
+
+    status = "✅ PASS" if python_vs_rust["within_tolerance"] else "⚠️ FAIL"
+    relative_diff = python_vs_rust["relative_diff_percent"]
+    rel_text = f"{relative_diff:.2f}%" if relative_diff is not None else "n/a"
+    print("\n  " + "─" * 50)
+    print("  Acceptance criterion — Python EMT vs Rust CLI:")
+    print(
+        f"    {status} relative difference {rel_text} "
+        f"(tolerance ±{analysis['tolerance_percent']:.2f}%)"
+    )
+
+
+def write_results(
+    output_path: Path,
+    metadata: dict[str, Any],
+    analysis: dict[str, Any],
+    all_results: dict[str, list[Result]],
+) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_payload = {
         "metadata": metadata,
@@ -577,6 +609,43 @@ def run_verification(
         encoding="utf-8",
     )
     print(f"\n  Results saved to {output_path}")
+
+
+def print_results(all_results: dict[str, list[Result]]) -> dict[str, Any]:
+    means = print_method_statistics(all_results)
+    print_pairwise_comparison(means)
+    print_iteration_table(all_results)
+    analysis = build_acceptance_analysis(all_results)
+    print_acceptance_summary(analysis)
+    return analysis
+
+
+def run_verification(
+    num_iterations: int,
+    workload_duration: float,
+    output_path: Path = DEFAULT_OUTPUT_PATH,
+    use_sudo: bool = False,
+) -> None:
+    rapl_entries = assert_rapl_available()
+    metadata = collect_run_metadata(
+        rapl_entries,
+        num_iterations,
+        workload_duration,
+        output_path,
+        use_sudo,
+    )
+    methods = build_verification_methods(use_sudo)
+    print_verification_header(
+        methods,
+        num_iterations,
+        workload_duration,
+        rapl_entries,
+        metadata,
+        use_sudo,
+    )
+    all_results = run_methods(methods, num_iterations, workload_duration)
+    analysis = print_results(all_results)
+    write_results(output_path, metadata, analysis, all_results)
 
 
 # ── CLI ──────────────────────────────────────────────────────────────────────

--- a/tests/test_rust_bindings.py
+++ b/tests/test_rust_bindings.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 
 def test_rust_bindings_create_energy_group():
     from emt._rust import EnergyGroup, RaplCollector
@@ -11,7 +13,7 @@ def test_rust_bindings_create_energy_group():
     )
 
     assert group.is_running() is False
-    assert group.total_energy() == 0.0
+    assert group.total_energy() == pytest.approx(0.0)
     assert group.energy_trace() == {
         "pid": [],
         "device": [],

--- a/tests/test_verification_scripts.py
+++ b/tests/test_verification_scripts.py
@@ -1,0 +1,327 @@
+import builtins
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts import verification_workload
+from scripts import verify
+
+
+def test_deterministic_value_is_stable_and_varies_by_coordinates():
+    value = verification_workload.deterministic_value(2, 3, 4)
+
+    assert value == pytest.approx(0.165)
+    assert verification_workload.deterministic_value(2, 3, 4) == value
+    assert verification_workload.deterministic_value(2, 3, 5) != value
+
+
+def test_cpu_intensive_work_uses_deterministic_matrix_and_checksum(monkeypatch, capsys):
+    times = iter([0.0, 0.0, 0.5, 2.0, 2.0])
+
+    def fake_range(size):
+        if size == 200:
+            return builtins.range(2)
+        return builtins.range(size)
+
+    monkeypatch.setattr(verification_workload.time, "perf_counter", lambda: next(times))
+    monkeypatch.setattr(verification_workload, "range", fake_range, raising=False)
+
+    iterations = verification_workload.cpu_intensive_work(duration_seconds=1.0)
+
+    expected_a = [
+        [
+            verification_workload.deterministic_value(row, col, 0)
+            for col in builtins.range(2)
+        ]
+        for row in builtins.range(2)
+    ]
+    expected_b = [
+        [
+            verification_workload.deterministic_value(row, col, 1)
+            for col in builtins.range(2)
+        ]
+        for row in builtins.range(2)
+    ]
+    expected_checksum = sum(
+        sum(
+            sum(expected_a[row][k] * expected_b[k][col] for k in builtins.range(2))
+            for col in builtins.range(2)
+        )
+        for row in builtins.range(2)
+    )
+
+    assert iterations == 1
+    assert f"checksum {expected_checksum:.2f}" in capsys.readouterr().out
+
+
+def test_build_verification_methods_forwards_sudo_to_rust(monkeypatch):
+    calls = []
+
+    def fake_measure_rust_cli(duration, iteration, use_sudo=False):
+        calls.append((duration, iteration, use_sudo))
+        return verify.Result("rust_cli", iteration, duration, 1.0)
+
+    monkeypatch.setattr(verify, "measure_rust_cli", fake_measure_rust_cli)
+
+    methods = verify.build_verification_methods(use_sudo=True)
+    rust_result = methods[1][1](3.5, 2)
+
+    assert [name for name, _ in methods] == ["Python EMT", "Rust CLI"]
+    assert rust_result.total_energy_j == pytest.approx(1.0)
+    assert calls == [(3.5, 2, True)]
+
+
+def test_measure_rust_cli_writes_output_under_artifacts_tmp(tmp_path, monkeypatch):
+    rust_binary = tmp_path / "energy-monitoring-tool"
+    rust_binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    output_dir = tmp_path / "rust-output"
+    popen_calls = []
+
+    class FakeProcess:
+        def __init__(self, cmd, **kwargs):
+            self.cmd = cmd
+            self.kwargs = kwargs
+            self.pid = 12345
+            self.returncode = 0
+            popen_calls.append(cmd)
+
+            if str(rust_binary) in cmd:
+                output_file = Path(cmd[cmd.index("--output") + 1])
+                output_file.write_text(
+                    json.dumps({"total_energy": 42.5, "devices": {"cpu": 42.5}}),
+                    encoding="utf-8",
+                )
+
+        def wait(self):
+            return 0
+
+        def communicate(self, timeout=None):
+            return "", ""
+
+    monkeypatch.setattr(verify, "RUST_BINARY", rust_binary)
+    monkeypatch.setattr(verify, "RUST_VERIFY_TMP_DIR", output_dir)
+    monkeypatch.setattr(verify.subprocess, "Popen", FakeProcess)
+    monkeypatch.setattr(verify.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(verify.time, "perf_counter", iter([10.0, 14.0]).__next__)
+
+    result = verify.measure_rust_cli(workload_duration=5.0, iteration=7)
+
+    assert result.total_energy_j == pytest.approx(42.5)
+    assert result.details["devices"] == {"cpu": 42.5}
+    assert output_dir.is_dir()
+    assert list(output_dir.iterdir()) == []
+    rust_cmd = popen_calls[1]
+    assert rust_cmd[rust_cmd.index("--output") + 1].startswith(str(output_dir))
+
+
+def test_measure_method_keeps_successes_and_reports_expected_errors(
+    monkeypatch, capsys
+):
+    sleeps = []
+
+    def fake_measure(duration, iteration):
+        if iteration == 2:
+            raise ValueError("bad sample")
+        return verify.Result("fake", iteration, duration + iteration, 10.0 + iteration)
+
+    monkeypatch.setattr(verify.time, "sleep", sleeps.append)
+    monkeypatch.setattr(verify, "SETTLE_SECONDS", 0.25)
+
+    results = verify.measure_method("Fake", fake_measure, 2, 3.0)
+
+    assert [result.iteration for result in results] == [1]
+    assert results[0].duration == pytest.approx(4.0)
+    assert sleeps == [1, 1, 0.25]
+    output = capsys.readouterr().out
+    assert "Phase: Fake" in output
+    assert "bad sample" in output
+
+
+def test_run_methods_invokes_each_named_method(monkeypatch):
+    calls = []
+
+    def fake_measure_method(name, fn, num_iterations, workload_duration):
+        calls.append((name, fn(workload_duration, 1), num_iterations))
+        return [verify.Result(name, 1, workload_duration, 1.0)]
+
+    monkeypatch.setattr(verify, "measure_method", fake_measure_method)
+
+    results = verify.run_methods(
+        [("A", lambda duration, iteration: duration + iteration)],
+        num_iterations=3,
+        workload_duration=2.0,
+    )
+
+    assert calls == [("A", 3.0, 3)]
+    assert results["A"][0].duration == pytest.approx(2.0)
+
+
+def test_printing_results_builds_statistics_tables_and_acceptance(capsys):
+    all_results = {
+        "Python EMT": [
+            verify.Result("python_emt", 1, 1.0, 10.0),
+            verify.Result("python_emt", 2, 1.0, 12.0),
+        ],
+        "Rust CLI": [verify.Result("rust_cli", 1, 1.0, 11.0)],
+    }
+
+    analysis = verify.print_results(all_results)
+
+    assert analysis["python_vs_rust"]["within_tolerance"] is True
+    output = capsys.readouterr().out
+    assert "RESULTS" in output
+    assert "Pairwise comparison" in output
+    assert "Acceptance criterion" in output
+
+
+def test_print_helpers_handle_empty_or_zero_reference_results(capsys):
+    assert verify.print_method_statistics({"empty": []}) == {}
+
+    verify.print_pairwise_comparison({"only": 1.0})
+    verify.print_pairwise_comparison({"zero": 0.0, "other": 3.0})
+    verify.print_iteration_table(
+        {"left": [], "right": [verify.Result("right", 1, 1, 2)]}
+    )
+    verify.print_acceptance_summary({"python_vs_rust": None})
+
+    output = capsys.readouterr().out
+    assert "RESULTS" in output
+    assert "Pairwise comparison" in output
+    assert "right" in output
+
+
+def test_write_results_serializes_metadata_analysis_and_dataclass_results(tmp_path):
+    output_path = tmp_path / "nested" / "results.json"
+    metadata = {"host": "test-host"}
+    analysis = {"python_vs_rust": None}
+    all_results = {
+        "Python EMT": [
+            verify.Result(
+                method="python_emt",
+                iteration=1,
+                duration=1.2,
+                total_energy_j=3.4,
+                details={"workload_pid": 123},
+            )
+        ]
+    }
+
+    verify.write_results(output_path, metadata, analysis, all_results)
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["metadata"] == metadata
+    assert payload["analysis"] == analysis
+    assert payload["Python EMT"][0]["total_energy_j"] == pytest.approx(3.4)
+    assert payload["Python EMT"][0]["details"] == {"workload_pid": 123}
+
+
+def test_print_verification_header_includes_methods_and_rapl(monkeypatch, capsys):
+    monkeypatch.setattr(
+        verify,
+        "print_metadata_summary",
+        lambda metadata: print(f"metadata:{metadata['hostname']}"),
+    )
+
+    verify.print_verification_header(
+        methods=[("Python EMT", lambda _duration, _iteration: None)],
+        num_iterations=2,
+        workload_duration=5.0,
+        rapl_entries=[Path("/sys/class/powercap/intel-rapl:0")],
+        metadata={"hostname": "host-a"},
+        use_sudo=True,
+    )
+
+    output = capsys.readouterr().out
+    assert "Methods: Python EMT" in output
+    assert "RAPL zones: intel-rapl:0" in output
+    assert "Rust CLI sudo: enabled" in output
+    assert "metadata:host-a" in output
+
+
+def test_run_verification_wires_collection_reporting_and_output(monkeypatch, tmp_path):
+    calls = []
+    output_path = tmp_path / "verification.json"
+    fake_methods = [("Fake", lambda _duration, _iteration: None)]
+    fake_results = {"Fake": [verify.Result("fake", 1, 0.1, 1.0)]}
+    fake_analysis = {"python_vs_rust": None}
+
+    monkeypatch.setattr(
+        verify,
+        "assert_rapl_available",
+        lambda: calls.append("rapl") or [Path("/rapl/intel-rapl:0")],
+    )
+    monkeypatch.setattr(
+        verify,
+        "collect_run_metadata",
+        lambda rapl_entries, iterations, duration, output, use_sudo: calls.append(
+            ("metadata", rapl_entries, iterations, duration, output, use_sudo)
+        )
+        or {"hostname": "host-a"},
+    )
+    monkeypatch.setattr(
+        verify,
+        "build_verification_methods",
+        lambda use_sudo: calls.append(("methods", use_sudo)) or fake_methods,
+    )
+    monkeypatch.setattr(
+        verify,
+        "print_verification_header",
+        lambda *args: calls.append(("header", args)),
+    )
+    monkeypatch.setattr(
+        verify,
+        "run_methods",
+        lambda methods, iterations, duration: calls.append(
+            ("run", methods, iterations, duration)
+        )
+        or fake_results,
+    )
+    monkeypatch.setattr(
+        verify,
+        "print_results",
+        lambda results: calls.append(("print", results)) or fake_analysis,
+    )
+    monkeypatch.setattr(
+        verify,
+        "write_results",
+        lambda output, metadata, analysis, results: calls.append(
+            ("write", output, metadata, analysis, results)
+        ),
+    )
+
+    verify.run_verification(
+        num_iterations=3,
+        workload_duration=4.0,
+        output_path=output_path,
+        use_sudo=True,
+    )
+
+    assert calls[0] == "rapl"
+    assert ("methods", True) in calls
+    assert ("run", fake_methods, 3, 4.0) in calls
+    assert ("print", fake_results) in calls
+    assert calls[-1] == (
+        "write",
+        output_path,
+        {"hostname": "host-a"},
+        fake_analysis,
+        fake_results,
+    )
+
+
+def test_measure_method_catches_subprocess_errors(monkeypatch, capsys):
+    monkeypatch.setattr(verify.time, "sleep", lambda _seconds: None)
+
+    results = verify.measure_method(
+        "Subprocess",
+        lambda _duration, _iteration: (_ for _ in ()).throw(
+            subprocess.SubprocessError("subprocess failed")
+        ),
+        num_iterations=1,
+        workload_duration=1.0,
+    )
+
+    assert results == []
+    assert "subprocess failed" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Clears the local SonarQube findings found in the latest workstation analysis by tightening the verification scripts and small test/helper code paths.

- Replace verification workload PRNG inputs with deterministic matrix values and retain a checksum so the workload output is consumed.
- Move Rust verifier temporary JSON output from public `/tmp` into ignored `.artifacts/tmp`.
- Split `run_verification` into focused helper functions to reduce cognitive complexity.
- Replace empty RAPL readability checks with an explicit one-byte read helper.
- Use `pytest.approx` for the Rust binding floating-point assertion.

## Validation

- `.venv/bin/python -m black --check .`
- `.venv/bin/python -m pytest`
- `.venv/bin/python -m coverage run -m pytest && .venv/bin/python -m coverage xml -o coverage.xml`
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release`
- `.venv/bin/python scripts/verify.py --iterations 1 --duration 1 -o .artifacts/sonar_cleanup_verify.json`

Note: I could inspect the local SonarQube database and target all unresolved findings from the latest analysis, but a fresh local scanner run was not possible because `sonar-scanner` and `SONAR_TOKEN` are not configured in the shell. The PR SonarQube check should provide the authoritative re-scan.