### PR TITLE
feat: Rust collector rewrite — Monitor, config, trace, CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ python scripts/verify.py --iterations 3 --duration 30
 The active comparison is:
 
 - Python EMT: `emt.EnergyMonitor`
-- Rust CLI: `energy-monitoring-tool`
+- Rust CLI: `emt`
 - Shared workload source: `scripts/verification_workload.py`
 - Output: `.artifacts/verification_results.json`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,6 +564,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "debug_unsafe"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,6 +678,7 @@ dependencies = [
  "env_logger",
  "itertools",
  "log",
+ "nvml-wrapper",
  "polars",
  "pyo3",
  "rand 0.8.5",
@@ -1200,6 +1236,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,6 +1358,16 @@ name = "libc"
 version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "libm"
@@ -1462,6 +1514,29 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "nvml-wrapper"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9bff0aa1d48904a1385ea2a8b97576fbdcbc9a3cfccd0d31fe978e1c4038c5"
+dependencies = [
+ "bitflags",
+ "libloading",
+ "nvml-wrapper-sys",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "wrapcenum-derive",
+]
+
+[[package]]
+name = "nvml-wrapper-sys"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "698d45156f28781a4e79652b6ebe2eaa0589057d588d3aec1333f6466f13fcb5"
+dependencies = [
+ "libloading",
 ]
 
 [[package]]
@@ -3835,6 +3910,18 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wrapcenum-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76ff259533532054cfbaefb115c613203c73707017459206380f03b3b3f266e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "argminmax"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,6 +580,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +639,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
+ "dirs",
  "env_logger",
  "itertools",
  "log",
@@ -620,7 +648,9 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "serde_yml",
  "sysinfo",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "users",
@@ -693,6 +723,12 @@ name = "fast-float2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1288,6 +1324,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1489,6 +1544,12 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking"
@@ -2388,6 +2449,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2692,6 +2764,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yml"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyml",
+ "memchr",
+ "ryu",
+ "serde",
+ "version_check",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2915,6 +3002,19 @@ name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ serde_json = "1.0"
 pyo3 = { version = "0.28.3", features = ["extension-module"], optional = true }
 serde_yml = "0.0.12"
 dirs = "6"
+nvml-wrapper = "0.10"
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 crate-type = ["cdylib", "rlib"]
 
 [[bin]]
-name = "energy-monitoring-tool"
+name = "emt"
 path = "src/main.rs"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,8 @@ clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 pyo3 = { version = "0.28.3", features = ["extension-module"], optional = true }
+serde_yml = "0.0.12"
+dirs = "6"
+
+[dev-dependencies]
+tempfile = "3"

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -4,7 +4,7 @@ Energy Monitoring Tool — Verification Script
 
 Compares energy measurements from two independent methods, each run in ISOLATION:
     1. Python EMT (emt.EnergyMonitor) — monitors verification_workload.py by PID
-    2. Rust CLI   (energy-monitoring-tool) — monitors verification_workload.py by PID
+    2. Rust CLI   (emt) — monitors verification_workload.py by PID
 
 Isolation is critical: because idle energy is attributed proportionally to all
 active processes, each method runs the workload alone so that the workload is
@@ -30,7 +30,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_ROOT))
 
 WORKLOAD_SCRIPT = Path(__file__).parent / "verification_workload.py"
-RUST_BINARY = PROJECT_ROOT / "target" / "release" / "energy-monitoring-tool"
+RUST_BINARY = PROJECT_ROOT / "target" / "release" / "emt"
 DEFAULT_OUTPUT_PATH = PROJECT_ROOT / ".artifacts" / "verification_results.json"
 RUST_VERIFY_TMP_DIR = PROJECT_ROOT / ".artifacts" / "tmp"
 PYTHON = sys.executable

--- a/src/collectors/nvidia_gpu.rs
+++ b/src/collectors/nvidia_gpu.rs
@@ -2,176 +2,124 @@ use crate::energy_group::{EnergyCollector, EnergyRecord};
 use async_trait::async_trait;
 use chrono::Utc;
 use log::{debug, warn};
+use nvml_wrapper::enums::device::UsedGpuMemory;
+use nvml_wrapper::Nvml;
 use std::collections::{HashMap, HashSet};
-use std::process::Command;
 use std::sync::{Arc, Mutex};
 use tokio::task;
 
+/// NVIDIA GPU energy collector using direct NVML library bindings.
+///
+/// Replaces the previous `nvidia-smi` CLI-based approach with the `nvml-wrapper`
+/// crate for significantly lower overhead (no process spawning per sample).
 pub struct NvidiaGpu {
-    pub device_ids: Vec<u32>,
+    /// NVML library handle. `None` when NVML is unavailable (graceful degradation).
+    nvml: Option<Arc<Nvml>>,
+    /// Number of GPU devices detected at construction time.
+    device_count: u32,
+    /// Optional device index filter. `None` means monitor all GPUs.
+    device_filter: Option<Vec<u32>>,
+    /// PIDs to attribute energy to.
     tracked_pids: Arc<Mutex<Vec<u32>>>,
-    previous_energy_mj: Arc<Mutex<HashMap<u32, f64>>>,
-}
-
-#[derive(Debug, Clone)]
-struct GpuSnapshot {
-    index: u32,
-    uuid: String,
-    total_energy_mj: f64,
-    used_memory_mib: f64,
+    /// Previous cumulative energy reading (millijoules) per GPU index, used for delta computation.
+    previous_energy_mj: Arc<Mutex<HashMap<u32, u64>>>,
 }
 
 impl NvidiaGpu {
-    pub fn new(device_ids: Vec<u32>) -> Self {
-        Self {
-            device_ids,
+    /// Construct a new collector that discovers all NVIDIA GPUs via NVML.
+    pub fn new() -> Result<Self, String> {
+        let nvml = Nvml::init().map_err(|e| format!("Failed to initialize NVML: {}", e))?;
+        let device_count = nvml
+            .device_count()
+            .map_err(|e| format!("Failed to get device count: {}", e))?;
+        Ok(Self {
+            nvml: Some(Arc::new(nvml)),
+            device_count,
+            device_filter: None,
             tracked_pids: Arc::new(Mutex::new(Vec::new())),
             previous_energy_mj: Arc::new(Mutex::new(HashMap::new())),
-        }
-    }
-
-    async fn run_nvidia_smi(args: &[&str]) -> Result<String, String> {
-        let args_vec: Vec<String> = args.iter().map(|arg| arg.to_string()).collect();
-        task::spawn_blocking(move || {
-            let output = Command::new("nvidia-smi")
-                .args(&args_vec)
-                .output()
-                .map_err(|e| {
-                    format!(
-                        "Failed to execute nvidia-smi with args {:?}: {}",
-                        args_vec, e
-                    )
-                })?;
-
-            if !output.status.success() {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                return Err(format!(
-                    "nvidia-smi command failed with args {:?}: {}",
-                    args_vec,
-                    stderr.trim()
-                ));
-            }
-
-            Ok(String::from_utf8_lossy(&output.stdout).to_string())
-        })
-        .await
-        .map_err(|e| format!("Failed to join nvidia-smi task with args {:?}: {}", args, e))?
-    }
-
-    fn parse_gpu_snapshot_line(line: &str) -> Option<GpuSnapshot> {
-        let fields: Vec<&str> = line.split(',').map(|s| s.trim()).collect();
-        if fields.len() != 4 {
-            return None;
-        }
-
-        let index = fields[0].parse::<u32>().ok()?;
-        let total_energy_mj = fields[2].parse::<f64>().ok()?;
-        let used_memory_mib = fields[3].parse::<f64>().ok()?;
-
-        Some(GpuSnapshot {
-            index,
-            uuid: fields[1].to_string(),
-            total_energy_mj,
-            used_memory_mib,
         })
     }
 
-    fn parse_process_line(line: &str) -> Option<(String, u32, f64)> {
-        let fields: Vec<&str> = line.split(',').map(|s| s.trim()).collect();
-        if fields.len() != 3 {
-            return None;
-        }
-
-        let pid = fields[1].parse::<u32>().ok()?;
-        let used_memory_mib = fields[2].parse::<f64>().ok()?;
-
-        Some((fields[0].to_string(), pid, used_memory_mib))
+    /// Construct a collector with an explicit device index filter.
+    ///
+    /// Only the GPUs whose indices appear in `device_ids` will be monitored.
+    pub fn with_device_filter(device_ids: Vec<u32>) -> Result<Self, String> {
+        let mut collector = Self::new()?;
+        collector.device_filter = Some(device_ids);
+        Ok(collector)
     }
 
-    fn compute_delta_joules(
-        previous_total_energy_mj: Option<f64>,
-        current_total_energy_mj: f64,
-    ) -> f64 {
-        previous_total_energy_mj
-            .map(|prev| ((current_total_energy_mj - prev) / 1000.0).max(0.0))
+    /// Compute the energy delta in joules from two consecutive millijoule readings.
+    ///
+    /// Returns 0.0 when there is no previous reading (first sample) or when the
+    /// delta is negative (counter wrap or driver reset).
+    fn compute_delta_joules(previous_mj: Option<u64>, current_mj: u64) -> f64 {
+        previous_mj
+            .map(|prev| {
+                if current_mj >= prev {
+                    (current_mj - prev) as f64 / 1000.0
+                } else {
+                    0.0
+                }
+            })
             .unwrap_or(0.0)
     }
 
+    /// Attribute a GPU energy delta to tracked processes by their GPU memory share.
     fn attribute_energy_for_processes(
-        gpu: &GpuSnapshot,
+        gpu_index: u32,
         delta_joules: f64,
+        total_used_memory_bytes: u64,
         tracked_pid_set: &HashSet<u32>,
-        process_memories: &[(u32, f64)],
+        process_memories: &[(u32, u64)],
         timestamp: i64,
     ) -> Vec<EnergyRecord> {
-        if delta_joules <= 0.0 || gpu.used_memory_mib <= 0.0 {
+        if delta_joules <= 0.0 || total_used_memory_bytes == 0 {
             return Vec::new();
         }
 
         process_memories
             .iter()
-            .filter(|(pid, used_mem)| tracked_pid_set.contains(pid) && *used_mem > 0.0)
-            .map(|(pid, process_memory_mib)| EnergyRecord {
+            .filter(|(pid, mem)| tracked_pid_set.contains(pid) && *mem > 0)
+            .map(|(pid, process_memory_bytes)| EnergyRecord {
                 pid: *pid,
                 timestamp,
-                device: format!("nvidia:gpu:{}", gpu.index),
-                energy: delta_joules * (process_memory_mib / gpu.used_memory_mib),
+                device: format!("nvidia:gpu:{}", gpu_index),
+                energy: delta_joules * (*process_memory_bytes as f64 / total_used_memory_bytes as f64),
             })
             .collect()
     }
 
-    async fn query_gpus(&self) -> Result<Vec<GpuSnapshot>, String> {
-        let output = Self::run_nvidia_smi(&[
-            "--query-gpu=index,uuid,total_energy_consumption,memory.used",
-            "--format=csv,noheader,nounits",
-        ])
-        .await?;
-
-        let wanted_devices: HashSet<u32> = self.device_ids.iter().cloned().collect();
-        let snapshots = output
-            .lines()
-            .filter_map(Self::parse_gpu_snapshot_line)
-            .filter(|gpu| wanted_devices.contains(&gpu.index))
-            .collect::<Vec<_>>();
-
-        Ok(snapshots)
-    }
-
-    async fn query_compute_processes(&self) -> HashMap<String, Vec<(u32, f64)>> {
-        let output = Self::run_nvidia_smi(&[
-            "--query-compute-apps=gpu_uuid,pid,used_gpu_memory",
-            "--format=csv,noheader,nounits",
-        ])
-        .await;
-
-        let output = match output {
-            Ok(output) => output,
-            Err(err) => {
-                // Treat failures as no active processes, but log so outages/misconfigurations are visible.
-                warn!(
-                    "Failed to query active compute processes via nvidia-smi: {}",
-                    err
-                );
-                return HashMap::new();
-            }
-        };
-
-        let mut per_gpu_processes: HashMap<String, Vec<(u32, f64)>> = HashMap::new();
-        for process in output.lines().filter_map(Self::parse_process_line) {
-            let (uuid, pid, used_memory_mib) = process;
-            per_gpu_processes
-                .entry(uuid)
-                .or_default()
-                .push((pid, used_memory_mib));
+    /// Determine which device indices to iterate based on the optional filter.
+    fn device_indices(&self) -> Vec<u32> {
+        match &self.device_filter {
+            Some(filter) => filter
+                .iter()
+                .filter(|&&idx| idx < self.device_count)
+                .copied()
+                .collect(),
+            None => (0..self.device_count).collect(),
         }
-
-        per_gpu_processes
     }
 }
 
 impl Default for NvidiaGpu {
+    /// Creates a safe default that works even when no NVIDIA GPU is present.
+    ///
+    /// The `nvml` field will be `None` and all collection operations will
+    /// gracefully return empty results.
     fn default() -> Self {
-        Self::new(vec![0]) // Default to GPU 0
+        match Self::new() {
+            Ok(collector) => collector,
+            Err(_) => Self {
+                nvml: None,
+                device_count: 0,
+                device_filter: None,
+                tracked_pids: Arc::new(Mutex::new(Vec::new())),
+                previous_energy_mj: Arc::new(Mutex::new(HashMap::new())),
+            },
+        }
     }
 }
 
@@ -182,49 +130,98 @@ impl EnergyCollector for NvidiaGpu {
     }
 
     async fn get_energy_trace(&self) -> Result<Vec<EnergyRecord>, String> {
-        let timestamp = Utc::now().timestamp_millis();
+        let nvml = match &self.nvml {
+            Some(nvml) => Arc::clone(nvml),
+            None => return Ok(Vec::new()),
+        };
+
         let tracked_pids = self.tracked_pids.lock().unwrap().clone();
         if tracked_pids.is_empty() {
             return Ok(Vec::new());
         }
 
         let tracked_pid_set: HashSet<u32> = tracked_pids.into_iter().collect();
-        let gpus = match self.query_gpus().await {
-            Ok(gpus) => gpus,
-            Err(e) => {
-                warn!("Could not query NVIDIA GPU energy: {}", e);
-                return Ok(Vec::new());
+        let device_indices = self.device_indices();
+        let previous_energy_mj = Arc::clone(&self.previous_energy_mj);
+
+        // NVML calls are blocking; run them on a blocking thread to avoid
+        // stalling the async runtime.
+        let records = task::spawn_blocking(move || {
+            let timestamp = Utc::now().timestamp_millis();
+            let mut previous = previous_energy_mj.lock().unwrap();
+            let mut records = Vec::new();
+
+            for idx in device_indices {
+                let device = match nvml.device_by_index(idx) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        warn!("Failed to get NVIDIA device {}: {}", idx, e);
+                        continue;
+                    }
+                };
+
+                // Read cumulative energy consumption in millijoules.
+                let current_energy_mj = match device.total_energy_consumption() {
+                    Ok(mj) => mj,
+                    Err(e) => {
+                        warn!("Failed to read energy for GPU {}: {}", idx, e);
+                        continue;
+                    }
+                };
+
+                // Compute delta from previous sample.
+                let prev = previous.get(&idx).copied();
+                previous.insert(idx, current_energy_mj);
+                let delta_joules = Self::compute_delta_joules(prev, current_energy_mj);
+
+                // Get memory info for the total used memory on the device.
+                let total_used_memory = match device.memory_info() {
+                    Ok(info) => info.used,
+                    Err(e) => {
+                        warn!("Failed to read memory info for GPU {}: {}", idx, e);
+                        continue;
+                    }
+                };
+
+                // Get per-process GPU memory for compute processes.
+                let process_memories: Vec<(u32, u64)> =
+                    match device.running_compute_processes() {
+                        Ok(procs) => procs
+                            .iter()
+                            .filter_map(|p| match p.used_gpu_memory {
+                                UsedGpuMemory::Used(bytes) => Some((p.pid, bytes)),
+                                UsedGpuMemory::Unavailable => None,
+                            })
+                            .collect(),
+                        Err(e) => {
+                            // No compute processes is a normal state; only warn
+                            // on unexpected errors.
+                            debug!(
+                                "No compute processes on GPU {} ({}), skipping attribution",
+                                idx, e
+                            );
+                            continue;
+                        }
+                    };
+
+                if process_memories.is_empty() {
+                    continue;
+                }
+
+                records.extend(Self::attribute_energy_for_processes(
+                    idx,
+                    delta_joules,
+                    total_used_memory,
+                    &tracked_pid_set,
+                    &process_memories,
+                    timestamp,
+                ));
             }
-        };
 
-        let per_gpu_processes = self.query_compute_processes().await;
-        let mut previous_energy_mj = self.previous_energy_mj.lock().unwrap();
-        let mut records = Vec::new();
-
-        for gpu in gpus {
-            let previous = previous_energy_mj.get(&gpu.index).copied();
-            previous_energy_mj.insert(gpu.index, gpu.total_energy_mj);
-            let delta_joules = Self::compute_delta_joules(previous, gpu.total_energy_mj);
-
-            let process_memories = per_gpu_processes
-                .get(&gpu.uuid)
-                .cloned()
-                .unwrap_or_default();
-
-            if process_memories.is_empty() {
-                continue;
-            }
-
-            // Match Python collector attribution: distribute zone energy by each tracked
-            // process memory share on the GPU for this sampling interval.
-            records.extend(Self::attribute_energy_for_processes(
-                &gpu,
-                delta_joules,
-                &tracked_pid_set,
-                &process_memories,
-                timestamp,
-            ));
-        }
+            records
+        })
+        .await
+        .map_err(|e| format!("Failed to join NVML collection task: {}", e))?;
 
         debug!(
             "NVIDIA GPU energy trace collected: {} records",
@@ -234,19 +231,8 @@ impl EnergyCollector for NvidiaGpu {
     }
 
     fn is_available() -> bool {
-        // Check if nvidia-smi command exists or NVIDIA drivers are loaded
-        Command::new("nvidia-smi")
-            .arg("--query-gpu=count")
-            .arg("--format=csv,noheader,nounits")
-            .output()
-            .ok()
-            .filter(|output| output.status.success())
-            .and_then(|output| {
-                String::from_utf8(output.stdout)
-                    .ok()
-                    .and_then(|stdout| stdout.lines().next()?.trim().parse::<u32>().ok())
-            })
-            .map(|count| count > 0)
+        Nvml::init()
+            .and_then(|nvml| nvml.device_count().map(|count| count > 0))
             .unwrap_or(false)
     }
 }
@@ -256,65 +242,191 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parses_gpu_snapshot_line() {
-        let parsed =
-            NvidiaGpu::parse_gpu_snapshot_line("0, GPU-1234, 1200, 2048").expect("must parse");
-        assert_eq!(parsed.index, 0);
-        assert_eq!(parsed.uuid, "GPU-1234");
-        assert_eq!(parsed.total_energy_mj, 1200.0);
-        assert_eq!(parsed.used_memory_mib, 2048.0);
-    }
-
-    #[test]
-    fn rejects_gpu_snapshot_line_with_non_numeric_energy() {
-        let parsed = NvidiaGpu::parse_gpu_snapshot_line("0, GPU-1234, N/A, 2048");
-        assert!(parsed.is_none());
-    }
-
-    #[test]
-    fn parses_process_line() {
-        let parsed = NvidiaGpu::parse_process_line("GPU-1234, 4242, 512").expect("must parse");
-        assert_eq!(parsed.0, "GPU-1234");
-        assert_eq!(parsed.1, 4242);
-        assert_eq!(parsed.2, 512.0);
-    }
-
-    #[test]
-    fn rejects_process_line_with_n_a_memory() {
-        let parsed = NvidiaGpu::parse_process_line("GPU-1234, 4242, N/A");
-        assert!(parsed.is_none());
-    }
-
-    #[test]
     fn first_sample_delta_is_zero() {
-        let delta = NvidiaGpu::compute_delta_joules(None, 1200.0);
+        let delta = NvidiaGpu::compute_delta_joules(None, 1200);
         assert_eq!(delta, 0.0);
     }
 
     #[test]
+    fn positive_delta_is_computed_correctly() {
+        // 2200 mJ -> 3200 mJ = 1000 mJ = 1.0 J
+        let delta = NvidiaGpu::compute_delta_joules(Some(2200), 3200);
+        assert!((delta - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
     fn negative_delta_is_clamped_to_zero() {
-        let delta = NvidiaGpu::compute_delta_joules(Some(2200.0), 1200.0);
+        let delta = NvidiaGpu::compute_delta_joules(Some(2200), 1200);
+        assert_eq!(delta, 0.0);
+    }
+
+    #[test]
+    fn zero_delta_when_no_change() {
+        let delta = NvidiaGpu::compute_delta_joules(Some(5000), 5000);
         assert_eq!(delta, 0.0);
     }
 
     #[test]
     fn attributes_energy_by_process_memory_share() {
-        let gpu = GpuSnapshot {
-            index: 0,
-            uuid: "GPU-1234".to_string(),
-            total_energy_mj: 2000.0,
-            used_memory_mib: 100.0,
-        };
         let tracked: HashSet<u32> = HashSet::from([1001, 1002]);
-        let process_memories = vec![(1001, 40.0), (1002, 60.0), (9999, 30.0)];
+        // Total used memory on GPU: 100 MB (in bytes)
+        let total_used = 100 * 1024 * 1024;
+        // Process memories in bytes
+        let process_memories = vec![
+            (1001, 40 * 1024 * 1024_u64),
+            (1002, 60 * 1024 * 1024_u64),
+            (9999, 30 * 1024 * 1024_u64),
+        ];
 
-        let records =
-            NvidiaGpu::attribute_energy_for_processes(&gpu, 10.0, &tracked, &process_memories, 42);
+        let records = NvidiaGpu::attribute_energy_for_processes(
+            0,
+            10.0,
+            total_used,
+            &tracked,
+            &process_memories,
+            42,
+        );
 
         assert_eq!(records.len(), 2);
         assert_eq!(records[0].pid, 1001);
         assert_eq!(records[1].pid, 1002);
+        // 10.0 * (40/100) = 4.0
         assert!((records[0].energy - 4.0).abs() < f64::EPSILON);
+        // 10.0 * (60/100) = 6.0
         assert!((records[1].energy - 6.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn attribution_returns_empty_on_zero_delta() {
+        let tracked: HashSet<u32> = HashSet::from([1001]);
+        let process_memories = vec![(1001, 1024_u64)];
+
+        let records = NvidiaGpu::attribute_energy_for_processes(
+            0,
+            0.0, // zero delta
+            4096,
+            &tracked,
+            &process_memories,
+            42,
+        );
+
+        assert!(records.is_empty());
+    }
+
+    #[test]
+    fn attribution_returns_empty_on_zero_memory() {
+        let tracked: HashSet<u32> = HashSet::from([1001]);
+        let process_memories = vec![(1001, 1024_u64)];
+
+        let records = NvidiaGpu::attribute_energy_for_processes(
+            0,
+            10.0,
+            0, // zero total used memory
+            &tracked,
+            &process_memories,
+            42,
+        );
+
+        assert!(records.is_empty());
+    }
+
+    #[test]
+    fn attribution_excludes_untracked_pids() {
+        let tracked: HashSet<u32> = HashSet::from([1001]);
+        let process_memories = vec![
+            (1001, 50 * 1024 * 1024_u64),
+            (9999, 50 * 1024 * 1024_u64), // not tracked
+        ];
+        let total_used = 100 * 1024 * 1024;
+
+        let records = NvidiaGpu::attribute_energy_for_processes(
+            0,
+            10.0,
+            total_used,
+            &tracked,
+            &process_memories,
+            42,
+        );
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].pid, 1001);
+        // 10.0 * (50/100) = 5.0
+        assert!((records[0].energy - 5.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn default_without_gpu_is_safe() {
+        // Default constructor should not panic regardless of GPU availability.
+        let collector = NvidiaGpu::default();
+        // device_count should be 0 if no GPU, >0 if GPU present
+        // Either way, no panic is the success criterion.
+        assert!(collector.device_count == 0 || collector.nvml.is_some());
+    }
+
+    #[test]
+    fn device_indices_with_no_filter() {
+        let collector = NvidiaGpu {
+            nvml: None,
+            device_count: 3,
+            device_filter: None,
+            tracked_pids: Arc::new(Mutex::new(Vec::new())),
+            previous_energy_mj: Arc::new(Mutex::new(HashMap::new())),
+        };
+        assert_eq!(collector.device_indices(), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn device_indices_with_filter() {
+        let collector = NvidiaGpu {
+            nvml: None,
+            device_count: 4,
+            device_filter: Some(vec![1, 3]),
+            tracked_pids: Arc::new(Mutex::new(Vec::new())),
+            previous_energy_mj: Arc::new(Mutex::new(HashMap::new())),
+        };
+        assert_eq!(collector.device_indices(), vec![1, 3]);
+    }
+
+    #[test]
+    fn device_indices_filter_excludes_out_of_range() {
+        let collector = NvidiaGpu {
+            nvml: None,
+            device_count: 2,
+            device_filter: Some(vec![0, 1, 5, 10]),
+            tracked_pids: Arc::new(Mutex::new(Vec::new())),
+            previous_energy_mj: Arc::new(Mutex::new(HashMap::new())),
+        };
+        assert_eq!(collector.device_indices(), vec![0, 1]);
+    }
+
+    #[test]
+    fn is_available_returns_false_without_gpu() {
+        // On CI/test hosts without NVIDIA GPUs, this should return false (not panic).
+        // On hosts with GPUs it returns true. Either is acceptable.
+        let _ = NvidiaGpu::is_available();
+    }
+
+    #[tokio::test]
+    async fn get_energy_trace_returns_empty_when_no_nvml() {
+        let collector = NvidiaGpu {
+            nvml: None,
+            device_count: 0,
+            device_filter: None,
+            tracked_pids: Arc::new(Mutex::new(vec![1234])),
+            previous_energy_mj: Arc::new(Mutex::new(HashMap::new())),
+        };
+
+        let result = collector.get_energy_trace().await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_energy_trace_returns_empty_when_no_tracked_pids() {
+        let collector = NvidiaGpu::default();
+        // No tracked PIDs set
+        let result = collector.get_energy_trace().await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
     }
 }

--- a/src/collectors/nvidia_gpu.rs
+++ b/src/collectors/nvidia_gpu.rs
@@ -177,7 +177,7 @@ impl Default for NvidiaGpu {
 
 #[async_trait]
 impl EnergyCollector for NvidiaGpu {
-    fn set_tracked_pids(&mut self, pids: Vec<u32>) {
+    fn set_tracked_pids(&self, pids: Vec<u32>) {
         *self.tracked_pids.lock().unwrap() = pids;
     }
 

--- a/src/collectors/rapl.rs
+++ b/src/collectors/rapl.rs
@@ -534,8 +534,8 @@ impl Default for Rapl {
 
 #[async_trait]
 impl EnergyCollector for Rapl {
-    fn set_tracked_pids(&mut self, pids: Vec<u32>) {
-        self.tracked_pids = Arc::new(Mutex::new(pids));
+    fn set_tracked_pids(&self, pids: Vec<u32>) {
+        *self.tracked_pids.lock().unwrap() = pids;
     }
 
     async fn get_energy_trace(&self) -> Result<Vec<EnergyRecord>, String> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,244 @@
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// Configuration for process discovery behavior.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct DiscoveryConfig {
+    /// Interval in seconds between process tree scans.
+    pub scan_interval_secs: f64,
+}
+
+/// Configuration for energy collection behavior.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CollectionConfig {
+    /// Collection rate in Hz.
+    pub rate_hz: f64,
+    /// Maximum trace retention in seconds before rotation.
+    pub trace_retention_secs: u64,
+}
+
+/// Top-level EMT configuration with layered resolution.
+///
+/// Resolution precedence (highest wins):
+/// 1. CLI arguments (applied programmatically after loading)
+/// 2. Project-local: `./emt.yaml`
+/// 3. User-level: `~/.config/emt/config.yaml`
+///
+/// Missing files are silently skipped. Missing keys use compiled defaults.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct EmtConfig {
+    pub discovery: DiscoveryConfig,
+    pub collection: CollectionConfig,
+}
+
+/// Errors that can occur while loading configuration.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("Failed to read config file: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Failed to parse YAML: {0}")]
+    Yaml(String),
+}
+
+impl Default for DiscoveryConfig {
+    fn default() -> Self {
+        Self {
+            scan_interval_secs: 2.0,
+        }
+    }
+}
+
+impl Default for CollectionConfig {
+    fn default() -> Self {
+        Self {
+            rate_hz: 10.0,
+            trace_retention_secs: 3600,
+        }
+    }
+}
+
+impl EmtConfig {
+    /// Load config with layered resolution.
+    ///
+    /// Reads user-level config first (`~/.config/emt/config.yaml`), then overlays
+    /// project-local config (`./emt.yaml`) on top. Missing files are silently
+    /// skipped and defaults are returned.
+    pub fn load() -> Self {
+        let mut base = serde_yml::to_value(EmtConfig::default())
+            .unwrap_or(serde_yml::Value::Mapping(serde_yml::Mapping::new()));
+
+        // Layer 1: user-level config
+        if let Some(user_path) = Self::user_config_path() {
+            if let Ok(content) = std::fs::read_to_string(&user_path) {
+                if let Ok(user_value) = serde_yml::from_str::<serde_yml::Value>(&content) {
+                    base = merge_yaml(base, user_value);
+                }
+            }
+        }
+
+        // Layer 2: project-local config (highest file priority)
+        let local_path = Path::new("./emt.yaml");
+        if let Ok(content) = std::fs::read_to_string(local_path) {
+            if let Ok(local_value) = serde_yml::from_str::<serde_yml::Value>(&content) {
+                base = merge_yaml(base, local_value);
+            }
+        }
+
+        serde_yml::from_value(base).unwrap_or_default()
+    }
+
+    /// Load configuration from a specific YAML file path.
+    pub fn from_file(path: &Path) -> Result<Self, ConfigError> {
+        let content = std::fs::read_to_string(path)?;
+        serde_yml::from_str(&content).map_err(|e| ConfigError::Yaml(e.to_string()))
+    }
+
+    /// Returns the user-level config path: `~/.config/emt/config.yaml`
+    fn user_config_path() -> Option<std::path::PathBuf> {
+        dirs::config_dir().map(|dir| dir.join("emt").join("config.yaml"))
+    }
+}
+
+/// Deep-merge two YAML values. Mappings are merged recursively;
+/// scalars and sequences in the overlay replace the base entirely.
+fn merge_yaml(base: serde_yml::Value, overlay: serde_yml::Value) -> serde_yml::Value {
+    match (base, overlay) {
+        (serde_yml::Value::Mapping(mut base_map), serde_yml::Value::Mapping(overlay_map)) => {
+            for (key, value) in overlay_map {
+                let merged = if let Some(base_value) = base_map.remove(&key) {
+                    merge_yaml(base_value, value)
+                } else {
+                    value
+                };
+                base_map.insert(key, merged);
+            }
+            serde_yml::Value::Mapping(base_map)
+        }
+        (_, overlay) => overlay,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    #[test]
+    fn defaults_are_sensible() {
+        let config = EmtConfig::default();
+        assert_eq!(config.discovery.scan_interval_secs, 2.0);
+        assert_eq!(config.collection.rate_hz, 10.0);
+        assert_eq!(config.collection.trace_retention_secs, 3600);
+    }
+
+    #[test]
+    fn partial_yaml_fills_defaults() {
+        let yaml = "collection:\n  rate_hz: 20.0\n";
+        let config: EmtConfig = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(config.collection.rate_hz, 20.0);
+        assert_eq!(config.collection.trace_retention_secs, 3600);
+        assert_eq!(config.discovery.scan_interval_secs, 2.0);
+    }
+
+    #[test]
+    fn empty_yaml_returns_defaults() {
+        let yaml = "{}";
+        let config: EmtConfig = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(config.collection.rate_hz, 10.0);
+        assert_eq!(config.collection.trace_retention_secs, 3600);
+        assert_eq!(config.discovery.scan_interval_secs, 2.0);
+    }
+
+    #[test]
+    fn from_file_reads_valid_yaml() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("test_config.yaml");
+        let mut file = std::fs::File::create(&file_path).unwrap();
+        writeln!(
+            file,
+            "discovery:\n  scan_interval_secs: 5.0\ncollection:\n  rate_hz: 25.0"
+        )
+        .unwrap();
+
+        let config = EmtConfig::from_file(&file_path).unwrap();
+        assert_eq!(config.discovery.scan_interval_secs, 5.0);
+        assert_eq!(config.collection.rate_hz, 25.0);
+        assert_eq!(config.collection.trace_retention_secs, 3600);
+    }
+
+    #[test]
+    fn from_file_returns_error_for_missing_file() {
+        let result = EmtConfig::from_file(Path::new("/nonexistent/path/config.yaml"));
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), ConfigError::Io(_)));
+    }
+
+    #[test]
+    fn from_file_returns_error_for_invalid_yaml() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("bad.yaml");
+        let mut file = std::fs::File::create(&file_path).unwrap();
+        writeln!(file, "collection:\n  rate_hz: [invalid").unwrap();
+
+        let result = EmtConfig::from_file(&file_path);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), ConfigError::Yaml(_)));
+    }
+
+    #[test]
+    fn merge_yaml_deep_merges_mappings() {
+        let base_yaml = "discovery:\n  scan_interval_secs: 2.0\ncollection:\n  rate_hz: 10.0\n  trace_retention_secs: 3600\n";
+        let overlay_yaml = "collection:\n  rate_hz: 50.0\n";
+
+        let base: serde_yml::Value = serde_yml::from_str(base_yaml).unwrap();
+        let overlay: serde_yml::Value = serde_yml::from_str(overlay_yaml).unwrap();
+
+        let merged = merge_yaml(base, overlay);
+        let config: EmtConfig = serde_yml::from_value(merged).unwrap();
+
+        assert_eq!(config.collection.rate_hz, 50.0);
+        assert_eq!(config.collection.trace_retention_secs, 3600);
+        assert_eq!(config.discovery.scan_interval_secs, 2.0);
+    }
+
+    #[test]
+    fn local_overrides_user_config() {
+        // Simulate the merge sequence: defaults -> user -> local
+        let user_yaml = "discovery:\n  scan_interval_secs: 5.0\ncollection:\n  rate_hz: 20.0\n";
+        let local_yaml = "collection:\n  rate_hz: 100.0\n";
+
+        let defaults = serde_yml::to_value(EmtConfig::default()).unwrap();
+        let user: serde_yml::Value = serde_yml::from_str(user_yaml).unwrap();
+        let local: serde_yml::Value = serde_yml::from_str(local_yaml).unwrap();
+
+        let merged = merge_yaml(merge_yaml(defaults, user), local);
+        let config: EmtConfig = serde_yml::from_value(merged).unwrap();
+
+        // local overrides user's rate_hz
+        assert_eq!(config.collection.rate_hz, 100.0);
+        // user's scan_interval_secs is preserved (local didn't touch it)
+        assert_eq!(config.discovery.scan_interval_secs, 5.0);
+        // defaults fill trace_retention_secs (neither user nor local set it)
+        assert_eq!(config.collection.trace_retention_secs, 3600);
+    }
+
+    #[test]
+    fn missing_files_return_defaults() {
+        // load() with no files on disk should return defaults without panicking
+        let config = EmtConfig::load();
+        assert_eq!(config.collection.rate_hz, 10.0);
+        assert_eq!(config.collection.trace_retention_secs, 3600);
+        assert_eq!(config.discovery.scan_interval_secs, 2.0);
+    }
+
+    #[test]
+    fn user_config_path_is_under_config_dir() {
+        if let Some(path) = EmtConfig::user_config_path() {
+            assert!(path.ends_with("emt/config.yaml"));
+        }
+    }
+}

--- a/src/energy_group.rs
+++ b/src/energy_group.rs
@@ -1,9 +1,8 @@
 use crate::utils::errors::MonitoringError;
-use crate::utils::psutils::collect_process_groups;
 use crate::utils::trace_rotation::RotatingTrace;
 use async_trait::async_trait;
-use itertools::multiunzip;
 use polars::prelude::*;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::mpsc;
@@ -14,13 +13,6 @@ pub enum EnergyCollectorType {
     Rapl,
     NvidiaGpu,
     Dummy,
-}
-
-#[derive(Debug)]
-pub struct ProcessGroup {
-    pub user: String,
-    pub task: String,
-    pub pids: Vec<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -47,8 +39,6 @@ pub struct EnergyGroup<T: EnergyCollector> {
     rate: f64,
     /// Number of iterations to batch before sending data back from the collector
     batch_size: usize,
-    /// DataFrame: user | task | pid
-    tracked_processes: DataFrame,
     /// Rotating trace: pid | timestamp | device | energy
     energy_trace: RotatingTrace,
     /// Underlying collector instance
@@ -59,69 +49,31 @@ pub struct EnergyGroup<T: EnergyCollector> {
     task_handle: Option<JoinHandle<()>>,
     /// Receiver for collected energy data from the background task
     data_receiver: Option<mpsc::Receiver<Vec<EnergyRecord>>>,
+    /// Per-PID cumulative energy accumulator
+    consumed_energy: HashMap<u32, f64>,
 }
 
 impl<T: EnergyCollector> EnergyGroup<T> {
-    /// Create a new PowerGroup with explicit collector instance
-    pub fn create_with_collector(
-        mut collector: T,
-        rate: f64,
-        pids: Option<Vec<usize>>,
-        batch_size: Option<usize>,
-    ) -> Result<Self, MonitoringError> {
-        let process_groups: Vec<ProcessGroup> = collect_process_groups(pids)?;
-        if process_groups.is_empty() {
-            return Err(MonitoringError::ProcessDiscoveryError(
-                "No processes found".to_string(),
-            ));
-        }
-
-        // Concise conversion to Polars DataFrame: user | task | pid
-        let (users, tasks, pids_col): (Vec<String>, Vec<String>, Vec<u32>) =
-            multiunzip(process_groups.iter().flat_map(|group| {
-                group
-                    .pids
-                    .iter()
-                    .map(move |&pid| (group.user.clone(), group.task.clone(), pid as u32))
-            }));
-
-        // Set tracked PIDs in the collector for per-process energy attribution
-        collector.set_tracked_pids(pids_col.clone());
-
-        let tracked_processes: DataFrame = df![
-            "user" => users,
-            "task" => tasks,
-            "pid" => pids_col,
-        ]
-        .map_err(|e| MonitoringError::Other(format!("Failed to create DataFrame: {}", e)))?;
-
+    /// Create a new EnergyGroup with an explicit collector instance
+    pub fn new(collector: T, rate: f64, batch_size: Option<usize>) -> Self {
         // Create rotating trace with 1 hour default retention
         let energy_trace = RotatingTrace::new(3600);
 
-        Ok(Self {
+        Self {
             rate,
             batch_size: batch_size.unwrap_or(1000),
-            tracked_processes,
             energy_trace,
             energy_collector: Arc::new(collector),
             is_running: Arc::new(AtomicBool::new(false)),
             task_handle: None,
             data_receiver: None,
-        })
+            consumed_energy: HashMap::new(),
+        }
     }
 
-    /// Convenience constructor: only rate and pids. A default collector instance is created.
-    /// for the collector type `T`, it must implement `Default`.
-    pub fn new(rate: f64, pids: Option<Vec<usize>>) -> Result<Self, MonitoringError>
-    where
-        T: Default,
-    {
-        Self::create_with_collector(T::default(), rate, pids, None)
-    }
-
-    /// Get a reference to the tracked process DataFrame
-    pub fn processes(&self) -> &DataFrame {
-        &self.tracked_processes
+    /// Set the tracked PIDs by delegating to the collector
+    pub fn set_tracked_pids(&self, pids: Vec<u32>) {
+        self.energy_collector.set_tracked_pids(pids);
     }
 
     /// Get a reference to the energy trace data (as DataFrame)
@@ -135,7 +87,6 @@ impl<T: EnergyCollector> EnergyGroup<T> {
     }
 
     /// Set the retention window for all traces (in seconds)
-    /// This affects both energy and utilization traces
     pub fn set_trace_retention(&mut self, retention_seconds: i64) {
         self.energy_trace.set_retention_seconds(retention_seconds);
     }
@@ -148,10 +99,20 @@ impl<T: EnergyCollector> EnergyGroup<T> {
         }
     }
 
+    /// Get the per-PID cumulative energy accumulator
+    pub fn consumed_energy_by_pid(&self) -> &HashMap<u32, f64> {
+        &self.consumed_energy
+    }
+
+    /// Get total consumed energy across all tracked PIDs
+    pub fn total_consumed_energy(&self) -> f64 {
+        self.consumed_energy.values().sum()
+    }
+
     /// Add energy records to the energy trace
-    pub fn append_energy_records(
+    fn append_energy_records(
         &mut self,
-        records: Vec<EnergyRecord>,
+        records: &[EnergyRecord],
     ) -> Result<(), MonitoringError> {
         if records.is_empty() {
             return Ok(());
@@ -180,6 +141,13 @@ impl<T: EnergyCollector> EnergyGroup<T> {
         self.energy_trace.append(&data)?;
 
         Ok(())
+    }
+
+    /// Accumulate energy records into the per-PID HashMap
+    fn accumulate_energy(&mut self, records: &[EnergyRecord]) {
+        for record in records {
+            *self.consumed_energy.entry(record.pid).or_insert(0.0) += record.energy;
+        }
     }
 
     /// Check if the underlying collector is available on the system
@@ -291,8 +259,9 @@ impl<T: EnergyCollector> EnergyGroup<T> {
             .await
             .map_err(|e| MonitoringError::Other(format!("Failed to get energy trace: {}", e)))?;
 
-        // Append initial data
-        self.append_energy_records(energy_records)?;
+        // Append and accumulate initial data
+        self.append_energy_records(&energy_records)?;
+        self.accumulate_energy(&energy_records);
 
         // Create bounded channel for background task to send data back
         // Channel capacity: allow a reasonable buffer (e.g., 10 batches)
@@ -318,9 +287,9 @@ impl<T: EnergyCollector> EnergyGroup<T> {
         Ok(())
     }
 
-    /// Poll the channel and append any received data to the energy trace
-    /// Call this periodically to receive and process data from the background task
-    pub fn poll_data(&mut self) -> Result<(), MonitoringError> {
+    /// Poll the channel, append received data to the energy trace, and accumulate per-PID energy.
+    /// Returns all energy records drained from the channel.
+    pub fn poll_data(&mut self) -> Vec<EnergyRecord> {
         // Collect all available messages first
         let mut all_energy_records = Vec::new();
 
@@ -330,12 +299,15 @@ impl<T: EnergyCollector> EnergyGroup<T> {
             }
         }
 
-        // Now append all collected records
+        // Append to trace and accumulate
         if !all_energy_records.is_empty() {
-            self.append_energy_records(all_energy_records)?;
+            if let Err(e) = self.append_energy_records(&all_energy_records) {
+                log::error!("Failed to append energy records to trace: {}", e);
+            }
+            self.accumulate_energy(&all_energy_records);
         }
 
-        Ok(())
+        all_energy_records
     }
 
     pub fn shutdown(&mut self) -> Result<(), MonitoringError> {
@@ -355,7 +327,7 @@ impl<T: EnergyCollector> EnergyGroup<T> {
         std::thread::sleep(std::time::Duration::from_millis(200));
 
         // Poll any remaining data from the channel
-        self.poll_data()?;
+        self.poll_data();
 
         // Now abort the background task (it should already be stopped)
         if let Some(handle) = self.task_handle.take() {
@@ -371,7 +343,7 @@ impl<T: EnergyCollector> EnergyGroup<T> {
 #[async_trait]
 pub trait EnergyCollector: Send + Sync + 'static {
     /// Set the list of tracked process PIDs for energy attribution
-    fn set_tracked_pids(&mut self, pids: Vec<u32>);
+    fn set_tracked_pids(&self, pids: Vec<u32>);
 
     /// Get energy trace data
     async fn get_energy_trace(&self) -> Result<Vec<EnergyRecord>, String>;

--- a/src/energy_group.rs
+++ b/src/energy_group.rs
@@ -1,3 +1,4 @@
+use crate::trace_recorder::TraceRecorder;
 use crate::utils::errors::MonitoringError;
 use crate::utils::trace_rotation::RotatingTrace;
 use async_trait::async_trait;
@@ -51,6 +52,8 @@ pub struct EnergyGroup<T: EnergyCollector> {
     data_receiver: Option<mpsc::Receiver<Vec<EnergyRecord>>>,
     /// Per-PID cumulative energy accumulator
     consumed_energy: HashMap<u32, f64>,
+    /// Registered trace recorders for persistent storage
+    recorders: Vec<Box<dyn TraceRecorder>>,
 }
 
 impl<T: EnergyCollector> EnergyGroup<T> {
@@ -68,12 +71,18 @@ impl<T: EnergyCollector> EnergyGroup<T> {
             task_handle: None,
             data_receiver: None,
             consumed_energy: HashMap::new(),
+            recorders: Vec::new(),
         }
     }
 
     /// Set the tracked PIDs by delegating to the collector
     pub fn set_tracked_pids(&self, pids: Vec<u32>) {
         self.energy_collector.set_tracked_pids(pids);
+    }
+
+    /// Register a trace recorder for persistent storage of energy data.
+    pub fn add_recorder(&mut self, recorder: Box<dyn TraceRecorder>) {
+        self.recorders.push(recorder);
     }
 
     /// Get a reference to the energy trace data (as DataFrame)
@@ -328,6 +337,11 @@ impl<T: EnergyCollector> EnergyGroup<T> {
 
         // Poll any remaining data from the channel
         self.poll_data();
+
+        // Final flush to all registered recorders
+        for recorder in &mut self.recorders {
+            recorder.flush(&self.energy_trace);
+        }
 
         // Now abort the background task (it should already be stopped)
         if let Some(handle) = self.task_handle.take() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod collectors;
 pub mod config;
 pub mod energy_group;
+pub mod monitor;
 
 pub mod utils {
     pub mod errors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod collectors;
+pub mod config;
 pub mod energy_group;
 
 pub mod utils {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod collectors;
 pub mod config;
 pub mod energy_group;
+pub mod trace_recorder;
 
 pub mod utils {
     pub mod errors;

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,26 +48,22 @@ async fn main() {
         info!("Energy Monitoring Tool started");
     }
 
-    // Convert PID to the format expected by EnergyGroup
-    let pids: Option<Vec<usize>> = args.pid.map(|p| vec![p as usize]);
+    // Determine PIDs to track
+    let tracked_pids: Vec<u32> = match args.pid {
+        Some(pid) => vec![pid],
+        None => vec![std::process::id()],
+    };
 
     // Create a RAPL energy group collector with small batch size for CLI
     // Batch size of 10 means data is sent every 10 iterations (1 second at 10 Hz)
-    let mut energy_group: EnergyGroup<Rapl> = match EnergyGroup::create_with_collector(
-        Rapl::default(),
-        args.rate,
-        pids,
-        Some(10), // Small batch size for responsive CLI output
-    ) {
-        Ok(group) => group,
-        Err(e) => {
-            eprintln!("Failed to create energy group: {}", e);
-            std::process::exit(1);
-        }
-    };
+    let mut energy_group: EnergyGroup<Rapl> =
+        EnergyGroup::new(Rapl::default(), args.rate, Some(10));
+
+    // Set the PIDs to track
+    energy_group.set_tracked_pids(tracked_pids.clone());
 
     if !args.quiet {
-        info!("Tracked processes: {:?}", energy_group.processes());
+        info!("Tracked PIDs: {:?}", tracked_pids);
         info!(
             "Monitoring for {} seconds at {} Hz...",
             args.duration, args.rate
@@ -86,33 +82,23 @@ async fn main() {
 
     while start.elapsed().as_secs() < args.duration {
         tokio::time::sleep(poll_interval).await;
-        if let Err(e) = energy_group.poll_data() {
-            eprintln!("Warning: Failed to poll data: {}", e);
-        }
+        energy_group.poll_data();
     }
-
-    // Polling complete
 
     // Shutdown and get final data
     if let Err(e) = energy_group.shutdown() {
         eprintln!("Warning: Shutdown error: {}", e);
     }
 
-    // Calculate total energy from trace
-    let trace = energy_group.energy_trace();
+    // Calculate total energy from the accumulator
     let actual_duration = start.elapsed().as_secs_f64();
+    let total_energy = energy_group.total_consumed_energy();
 
-    let mut total_energy = 0.0;
+    // Group energy by device from trace
+    let trace = energy_group.energy_trace();
     let mut device_energy: std::collections::HashMap<String, f64> =
         std::collections::HashMap::new();
 
-    if let Ok(energy_col) = trace.column("energy") {
-        if let Ok(values) = energy_col.f64() {
-            total_energy = values.iter().flatten().sum();
-        }
-    }
-
-    // Group energy by device
     if let (Ok(device_col), Ok(energy_col)) = (trace.column("device"), trace.column("energy")) {
         if let (Ok(devices), Ok(energies)) = (device_col.str(), energy_col.f64()) {
             for (device, energy) in devices.iter().zip(energies.iter()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,15 @@
 use clap::Parser;
-use emt::{collectors::Rapl, energy_group::EnergyGroup, utils};
-use log::info;
+use emt::config::EmtConfig;
+use emt::monitor::{DeviceEnergy, MetricsSnapshot, Monitor};
 use serde::Serialize;
 use std::fs::File;
 use std::io::Write;
 
 #[derive(Parser, Debug)]
-#[command(name = "energy-monitoring-tool")]
-#[command(about = "Monitor energy consumption of processes using RAPL")]
+#[command(name = "emt")]
+#[command(about = "Monitor energy consumption of processes")]
 struct Args {
-    /// Process ID to monitor (if not specified, monitors current process tree)
+    /// Process ID to monitor (if not specified, monitors all root processes)
     #[arg(short, long)]
     pid: Option<u32>,
 
@@ -17,9 +17,9 @@ struct Args {
     #[arg(short, long, default_value = "10")]
     duration: u64,
 
-    /// Collection rate in Hz
-    #[arg(short, long, default_value = "10.0")]
-    rate: f64,
+    /// Collection rate in Hz (overrides config file)
+    #[arg(short, long)]
+    rate: Option<f64>,
 
     /// Output file for JSON results (optional)
     #[arg(short, long)]
@@ -31,12 +31,97 @@ struct Args {
 }
 
 #[derive(Serialize)]
-struct EnergyResult {
+struct CliOutput {
     pid: Option<u32>,
     duration_seconds: f64,
-    total_energy: f64,
-    energy_unit: String,
-    devices: std::collections::HashMap<String, f64>,
+    total_energy_joules: f64,
+    power_watts: f64,
+    devices: DeviceBreakdown,
+    workloads: Vec<WorkloadOutput>,
+}
+
+#[derive(Serialize)]
+struct DeviceBreakdown {
+    cpu_joules: f64,
+    dram_joules: f64,
+    gpu_joules: f64,
+}
+
+#[derive(Serialize)]
+struct WorkloadOutput {
+    root_pid: u32,
+    name: String,
+    user: String,
+    energy_joules: f64,
+    power_watts: f64,
+}
+
+impl From<&DeviceEnergy> for DeviceBreakdown {
+    fn from(de: &DeviceEnergy) -> Self {
+        Self {
+            cpu_joules: de.cpu_joules,
+            dram_joules: de.dram_joules,
+            gpu_joules: de.gpu_joules,
+        }
+    }
+}
+
+fn build_cli_output(args: &Args, duration: f64, snapshot: &MetricsSnapshot) -> CliOutput {
+    let total_energy = snapshot.system_total.total();
+    let power_watts = if duration > 0.0 {
+        total_energy / duration
+    } else {
+        0.0
+    };
+
+    let workloads: Vec<WorkloadOutput> = snapshot
+        .workloads
+        .iter()
+        .map(|wl| WorkloadOutput {
+            root_pid: wl.root_pid,
+            name: wl.name.clone(),
+            user: wl.user.clone(),
+            energy_joules: wl.energy.total(),
+            power_watts: wl.power_watts,
+        })
+        .collect();
+
+    CliOutput {
+        pid: args.pid,
+        duration_seconds: duration,
+        total_energy_joules: total_energy,
+        power_watts,
+        devices: DeviceBreakdown::from(&snapshot.system_total),
+        workloads,
+    }
+}
+
+fn print_human_readable(output: &CliOutput) {
+    println!("\n=== Energy Consumption Results ===");
+    println!(
+        "PID: {}",
+        output
+            .pid
+            .map(|p| p.to_string())
+            .unwrap_or_else(|| "all".to_string())
+    );
+    println!("Duration: {:.2} s", output.duration_seconds);
+    println!("Total Energy: {:.4} J", output.total_energy_joules);
+    println!("Average Power: {:.2} W", output.power_watts);
+    println!("Device breakdown:");
+    println!("  CPU: {:.4} J", output.devices.cpu_joules);
+    println!("  DRAM: {:.4} J", output.devices.dram_joules);
+    println!("  GPU: {:.4} J", output.devices.gpu_joules);
+
+    if !output.workloads.is_empty() {
+        println!("Workloads:");
+        for wl in &output.workloads {
+            println!(
+                "  PID {} ({}, {}): {:.4} J, {:.2} W",
+                wl.root_pid, wl.name, wl.user, wl.energy_joules, wl.power_watts
+            );
+        }
+    }
 }
 
 #[tokio::main]
@@ -44,106 +129,58 @@ async fn main() {
     let args = Args::parse();
 
     if !args.quiet {
-        utils::logger::setup_logger();
-        info!("Energy Monitoring Tool started");
+        emt::utils::logger::setup_logger();
     }
 
-    // Determine PIDs to track
-    let tracked_pids: Vec<u32> = match args.pid {
-        Some(pid) => vec![pid],
-        None => vec![std::process::id()],
-    };
-
-    // Create a RAPL energy group collector with small batch size for CLI
-    // Batch size of 10 means data is sent every 10 iterations (1 second at 10 Hz)
-    let mut energy_group: EnergyGroup<Rapl> =
-        EnergyGroup::new(Rapl::default(), args.rate, Some(10));
-
-    // Set the PIDs to track
-    energy_group.set_tracked_pids(tracked_pids.clone());
-
-    if !args.quiet {
-        info!("Tracked PIDs: {:?}", tracked_pids);
-        info!(
-            "Monitoring for {} seconds at {} Hz...",
-            args.duration, args.rate
-        );
+    // Load config and apply CLI rate override
+    let mut config = EmtConfig::load();
+    if let Some(rate) = args.rate {
+        config.collection.rate_hz = rate;
     }
+
+    // Create Monitor with optional root PIDs
+    let root_pids = args.pid.map(|p| vec![p]);
+    let mut monitor = Monitor::new(config, root_pids);
 
     // Start monitoring
-    if let Err(e) = energy_group.commence().await {
-        eprintln!("Failed to start monitoring: {}", e);
-        std::process::exit(1);
-    }
-
-    // Monitor for the specified duration, polling data periodically
-    let start = std::time::Instant::now();
-    let poll_interval = tokio::time::Duration::from_millis(500);
-
-    while start.elapsed().as_secs() < args.duration {
-        tokio::time::sleep(poll_interval).await;
-        energy_group.poll_data();
-    }
-
-    // Shutdown and get final data
-    if let Err(e) = energy_group.shutdown() {
-        eprintln!("Warning: Shutdown error: {}", e);
-    }
-
-    // Calculate total energy from the accumulator
-    let actual_duration = start.elapsed().as_secs_f64();
-    let total_energy = energy_group.total_consumed_energy();
-
-    // Group energy by device from trace
-    let trace = energy_group.energy_trace();
-    let mut device_energy: std::collections::HashMap<String, f64> =
-        std::collections::HashMap::new();
-
-    if let (Ok(device_col), Ok(energy_col)) = (trace.column("device"), trace.column("energy")) {
-        if let (Ok(devices), Ok(energies)) = (device_col.str(), energy_col.f64()) {
-            for (device, energy) in devices.iter().zip(energies.iter()) {
-                if let (Some(d), Some(e)) = (device, energy) {
-                    *device_energy.entry(d.to_string()).or_insert(0.0) += e;
-                }
-            }
+    let handle = match monitor.commence().await {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("Failed to start monitoring: {e}");
+            std::process::exit(1);
         }
-    }
-
-    let result = EnergyResult {
-        pid: args.pid,
-        duration_seconds: actual_duration,
-        total_energy,
-        energy_unit: "Joules".to_string(),
-        devices: device_energy,
     };
 
-    // Output results
-    let json_output = serde_json::to_string_pretty(&result).unwrap();
+    // Sleep for the requested duration
+    tokio::time::sleep(tokio::time::Duration::from_secs(args.duration)).await;
 
+    // Capture final snapshot
+    let snapshot = handle.snapshot();
+    let duration = args.duration as f64;
+
+    // Shutdown monitor
+    if let Err(e) = monitor.shutdown().await {
+        eprintln!("Warning: Shutdown error: {e}");
+    }
+
+    // Build output
+    let output = build_cli_output(&args, duration, &snapshot);
+    let json_output = serde_json::to_string_pretty(&output).expect("Failed to serialize output");
+
+    // Write to file if requested
     if let Some(output_path) = &args.output {
         let mut file = File::create(output_path).expect("Failed to create output file");
         file.write_all(json_output.as_bytes())
             .expect("Failed to write output");
         if !args.quiet {
-            info!("Results written to: {}", output_path);
+            eprintln!("Results written to: {output_path}");
         }
     }
 
+    // Print output
     if args.quiet {
-        println!("{}", json_output);
+        println!("{json_output}");
     } else {
-        info!("Monitoring complete");
-        println!("\n=== Energy Consumption Results ===");
-        println!(
-            "PID: {:?}",
-            args.pid.map(|p| p.to_string()).unwrap_or("all".to_string())
-        );
-        println!("Duration: {:.2} s", actual_duration);
-        println!("Total Energy: {:.4} J", total_energy);
-        println!("Average Power: {:.2} W", total_energy / actual_duration);
-        println!("\nPer-device breakdown:");
-        for (device, energy) in &result.devices {
-            println!("  {}: {:.4} J", device, energy);
-        }
+        print_human_readable(&output);
     }
 }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,0 +1,320 @@
+use crate::collectors::{NvidiaGpu, Rapl};
+use crate::config::EmtConfig;
+use crate::energy_group::{EnergyCollector, EnergyGroup};
+use crate::utils::errors::MonitoringError;
+use crate::utils::psutils::{scan_roots, walk_child_pids, ProcessRoot};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+
+/// Simplified snapshot of monitor state, shared with MonitorHandle.
+/// ENE-36 will extend this into a full MetricsSnapshot.
+#[derive(Debug, Clone, Default)]
+pub struct MonitorSnapshot {
+    pub timestamp: i64,
+    pub total_energy_joules: f64,
+    pub energy_by_pid: HashMap<u32, f64>,
+    pub tracked_pids: Vec<u32>,
+}
+
+/// A cloneable handle providing read-only access to the latest monitor state.
+#[derive(Clone)]
+pub struct MonitorHandle {
+    snapshot: Arc<RwLock<MonitorSnapshot>>,
+}
+
+impl MonitorHandle {
+    /// Returns a clone of the current snapshot.
+    pub fn snapshot(&self) -> MonitorSnapshot {
+        self.snapshot.read().unwrap().clone()
+    }
+
+    /// Returns the total consumed energy in joules across all PIDs and collectors.
+    pub fn total_consumed_energy(&self) -> f64 {
+        self.snapshot.read().unwrap().total_energy_joules
+    }
+
+    /// Returns a clone of the per-PID energy map.
+    pub fn consumed_energy_by_pid(&self) -> HashMap<u32, f64> {
+        self.snapshot.read().unwrap().energy_by_pid.clone()
+    }
+}
+
+/// Central coordinator that owns all collectors, process discovery, and runs autonomously.
+pub struct Monitor {
+    config: EmtConfig,
+    rapl_group: Arc<Mutex<EnergyGroup<Rapl>>>,
+    gpu_group: Option<Arc<Mutex<EnergyGroup<NvidiaGpu>>>>,
+    root_pids: Option<Vec<u32>>,
+    /// Shared state for scan task results
+    discovered_roots: Arc<RwLock<Vec<ProcessRoot>>>,
+    /// Internal task handles
+    tick_handle: Option<JoinHandle<()>>,
+    scan_handle: Option<JoinHandle<()>>,
+    /// Shared snapshot for MonitorHandle
+    snapshot: Arc<RwLock<MonitorSnapshot>>,
+    is_running: Arc<AtomicBool>,
+}
+
+impl Monitor {
+    /// Create a new Monitor with the given config and optional root PIDs.
+    /// If `root_pids` is None, the monitor will use a background scan task
+    /// to discover all root processes on the system.
+    pub fn new(config: EmtConfig, root_pids: Option<Vec<u32>>) -> Self {
+        let rate = config.collection.rate_hz;
+        // Batch size = rate (flush once per second for responsive snapshots)
+        let batch_size = Some(rate.ceil() as usize);
+        let rapl_group = EnergyGroup::new(Rapl::default(), rate, batch_size);
+
+        // Auto-detect GPU availability
+        let gpu_group = if NvidiaGpu::is_available() {
+            Some(Arc::new(Mutex::new(EnergyGroup::new(
+                NvidiaGpu::default(),
+                rate,
+                batch_size,
+            ))))
+        } else {
+            None
+        };
+
+        Self {
+            config,
+            rapl_group: Arc::new(Mutex::new(rapl_group)),
+            gpu_group,
+            root_pids,
+            discovered_roots: Arc::new(RwLock::new(Vec::new())),
+            tick_handle: None,
+            scan_handle: None,
+            snapshot: Arc::new(RwLock::new(MonitorSnapshot::default())),
+            is_running: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Start the monitor and return a handle for reading state.
+    /// If already running, returns a new handle to the existing shared snapshot.
+    pub async fn commence(&mut self) -> Result<MonitorHandle, MonitoringError> {
+        if self.is_running.load(Ordering::SeqCst) {
+            // Already running -- return existing handle
+            return Ok(MonitorHandle {
+                snapshot: Arc::clone(&self.snapshot),
+            });
+        }
+
+        self.is_running.store(true, Ordering::SeqCst);
+
+        // Start collector background tasks
+        {
+            let mut rapl = self.rapl_group.lock().await;
+            rapl.commence().await?;
+        }
+        if let Some(gpu) = &self.gpu_group {
+            let mut gpu_lock = gpu.lock().await;
+            gpu_lock.commence().await?;
+        }
+
+        // If no specific root_pids, spawn scan task for automatic discovery
+        if self.root_pids.is_none() {
+            self.spawn_scan_task();
+        }
+
+        // Spawn tick task (internal loop at configured rate)
+        self.spawn_tick_task();
+
+        Ok(MonitorHandle {
+            snapshot: Arc::clone(&self.snapshot),
+        })
+    }
+
+    /// Shut down the monitor, stopping all background tasks and collectors.
+    pub async fn shutdown(&mut self) -> Result<(), MonitoringError> {
+        self.is_running.store(false, Ordering::SeqCst);
+
+        // Abort background tasks
+        if let Some(handle) = self.tick_handle.take() {
+            handle.abort();
+        }
+        if let Some(handle) = self.scan_handle.take() {
+            handle.abort();
+        }
+
+        // Shutdown collector groups
+        {
+            let mut rapl = self.rapl_group.lock().await;
+            rapl.shutdown()?;
+        }
+        if let Some(gpu) = &self.gpu_group {
+            let mut gpu_lock = gpu.lock().await;
+            gpu_lock.shutdown()?;
+        }
+
+        Ok(())
+    }
+
+    /// Spawn the tick task that runs the core polling and update loop.
+    fn spawn_tick_task(&mut self) {
+        let interval = Duration::from_secs_f64(1.0 / self.config.collection.rate_hz);
+        let rapl_group = Arc::clone(&self.rapl_group);
+        let gpu_group = self.gpu_group.clone();
+        let root_pids = self.root_pids.clone();
+        let discovered_roots = Arc::clone(&self.discovered_roots);
+        let snapshot = Arc::clone(&self.snapshot);
+        let is_running = Arc::clone(&self.is_running);
+
+        self.tick_handle = Some(tokio::spawn(async move {
+            while is_running.load(Ordering::SeqCst) {
+                // 1. Determine current root PIDs
+                let roots: Vec<u32> = if let Some(ref pids) = root_pids {
+                    pids.clone()
+                } else {
+                    discovered_roots
+                        .read()
+                        .unwrap()
+                        .iter()
+                        .map(|r| r.pid)
+                        .collect()
+                };
+
+                // 2. Walk child PIDs to expand the full process tree
+                let expanded_pids = if roots.is_empty() {
+                    Vec::new()
+                } else {
+                    tokio::task::spawn_blocking(move || walk_child_pids(&roots))
+                        .await
+                        .unwrap_or_default()
+                };
+
+                // 3. Set tracked PIDs on collectors and poll data
+                {
+                    let mut rapl = rapl_group.lock().await;
+                    rapl.set_tracked_pids(expanded_pids.clone());
+                    rapl.poll_data();
+                }
+
+                if let Some(ref gpu) = gpu_group {
+                    let mut gpu_lock = gpu.lock().await;
+                    gpu_lock.set_tracked_pids(expanded_pids.clone());
+                    gpu_lock.poll_data();
+                }
+
+                // 4. Update snapshot from accumulated state
+                let mut merged_energy: HashMap<u32, f64> = HashMap::new();
+                let mut total_energy = 0.0;
+
+                {
+                    let rapl = rapl_group.lock().await;
+                    for (&pid, &energy) in rapl.consumed_energy_by_pid() {
+                        *merged_energy.entry(pid).or_insert(0.0) += energy;
+                        total_energy += energy;
+                    }
+                }
+
+                if let Some(ref gpu) = gpu_group {
+                    let gpu_lock = gpu.lock().await;
+                    for (&pid, &energy) in gpu_lock.consumed_energy_by_pid() {
+                        *merged_energy.entry(pid).or_insert(0.0) += energy;
+                        total_energy += energy;
+                    }
+                }
+
+                // Write updated snapshot
+                {
+                    let mut snap = snapshot.write().unwrap();
+                    snap.timestamp = chrono::Utc::now().timestamp_millis();
+                    snap.total_energy_joules = total_energy;
+                    snap.energy_by_pid = merged_energy;
+                    snap.tracked_pids = expanded_pids;
+                }
+
+                tokio::time::sleep(interval).await;
+            }
+        }));
+    }
+
+    /// Spawn the scan task that periodically discovers all root processes.
+    /// Only spawned when `root_pids` is None (monitor-all mode).
+    fn spawn_scan_task(&mut self) {
+        let interval = Duration::from_secs_f64(self.config.discovery.scan_interval_secs);
+        let discovered_roots = Arc::clone(&self.discovered_roots);
+        let is_running = Arc::clone(&self.is_running);
+
+        self.scan_handle = Some(tokio::spawn(async move {
+            while is_running.load(Ordering::SeqCst) {
+                let roots = tokio::task::spawn_blocking(scan_roots)
+                    .await
+                    .unwrap_or_default();
+                *discovered_roots.write().unwrap() = roots;
+                tokio::time::sleep(interval).await;
+            }
+        }));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn monitor_starts_and_stops_cleanly() {
+        let config = EmtConfig::default();
+        let mut monitor = Monitor::new(config, Some(vec![std::process::id()]));
+
+        let handle = monitor.commence().await.unwrap();
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let snapshot = handle.snapshot();
+        assert!(snapshot.total_energy_joules >= 0.0);
+
+        monitor.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn monitor_handle_returns_non_zero_energy_after_running() {
+        let config = EmtConfig::default();
+        let mut monitor = Monitor::new(config, Some(vec![std::process::id()]));
+
+        let handle = monitor.commence().await.unwrap();
+        // Wait long enough for at least one batch to flush (batch_size = rate = 10,
+        // so 1 second of collection plus margin for scheduling).
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        // On a RAPL-capable host with readable counters, should have some energy.
+        // The assertion is gated because CI or container environments may expose
+        // the powercap path but return zero deltas.
+        if Rapl::is_available() {
+            let energy = handle.total_consumed_energy();
+            // Energy should be non-negative; a positive value means attribution worked.
+            assert!(energy >= 0.0, "Energy must be non-negative, got {}", energy);
+        }
+
+        monitor.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn double_commence_is_noop() {
+        let config = EmtConfig::default();
+        let mut monitor = Monitor::new(config, Some(vec![std::process::id()]));
+
+        let _handle1 = monitor.commence().await.unwrap();
+        let _handle2 = monitor.commence().await.unwrap();
+
+        monitor.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn monitor_without_pids_uses_scan_task() {
+        let config = EmtConfig::default();
+        let mut monitor = Monitor::new(config, None);
+
+        let handle = monitor.commence().await.unwrap();
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let snapshot = handle.snapshot();
+        // Should have discovered some PIDs via scan
+        assert!(!snapshot.tracked_pids.is_empty());
+
+        monitor.shutdown().await.unwrap();
+    }
+}

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,6 +1,6 @@
 use crate::collectors::{NvidiaGpu, Rapl};
 use crate::config::EmtConfig;
-use crate::energy_group::{EnergyCollector, EnergyGroup};
+use crate::energy_group::{EnergyCollector, EnergyGroup, EnergyRecord};
 use crate::utils::errors::MonitoringError;
 use crate::utils::psutils::{scan_roots, walk_child_pids, ProcessRoot};
 use std::collections::HashMap;
@@ -10,38 +10,147 @@ use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
-/// Simplified snapshot of monitor state, shared with MonitorHandle.
-/// ENE-36 will extend this into a full MetricsSnapshot.
+// ─── MetricsSnapshot data structures ────────────────────────────────────────
+
+/// Energy breakdown by device type (CPU, DRAM, GPU).
 #[derive(Debug, Clone, Default)]
-pub struct MonitorSnapshot {
+pub struct DeviceEnergy {
+    pub cpu_joules: f64,
+    pub dram_joules: f64,
+    pub gpu_joules: f64,
+}
+
+impl DeviceEnergy {
+    /// Total energy across all device types.
+    pub fn total(&self) -> f64 {
+        self.cpu_joules + self.dram_joules + self.gpu_joules
+    }
+
+    /// Subtract another DeviceEnergy, clamping each component to >= 0.
+    pub fn saturating_sub(&self, other: &DeviceEnergy) -> DeviceEnergy {
+        DeviceEnergy {
+            cpu_joules: (self.cpu_joules - other.cpu_joules).max(0.0),
+            dram_joules: (self.dram_joules - other.dram_joules).max(0.0),
+            gpu_joules: (self.gpu_joules - other.gpu_joules).max(0.0),
+        }
+    }
+}
+
+/// Per-workload (root process) energy and power snapshot.
+#[derive(Debug, Clone)]
+pub struct WorkloadSnapshot {
+    pub root_pid: u32,
+    pub name: String,
+    pub user: String,
+    pub energy: DeviceEnergy,
+    pub power_watts: f64,
+}
+
+/// Full metrics snapshot shared via MonitorHandle.
+#[derive(Debug, Clone, Default)]
+pub struct MetricsSnapshot {
     pub timestamp: i64,
-    pub total_energy_joules: f64,
-    pub energy_by_pid: HashMap<u32, f64>,
+    pub system_total: DeviceEnergy,
+    pub workloads: Vec<WorkloadSnapshot>,
+    pub unattributed: DeviceEnergy,
     pub tracked_pids: Vec<u32>,
 }
+
+// ─── Device classification ──────────────────────────────────────────────────
+
+/// Classify an EnergyRecord into a device category and return the energy value.
+fn classify_energy(record: &EnergyRecord) -> EnergyClass {
+    if record.device.starts_with("nvidia:") {
+        EnergyClass::Gpu
+    } else if record.device == "rapl:system:dram" {
+        EnergyClass::Dram
+    } else {
+        // rapl:socket:*:package, rapl:system:psys, or any other RAPL device
+        EnergyClass::Cpu
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EnergyClass {
+    Cpu,
+    Dram,
+    Gpu,
+}
+
+/// Accumulate an energy record into a DeviceEnergy struct.
+fn accumulate_device_energy(device_energy: &mut DeviceEnergy, class: EnergyClass, joules: f64) {
+    match class {
+        EnergyClass::Cpu => device_energy.cpu_joules += joules,
+        EnergyClass::Dram => device_energy.dram_joules += joules,
+        EnergyClass::Gpu => device_energy.gpu_joules += joules,
+    }
+}
+
+// ─── Child-to-root mapping ──────────────────────────────────────────────────
+
+/// Build a map from each child PID to its root PID.
+/// Each root is walked independently so that all descendants map back.
+fn build_child_to_root_map(roots: &[u32]) -> (HashMap<u32, u32>, Vec<u32>) {
+    let mut map: HashMap<u32, u32> = HashMap::new();
+    let mut all_pids: Vec<u32> = Vec::new();
+
+    for &root in roots {
+        let children = walk_child_pids(&[root]);
+        for &child in &children {
+            map.insert(child, root);
+        }
+        all_pids.extend(children);
+    }
+
+    // Deduplicate all_pids while preserving order
+    let mut seen = std::collections::HashSet::new();
+    all_pids.retain(|pid| seen.insert(*pid));
+
+    (map, all_pids)
+}
+
+// ─── MonitorHandle ──────────────────────────────────────────────────────────
 
 /// A cloneable handle providing read-only access to the latest monitor state.
 #[derive(Clone)]
 pub struct MonitorHandle {
-    snapshot: Arc<RwLock<MonitorSnapshot>>,
+    snapshot: Arc<RwLock<MetricsSnapshot>>,
 }
 
 impl MonitorHandle {
     /// Returns a clone of the current snapshot.
-    pub fn snapshot(&self) -> MonitorSnapshot {
+    pub fn snapshot(&self) -> MetricsSnapshot {
         self.snapshot.read().unwrap().clone()
     }
 
-    /// Returns the total consumed energy in joules across all PIDs and collectors.
+    /// Returns the total consumed energy in joules across all device types.
     pub fn total_consumed_energy(&self) -> f64 {
-        self.snapshot.read().unwrap().total_energy_joules
+        let snap = self.snapshot.read().unwrap();
+        snap.system_total.total()
     }
 
-    /// Returns a clone of the per-PID energy map.
+    /// Returns a per-PID energy map (sum of all device types per PID).
+    /// Kept for backwards compatibility.
     pub fn consumed_energy_by_pid(&self) -> HashMap<u32, f64> {
-        self.snapshot.read().unwrap().energy_by_pid.clone()
+        let snap = self.snapshot.read().unwrap();
+        let mut result = HashMap::new();
+        for wl in &snap.workloads {
+            *result.entry(wl.root_pid).or_insert(0.0) += wl.energy.total();
+        }
+        result
     }
 }
+
+// ─── Internal state for power computation ───────────────────────────────────
+
+/// Tracks previous tick state for computing power (watts).
+#[derive(Debug, Clone, Default)]
+struct PreviousTickState {
+    timestamp: i64,
+    workload_energy: HashMap<u32, DeviceEnergy>,
+}
+
+// ─── Monitor ────────────────────────────────────────────────────────────────
 
 /// Central coordinator that owns all collectors, process discovery, and runs autonomously.
 pub struct Monitor {
@@ -55,7 +164,7 @@ pub struct Monitor {
     tick_handle: Option<JoinHandle<()>>,
     scan_handle: Option<JoinHandle<()>>,
     /// Shared snapshot for MonitorHandle
-    snapshot: Arc<RwLock<MonitorSnapshot>>,
+    snapshot: Arc<RwLock<MetricsSnapshot>>,
     is_running: Arc<AtomicBool>,
 }
 
@@ -88,7 +197,7 @@ impl Monitor {
             discovered_roots: Arc::new(RwLock::new(Vec::new())),
             tick_handle: None,
             scan_handle: None,
-            snapshot: Arc::new(RwLock::new(MonitorSnapshot::default())),
+            snapshot: Arc::new(RwLock::new(MetricsSnapshot::default())),
             is_running: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -164,67 +273,184 @@ impl Monitor {
         let is_running = Arc::clone(&self.is_running);
 
         self.tick_handle = Some(tokio::spawn(async move {
+            let mut prev_state = PreviousTickState::default();
+
             while is_running.load(Ordering::SeqCst) {
-                // 1. Determine current root PIDs
-                let roots: Vec<u32> = if let Some(ref pids) = root_pids {
-                    pids.clone()
-                } else {
-                    discovered_roots
-                        .read()
-                        .unwrap()
-                        .iter()
-                        .map(|r| r.pid)
+                // 1. Determine current root PIDs and metadata
+                let roots_with_metadata: Vec<ProcessRoot> = if let Some(ref pids) = root_pids {
+                    // When explicit PIDs are given, create minimal ProcessRoot entries
+                    pids.iter()
+                        .map(|&pid| ProcessRoot {
+                            pid,
+                            user: String::new(),
+                            name: String::new(),
+                        })
                         .collect()
+                } else {
+                    discovered_roots.read().unwrap().clone()
                 };
 
-                // 2. Walk child PIDs to expand the full process tree
-                let expanded_pids = if roots.is_empty() {
-                    Vec::new()
+                let root_pid_list: Vec<u32> =
+                    roots_with_metadata.iter().map(|r| r.pid).collect();
+
+                // 2. Build child-to-root map and get expanded PID set
+                let (child_to_root, expanded_pids) = if root_pid_list.is_empty() {
+                    (HashMap::new(), Vec::new())
                 } else {
-                    tokio::task::spawn_blocking(move || walk_child_pids(&roots))
-                        .await
-                        .unwrap_or_default()
+                    let roots_for_walk = root_pid_list.clone();
+                    tokio::task::spawn_blocking(move || {
+                        build_child_to_root_map(&roots_for_walk)
+                    })
+                    .await
+                    .unwrap_or_default()
                 };
 
                 // 3. Set tracked PIDs on collectors and poll data
+                let rapl_records;
                 {
                     let mut rapl = rapl_group.lock().await;
                     rapl.set_tracked_pids(expanded_pids.clone());
-                    rapl.poll_data();
+                    rapl_records = rapl.poll_data();
                 }
 
-                if let Some(ref gpu) = gpu_group {
+                let gpu_records = if let Some(ref gpu) = gpu_group {
                     let mut gpu_lock = gpu.lock().await;
                     gpu_lock.set_tracked_pids(expanded_pids.clone());
-                    gpu_lock.poll_data();
+                    gpu_lock.poll_data()
+                } else {
+                    Vec::new()
+                };
+
+                // 4. Compute MetricsSnapshot from records
+                let all_records: Vec<&EnergyRecord> =
+                    rapl_records.iter().chain(gpu_records.iter()).collect();
+
+                // Compute system_total from all records
+                let mut system_total = DeviceEnergy::default();
+                for record in &all_records {
+                    let class = classify_energy(record);
+                    accumulate_device_energy(&mut system_total, class, record.energy);
                 }
 
-                // 4. Update snapshot from accumulated state
-                let mut merged_energy: HashMap<u32, f64> = HashMap::new();
-                let mut total_energy = 0.0;
-
-                {
-                    let rapl = rapl_group.lock().await;
-                    for (&pid, &energy) in rapl.consumed_energy_by_pid() {
-                        *merged_energy.entry(pid).or_insert(0.0) += energy;
-                        total_energy += energy;
+                // Compute per-root energy using child_to_root map
+                let mut workload_energy_map: HashMap<u32, DeviceEnergy> = HashMap::new();
+                for record in &all_records {
+                    if let Some(&root) = child_to_root.get(&record.pid) {
+                        let class = classify_energy(record);
+                        let entry = workload_energy_map.entry(root).or_default();
+                        accumulate_device_energy(entry, class, record.energy);
                     }
                 }
 
-                if let Some(ref gpu) = gpu_group {
-                    let gpu_lock = gpu.lock().await;
-                    for (&pid, &energy) in gpu_lock.consumed_energy_by_pid() {
-                        *merged_energy.entry(pid).or_insert(0.0) += energy;
-                        total_energy += energy;
-                    }
+                // Build workload snapshots with power computation
+                let current_timestamp = chrono::Utc::now().timestamp_millis();
+                let time_delta_s = if prev_state.timestamp > 0 {
+                    (current_timestamp - prev_state.timestamp) as f64 / 1000.0
+                } else {
+                    0.0
+                };
+
+                let mut workloads: Vec<WorkloadSnapshot> = Vec::new();
+                let mut workloads_sum = DeviceEnergy::default();
+
+                for root_info in &roots_with_metadata {
+                    let energy = workload_energy_map
+                        .get(&root_info.pid)
+                        .cloned()
+                        .unwrap_or_default();
+
+                    // Compute power from energy delta between ticks
+                    let power_watts = if time_delta_s > 0.0 {
+                        let prev_energy = prev_state
+                            .workload_energy
+                            .get(&root_info.pid)
+                            .map(|de| de.total())
+                            .unwrap_or(0.0);
+                        let energy_delta = energy.total() - prev_energy;
+                        (energy_delta / time_delta_s).max(0.0)
+                    } else {
+                        0.0
+                    };
+
+                    workloads_sum.cpu_joules += energy.cpu_joules;
+                    workloads_sum.dram_joules += energy.dram_joules;
+                    workloads_sum.gpu_joules += energy.gpu_joules;
+
+                    workloads.push(WorkloadSnapshot {
+                        root_pid: root_info.pid,
+                        name: root_info.name.clone(),
+                        user: root_info.user.clone(),
+                        energy,
+                        power_watts,
+                    });
                 }
+
+                // Unattributed = system_total - sum(workloads), clamped >= 0
+                let unattributed = system_total.saturating_sub(&workloads_sum);
+
+                // Read previous snapshot to accumulate total energy
+                let prev_snap = snapshot.read().unwrap().clone();
+
+                // The system_total should be cumulative (add this tick's delta)
+                let cumulative_total = DeviceEnergy {
+                    cpu_joules: prev_snap.system_total.cpu_joules + system_total.cpu_joules,
+                    dram_joules: prev_snap.system_total.dram_joules + system_total.dram_joules,
+                    gpu_joules: prev_snap.system_total.gpu_joules + system_total.gpu_joules,
+                };
+
+                // Accumulate workload energy cumulatively
+                let cumulative_workloads: Vec<WorkloadSnapshot> = workloads
+                    .into_iter()
+                    .map(|wl| {
+                        // Find previous workload energy
+                        let prev_wl_energy = prev_snap
+                            .workloads
+                            .iter()
+                            .find(|pw| pw.root_pid == wl.root_pid)
+                            .map(|pw| &pw.energy);
+
+                        let cumulative_energy = if let Some(prev_e) = prev_wl_energy {
+                            DeviceEnergy {
+                                cpu_joules: prev_e.cpu_joules + wl.energy.cpu_joules,
+                                dram_joules: prev_e.dram_joules + wl.energy.dram_joules,
+                                gpu_joules: prev_e.gpu_joules + wl.energy.gpu_joules,
+                            }
+                        } else {
+                            wl.energy
+                        };
+
+                        WorkloadSnapshot {
+                            root_pid: wl.root_pid,
+                            name: wl.name,
+                            user: wl.user,
+                            energy: cumulative_energy,
+                            power_watts: wl.power_watts,
+                        }
+                    })
+                    .collect();
+
+                let cumulative_unattributed = DeviceEnergy {
+                    cpu_joules: prev_snap.unattributed.cpu_joules + unattributed.cpu_joules,
+                    dram_joules: prev_snap.unattributed.dram_joules + unattributed.dram_joules,
+                    gpu_joules: prev_snap.unattributed.gpu_joules + unattributed.gpu_joules,
+                };
+
+                // Update previous tick state for power computation
+                prev_state = PreviousTickState {
+                    timestamp: current_timestamp,
+                    workload_energy: cumulative_workloads
+                        .iter()
+                        .map(|wl| (wl.root_pid, wl.energy.clone()))
+                        .collect(),
+                };
 
                 // Write updated snapshot
                 {
                     let mut snap = snapshot.write().unwrap();
-                    snap.timestamp = chrono::Utc::now().timestamp_millis();
-                    snap.total_energy_joules = total_energy;
-                    snap.energy_by_pid = merged_energy;
+                    snap.timestamp = current_timestamp;
+                    snap.system_total = cumulative_total;
+                    snap.workloads = cumulative_workloads;
+                    snap.unattributed = cumulative_unattributed;
                     snap.tracked_pids = expanded_pids;
                 }
 
@@ -256,6 +482,131 @@ impl Monitor {
 mod tests {
     use super::*;
 
+    #[test]
+    fn device_energy_default_is_zero() {
+        let de = DeviceEnergy::default();
+        assert_eq!(de.cpu_joules, 0.0);
+        assert_eq!(de.dram_joules, 0.0);
+        assert_eq!(de.gpu_joules, 0.0);
+    }
+
+    #[test]
+    fn device_energy_total() {
+        let de = DeviceEnergy {
+            cpu_joules: 1.0,
+            dram_joules: 2.0,
+            gpu_joules: 3.0,
+        };
+        assert!((de.total() - 6.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn device_energy_saturating_sub_clamps_to_zero() {
+        let a = DeviceEnergy {
+            cpu_joules: 1.0,
+            dram_joules: 0.5,
+            gpu_joules: 0.0,
+        };
+        let b = DeviceEnergy {
+            cpu_joules: 2.0,
+            dram_joules: 0.3,
+            gpu_joules: 1.0,
+        };
+        let result = a.saturating_sub(&b);
+        assert_eq!(result.cpu_joules, 0.0); // clamped
+        assert!((result.dram_joules - 0.2).abs() < 1e-10);
+        assert_eq!(result.gpu_joules, 0.0); // clamped
+    }
+
+    #[test]
+    fn classify_energy_rapl_package() {
+        let record = EnergyRecord {
+            pid: 1,
+            timestamp: 0,
+            device: "rapl:socket:0:package".to_string(),
+            energy: 5.0,
+        };
+        assert_eq!(classify_energy(&record), EnergyClass::Cpu);
+    }
+
+    #[test]
+    fn classify_energy_rapl_dram() {
+        let record = EnergyRecord {
+            pid: 1,
+            timestamp: 0,
+            device: "rapl:system:dram".to_string(),
+            energy: 2.0,
+        };
+        assert_eq!(classify_energy(&record), EnergyClass::Dram);
+    }
+
+    #[test]
+    fn classify_energy_rapl_psys() {
+        let record = EnergyRecord {
+            pid: 1,
+            timestamp: 0,
+            device: "rapl:system:psys".to_string(),
+            energy: 3.0,
+        };
+        assert_eq!(classify_energy(&record), EnergyClass::Cpu);
+    }
+
+    #[test]
+    fn classify_energy_nvidia() {
+        let record = EnergyRecord {
+            pid: 1,
+            timestamp: 0,
+            device: "nvidia:gpu:0".to_string(),
+            energy: 10.0,
+        };
+        assert_eq!(classify_energy(&record), EnergyClass::Gpu);
+    }
+
+    #[test]
+    fn unattributed_is_clamped_to_zero() {
+        // Simulate jitter: workloads sum exceeds system_total
+        let system_total = DeviceEnergy {
+            cpu_joules: 5.0,
+            dram_joules: 1.0,
+            gpu_joules: 0.0,
+        };
+        let workloads_sum = DeviceEnergy {
+            cpu_joules: 5.5, // exceeds system_total due to jitter
+            dram_joules: 1.2,
+            gpu_joules: 0.1,
+        };
+        let unattributed = system_total.saturating_sub(&workloads_sum);
+        assert_eq!(unattributed.cpu_joules, 0.0);
+        assert_eq!(unattributed.dram_joules, 0.0);
+        assert_eq!(unattributed.gpu_joules, 0.0);
+    }
+
+    #[test]
+    fn build_child_to_root_map_maps_self() {
+        let my_pid = std::process::id();
+        let (map, pids) = build_child_to_root_map(&[my_pid]);
+        // The root maps to itself
+        assert_eq!(map.get(&my_pid), Some(&my_pid));
+        assert!(pids.contains(&my_pid));
+    }
+
+    #[test]
+    fn build_child_to_root_map_empty_returns_empty() {
+        let (map, pids) = build_child_to_root_map(&[]);
+        assert!(map.is_empty());
+        assert!(pids.is_empty());
+    }
+
+    #[test]
+    fn metrics_snapshot_default() {
+        let snap = MetricsSnapshot::default();
+        assert_eq!(snap.timestamp, 0);
+        assert_eq!(snap.system_total.total(), 0.0);
+        assert!(snap.workloads.is_empty());
+        assert_eq!(snap.unattributed.total(), 0.0);
+        assert!(snap.tracked_pids.is_empty());
+    }
+
     #[tokio::test]
     async fn monitor_starts_and_stops_cleanly() {
         let config = EmtConfig::default();
@@ -265,7 +616,7 @@ mod tests {
         tokio::time::sleep(Duration::from_secs(2)).await;
 
         let snapshot = handle.snapshot();
-        assert!(snapshot.total_energy_joules >= 0.0);
+        assert!(snapshot.system_total.total() >= 0.0);
 
         monitor.shutdown().await.unwrap();
     }
@@ -314,6 +665,50 @@ mod tests {
         let snapshot = handle.snapshot();
         // Should have discovered some PIDs via scan
         assert!(!snapshot.tracked_pids.is_empty());
+
+        monitor.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn monitor_snapshot_has_device_breakdown() {
+        let config = EmtConfig::default();
+        let mut monitor = Monitor::new(config, Some(vec![std::process::id()]));
+
+        let handle = monitor.commence().await.unwrap();
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let snapshot = handle.snapshot();
+
+        // On a RAPL-capable host, cpu_joules should be populated
+        if Rapl::is_available() {
+            // At minimum, the snapshot should have some structure
+            assert!(snapshot.system_total.cpu_joules >= 0.0);
+            assert!(snapshot.system_total.dram_joules >= 0.0);
+            assert!(snapshot.system_total.gpu_joules >= 0.0);
+        }
+
+        // Unattributed should never be negative (clamped)
+        assert!(snapshot.unattributed.cpu_joules >= 0.0);
+        assert!(snapshot.unattributed.dram_joules >= 0.0);
+        assert!(snapshot.unattributed.gpu_joules >= 0.0);
+
+        monitor.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn consumed_energy_by_pid_backwards_compat() {
+        let config = EmtConfig::default();
+        let mut monitor = Monitor::new(config, Some(vec![std::process::id()]));
+
+        let handle = monitor.commence().await.unwrap();
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        // The backwards-compat method should return a HashMap
+        let by_pid = handle.consumed_energy_by_pid();
+        // All values should be non-negative
+        for &energy in by_pid.values() {
+            assert!(energy >= 0.0);
+        }
 
         monitor.shutdown().await.unwrap();
     }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -143,11 +143,20 @@ impl MonitorHandle {
 
 // ─── Internal state for power computation ───────────────────────────────────
 
-/// Tracks previous tick state for computing power (watts).
-#[derive(Debug, Clone, Default)]
-struct PreviousTickState {
-    timestamp: i64,
+/// Tracks cumulative state for computing power (watts).
+#[derive(Debug, Clone)]
+struct TickState {
+    start_timestamp: i64,
     workload_energy: HashMap<u32, DeviceEnergy>,
+}
+
+impl Default for TickState {
+    fn default() -> Self {
+        Self {
+            start_timestamp: 0,
+            workload_energy: HashMap::new(),
+        }
+    }
 }
 
 // ─── Monitor ────────────────────────────────────────────────────────────────
@@ -273,19 +282,43 @@ impl Monitor {
         let is_running = Arc::clone(&self.is_running);
 
         self.tick_handle = Some(tokio::spawn(async move {
-            let mut prev_state = PreviousTickState::default();
+            let mut tick_state = TickState::default();
 
             while is_running.load(Ordering::SeqCst) {
                 // 1. Determine current root PIDs and metadata
                 let roots_with_metadata: Vec<ProcessRoot> = if let Some(ref pids) = root_pids {
-                    // When explicit PIDs are given, create minimal ProcessRoot entries
-                    pids.iter()
-                        .map(|&pid| ProcessRoot {
-                            pid,
-                            user: String::new(),
-                            name: String::new(),
-                        })
-                        .collect()
+                    // Resolve process metadata for user-supplied PIDs
+                    let pids_clone = pids.clone();
+                    tokio::task::spawn_blocking(move || {
+                        use sysinfo::System;
+                        use users::{Users, UsersCache};
+                        let system = System::new_all();
+                        let users_cache = UsersCache::new();
+                        pids_clone
+                            .iter()
+                            .map(|&pid| {
+                                let (name, user) = system
+                                    .process(sysinfo::Pid::from_u32(pid))
+                                    .map(|p| {
+                                        let n = p.name().to_string_lossy().to_string();
+                                        let u = p
+                                            .user_id()
+                                            .map(|uid| {
+                                                users_cache
+                                                    .get_user_by_uid(**uid)
+                                                    .map(|u| u.name().to_string_lossy().to_string())
+                                                    .unwrap_or_else(|| uid.to_string())
+                                            })
+                                            .unwrap_or_else(|| "unknown".to_string());
+                                        (n, u)
+                                    })
+                                    .unwrap_or_else(|| (String::new(), String::new()));
+                                ProcessRoot { pid, user, name }
+                            })
+                            .collect()
+                    })
+                    .await
+                    .unwrap_or_default()
                 } else {
                     discovered_roots.read().unwrap().clone()
                 };
@@ -344,112 +377,88 @@ impl Monitor {
 
                 // Build workload snapshots with power computation
                 let current_timestamp = chrono::Utc::now().timestamp_millis();
-                let time_delta_s = if prev_state.timestamp > 0 {
-                    (current_timestamp - prev_state.timestamp) as f64 / 1000.0
-                } else {
-                    0.0
-                };
+                if tick_state.start_timestamp == 0 {
+                    tick_state.start_timestamp = current_timestamp;
+                }
+                let elapsed_s =
+                    (current_timestamp - tick_state.start_timestamp) as f64 / 1000.0;
 
                 let mut workloads: Vec<WorkloadSnapshot> = Vec::new();
                 let mut workloads_sum = DeviceEnergy::default();
 
                 for root_info in &roots_with_metadata {
-                    let energy = workload_energy_map
+                    let tick_energy = workload_energy_map
                         .get(&root_info.pid)
                         .cloned()
                         .unwrap_or_default();
 
-                    // Compute power from energy delta between ticks
-                    let power_watts = if time_delta_s > 0.0 {
-                        let prev_energy = prev_state
-                            .workload_energy
-                            .get(&root_info.pid)
-                            .map(|de| de.total())
-                            .unwrap_or(0.0);
-                        let energy_delta = energy.total() - prev_energy;
-                        (energy_delta / time_delta_s).max(0.0)
+                    // Compute cumulative energy for this workload
+                    let prev_cumulative_energy = tick_state
+                        .workload_energy
+                        .get(&root_info.pid)
+                        .cloned()
+                        .unwrap_or_default();
+                    let cumulative_energy = DeviceEnergy {
+                        cpu_joules: prev_cumulative_energy.cpu_joules + tick_energy.cpu_joules,
+                        dram_joules: prev_cumulative_energy.dram_joules + tick_energy.dram_joules,
+                        gpu_joules: prev_cumulative_energy.gpu_joules + tick_energy.gpu_joules,
+                    };
+
+                    // Average power = cumulative energy / total elapsed time
+                    let power_watts = if elapsed_s > 0.0 {
+                        cumulative_energy.total() / elapsed_s
                     } else {
                         0.0
                     };
 
-                    workloads_sum.cpu_joules += energy.cpu_joules;
-                    workloads_sum.dram_joules += energy.dram_joules;
-                    workloads_sum.gpu_joules += energy.gpu_joules;
+                    workloads_sum.cpu_joules += tick_energy.cpu_joules;
+                    workloads_sum.dram_joules += tick_energy.dram_joules;
+                    workloads_sum.gpu_joules += tick_energy.gpu_joules;
 
                     workloads.push(WorkloadSnapshot {
                         root_pid: root_info.pid,
                         name: root_info.name.clone(),
                         user: root_info.user.clone(),
-                        energy,
+                        energy: cumulative_energy,
                         power_watts,
                     });
                 }
 
-                // Unattributed = system_total - sum(workloads), clamped >= 0
-                let unattributed = system_total.saturating_sub(&workloads_sum);
+                // Unattributed this tick = system_total - sum(workloads), clamped >= 0
+                let tick_unattributed = system_total.saturating_sub(&workloads_sum);
 
-                // Read previous snapshot to accumulate total energy
-                let prev_snap = snapshot.read().unwrap().clone();
-
-                // The system_total should be cumulative (add this tick's delta)
-                let cumulative_total = DeviceEnergy {
-                    cpu_joules: prev_snap.system_total.cpu_joules + system_total.cpu_joules,
-                    dram_joules: prev_snap.system_total.dram_joules + system_total.dram_joules,
-                    gpu_joules: prev_snap.system_total.gpu_joules + system_total.gpu_joules,
+                // Accumulate unattributed energy
+                let prev_unattributed = {
+                    snapshot.read().unwrap().unattributed.clone()
                 };
-
-                // Accumulate workload energy cumulatively
-                let cumulative_workloads: Vec<WorkloadSnapshot> = workloads
-                    .into_iter()
-                    .map(|wl| {
-                        // Find previous workload energy
-                        let prev_wl_energy = prev_snap
-                            .workloads
-                            .iter()
-                            .find(|pw| pw.root_pid == wl.root_pid)
-                            .map(|pw| &pw.energy);
-
-                        let cumulative_energy = if let Some(prev_e) = prev_wl_energy {
-                            DeviceEnergy {
-                                cpu_joules: prev_e.cpu_joules + wl.energy.cpu_joules,
-                                dram_joules: prev_e.dram_joules + wl.energy.dram_joules,
-                                gpu_joules: prev_e.gpu_joules + wl.energy.gpu_joules,
-                            }
-                        } else {
-                            wl.energy
-                        };
-
-                        WorkloadSnapshot {
-                            root_pid: wl.root_pid,
-                            name: wl.name,
-                            user: wl.user,
-                            energy: cumulative_energy,
-                            power_watts: wl.power_watts,
-                        }
-                    })
-                    .collect();
-
                 let cumulative_unattributed = DeviceEnergy {
-                    cpu_joules: prev_snap.unattributed.cpu_joules + unattributed.cpu_joules,
-                    dram_joules: prev_snap.unattributed.dram_joules + unattributed.dram_joules,
-                    gpu_joules: prev_snap.unattributed.gpu_joules + unattributed.gpu_joules,
+                    cpu_joules: prev_unattributed.cpu_joules + tick_unattributed.cpu_joules,
+                    dram_joules: prev_unattributed.dram_joules + tick_unattributed.dram_joules,
+                    gpu_joules: prev_unattributed.gpu_joules + tick_unattributed.gpu_joules,
                 };
 
-                // Update previous tick state for power computation
-                prev_state = PreviousTickState {
-                    timestamp: current_timestamp,
-                    workload_energy: cumulative_workloads
-                        .iter()
-                        .map(|wl| (wl.root_pid, wl.energy.clone()))
-                        .collect(),
+                // system_total = sum(workload cumulative energies) + cumulative unattributed
+                let cumulative_system_total = DeviceEnergy {
+                    cpu_joules: workloads.iter().map(|w| w.energy.cpu_joules).sum::<f64>()
+                        + cumulative_unattributed.cpu_joules,
+                    dram_joules: workloads.iter().map(|w| w.energy.dram_joules).sum::<f64>()
+                        + cumulative_unattributed.dram_joules,
+                    gpu_joules: workloads.iter().map(|w| w.energy.gpu_joules).sum::<f64>()
+                        + cumulative_unattributed.gpu_joules,
                 };
+
+                // Update tick state with cumulative energies for next iteration
+                tick_state.workload_energy = workloads
+                    .iter()
+                    .map(|wl| (wl.root_pid, wl.energy.clone()))
+                    .collect();
 
                 // Write updated snapshot
                 {
                     let mut snap = snapshot.write().unwrap();
                     snap.timestamp = current_timestamp;
-                    snap.system_total = cumulative_total;
-                    snap.workloads = cumulative_workloads;
+                    snap.system_total = cumulative_system_total;
+                    snap.workloads = workloads;
                     snap.unattributed = cumulative_unattributed;
                     snap.tracked_pids = expanded_pids;
                 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -66,6 +66,13 @@ enum PyEnergyGroupInner {
 }
 
 impl PyEnergyGroupInner {
+    fn set_tracked_pids(&self, pids: Vec<u32>) {
+        match self {
+            Self::Rapl(group) => group.set_tracked_pids(pids),
+            Self::NvidiaGpu(group) => group.set_tracked_pids(pids),
+        }
+    }
+
     fn commence(&mut self, runtime: &Runtime) -> Result<(), MonitoringError> {
         match self {
             Self::Rapl(group) => runtime.block_on(group.commence()),
@@ -73,10 +80,14 @@ impl PyEnergyGroupInner {
         }
     }
 
-    fn poll_data(&mut self) -> Result<(), MonitoringError> {
+    fn poll_data(&mut self) {
         match self {
-            Self::Rapl(group) => group.poll_data(),
-            Self::NvidiaGpu(group) => group.poll_data(),
+            Self::Rapl(group) => {
+                group.poll_data();
+            }
+            Self::NvidiaGpu(group) => {
+                group.poll_data();
+            }
         }
     }
 
@@ -101,22 +112,11 @@ impl PyEnergyGroupInner {
         }
     }
 
-    fn total_energy(&self) -> Result<f64, MonitoringError> {
-        let trace = self.energy_trace();
-        if !trace
-            .get_column_names()
-            .iter()
-            .any(|column_name| column_name.as_str() == "energy")
-        {
-            return Ok(0.0);
+    fn total_consumed_energy(&self) -> f64 {
+        match self {
+            Self::Rapl(group) => group.total_consumed_energy(),
+            Self::NvidiaGpu(group) => group.total_consumed_energy(),
         }
-
-        trace
-            .column("energy")
-            .map_err(|err| MonitoringError::Other(err.to_string()))?
-            .f64()
-            .map_err(|err| MonitoringError::Other(err.to_string()))
-            .map(|values| values.iter().flatten().sum())
     }
 }
 
@@ -195,34 +195,42 @@ impl PyEnergyGroup {
         _cls: &Bound<'_, PyType>,
         collector: &Bound<'_, PyAny>,
         rate: f64,
-        pids: Option<Vec<usize>>,
+        pids: Option<Vec<u32>>,
         batch_size: Option<usize>,
     ) -> PyResult<Self> {
-        if let Ok(collector) = collector.extract::<PyRef<'_, PyRaplCollector>>() {
-            let group = EnergyGroup::create_with_collector(
-                Rapl::new(collector.rapl_path.clone()),
+        if let Ok(collector_ref) = collector.extract::<PyRef<'_, PyRaplCollector>>() {
+            let group = EnergyGroup::new(
+                Rapl::new(collector_ref.rapl_path.clone()),
                 rate,
-                pids,
                 batch_size,
-            )
-            .map_err(to_py_err)?;
-            return Self::with_inner(PyEnergyGroupInner::Rapl(group));
+            );
+            let result = Self::with_inner(PyEnergyGroupInner::Rapl(group))?;
+            if let Some(pids) = pids {
+                result.inner.set_tracked_pids(pids);
+            }
+            return Ok(result);
         }
 
-        if let Ok(collector) = collector.extract::<PyRef<'_, PyNvidiaGpuCollector>>() {
-            let group = EnergyGroup::create_with_collector(
-                NvidiaGpu::new(collector.device_ids.clone()),
+        if let Ok(collector_ref) = collector.extract::<PyRef<'_, PyNvidiaGpuCollector>>() {
+            let group = EnergyGroup::new(
+                NvidiaGpu::new(collector_ref.device_ids.clone()),
                 rate,
-                pids,
                 batch_size,
-            )
-            .map_err(to_py_err)?;
-            return Self::with_inner(PyEnergyGroupInner::NvidiaGpu(group));
+            );
+            let result = Self::with_inner(PyEnergyGroupInner::NvidiaGpu(group))?;
+            if let Some(pids) = pids {
+                result.inner.set_tracked_pids(pids);
+            }
+            return Ok(result);
         }
 
         Err(PyTypeError::new_err(
             "collector must be an instance of RaplCollector or NvidiaGpuCollector",
         ))
+    }
+
+    fn set_tracked_pids(&self, pids: Vec<u32>) {
+        self.inner.set_tracked_pids(pids);
     }
 
     fn commence(&mut self, py: Python<'_>) -> PyResult<()> {
@@ -231,7 +239,10 @@ impl PyEnergyGroup {
     }
 
     fn poll_data(&mut self, py: Python<'_>) -> PyResult<()> {
-        py.detach(|| self.inner.poll_data().map_err(to_py_err))
+        py.detach(|| {
+            self.inner.poll_data();
+            Ok(())
+        })
     }
 
     fn shutdown(&mut self, py: Python<'_>) -> PyResult<()> {
@@ -242,8 +253,8 @@ impl PyEnergyGroup {
         self.inner.is_running()
     }
 
-    fn total_energy(&self) -> PyResult<f64> {
-        self.inner.total_energy().map_err(to_py_err)
+    fn total_energy(&self) -> f64 {
+        self.inner.total_consumed_energy()
     }
 
     fn energy_trace(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {

--- a/src/python.rs
+++ b/src/python.rs
@@ -50,7 +50,7 @@ impl PyNvidiaGpuCollector {
     #[pyo3(signature = (device_ids=None))]
     fn new(device_ids: Option<Vec<u32>>) -> Self {
         Self {
-            device_ids: device_ids.unwrap_or_else(|| vec![0]),
+            device_ids: device_ids.unwrap_or_default(),
         }
     }
 
@@ -212,11 +212,14 @@ impl PyEnergyGroup {
         }
 
         if let Ok(collector_ref) = collector.extract::<PyRef<'_, PyNvidiaGpuCollector>>() {
-            let group = EnergyGroup::new(
-                NvidiaGpu::new(collector_ref.device_ids.clone()),
-                rate,
-                batch_size,
-            );
+            let nvidia_collector = if collector_ref.device_ids.is_empty() {
+                NvidiaGpu::new()
+                    .map_err(|e| PyRuntimeError::new_err(format!("NVML init failed: {}", e)))?
+            } else {
+                NvidiaGpu::with_device_filter(collector_ref.device_ids.clone())
+                    .map_err(|e| PyRuntimeError::new_err(format!("NVML init failed: {}", e)))?
+            };
+            let group = EnergyGroup::new(nvidia_collector, rate, batch_size);
             let result = Self::with_inner(PyEnergyGroupInner::NvidiaGpu(group))?;
             if let Some(pids) = pids {
                 result.inner.set_tracked_pids(pids);

--- a/src/trace_recorder.rs
+++ b/src/trace_recorder.rs
@@ -1,0 +1,525 @@
+/// Trace Recorder Module
+///
+/// Provides a trait and implementations for flushing energy trace data to disk.
+/// The `CsvTraceRecorder` writes data from a `RotatingTrace` to CSV files with
+/// automatic file rotation based on size limits.
+use crate::utils::trace_rotation::RotatingTrace;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+
+/// Trait for recording trace data to persistent storage.
+///
+/// Implementors receive a reference to a `RotatingTrace` and are responsible
+/// for writing some or all of that data to their backing store.
+pub trait TraceRecorder: Send + Sync {
+    /// Flush data from the given trace to persistent storage.
+    fn flush(&mut self, trace: &RotatingTrace);
+}
+
+/// A CSV-based trace recorder that writes energy records to rotating CSV files.
+///
+/// Behavior:
+/// - Writes all columns from the RotatingTrace DataFrame (pid, timestamp, device, energy).
+/// - Rotates to a new file when the current file exceeds `max_file_size_bytes`.
+/// - Keeps at most `max_files` CSV files, deleting the oldest when the limit is exceeded.
+/// - Only flushes records newer than the last flushed timestamp to avoid duplicates.
+pub struct CsvTraceRecorder {
+    output_dir: PathBuf,
+    max_file_size_bytes: u64,
+    max_files: usize,
+    current_file: Option<File>,
+    current_file_path: Option<PathBuf>,
+    current_file_size: u64,
+    file_index: usize,
+    last_flushed_timestamp: Option<i64>,
+}
+
+impl CsvTraceRecorder {
+    /// Create a new CsvTraceRecorder.
+    ///
+    /// # Arguments
+    /// * `output_dir` - Directory where CSV files will be written.
+    /// * `max_file_size_bytes` - Maximum size per file before rotation (default: 10 MB).
+    /// * `max_files` - Maximum number of rotated files to keep (default: 5).
+    pub fn new(
+        output_dir: PathBuf,
+        max_file_size_bytes: Option<u64>,
+        max_files: Option<usize>,
+    ) -> Self {
+        Self {
+            output_dir,
+            max_file_size_bytes: max_file_size_bytes.unwrap_or(10 * 1024 * 1024),
+            max_files: max_files.unwrap_or(5),
+            current_file: None,
+            current_file_path: None,
+            current_file_size: 0,
+            file_index: 0,
+            last_flushed_timestamp: None,
+        }
+    }
+
+    /// Generate the file path for a given index.
+    fn file_path_for_index(&self, index: usize) -> PathBuf {
+        self.output_dir.join(format!("trace_{}.csv", index))
+    }
+
+    /// Ensure the output directory exists.
+    fn ensure_output_dir(&self) -> std::io::Result<()> {
+        fs::create_dir_all(&self.output_dir)
+    }
+
+    /// Open a new CSV file and write the header row.
+    fn rotate_file(&mut self) -> std::io::Result<()> {
+        // Close current file if open
+        self.current_file = None;
+
+        // Advance to next file index
+        self.file_index += 1;
+        let path = self.file_path_for_index(self.file_index);
+
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&path)?;
+
+        self.current_file = Some(file);
+        self.current_file_path = Some(path);
+        self.current_file_size = 0;
+
+        // Write CSV header
+        self.write_header()?;
+
+        // Enforce max_files limit
+        self.enforce_max_files();
+
+        Ok(())
+    }
+
+    /// Write the CSV header row.
+    fn write_header(&mut self) -> std::io::Result<()> {
+        let header = "pid,timestamp,device,energy\n";
+        if let Some(ref mut file) = self.current_file {
+            file.write_all(header.as_bytes())?;
+            self.current_file_size += header.len() as u64;
+        }
+        Ok(())
+    }
+
+    /// Open the initial file if none is currently open.
+    fn ensure_file_open(&mut self) -> std::io::Result<()> {
+        if self.current_file.is_none() {
+            self.ensure_output_dir()?;
+            let path = self.file_path_for_index(self.file_index);
+
+            let file = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(&path)?;
+
+            self.current_file = Some(file);
+            self.current_file_path = Some(path);
+            self.current_file_size = 0;
+
+            self.write_header()?;
+        }
+        Ok(())
+    }
+
+    /// Remove old files that exceed the max_files limit.
+    fn enforce_max_files(&self) {
+        if self.file_index < self.max_files {
+            return;
+        }
+
+        // Delete files older than (file_index - max_files)
+        let oldest_to_keep = self.file_index - self.max_files + 1;
+        for i in 0..oldest_to_keep {
+            let path = self.file_path_for_index(i);
+            let _ = fs::remove_file(path);
+        }
+    }
+
+    /// Write a single CSV row.
+    fn write_row(
+        &mut self,
+        pid: u32,
+        timestamp: i64,
+        device: &str,
+        energy: f64,
+    ) -> std::io::Result<()> {
+        let row = format!("{},{},{},{}\n", pid, timestamp, device, energy);
+        let row_bytes = row.as_bytes();
+
+        // Check if we need to rotate before writing
+        if self.current_file_size + row_bytes.len() as u64 > self.max_file_size_bytes {
+            self.ensure_output_dir()?;
+            self.rotate_file()?;
+        }
+
+        if let Some(ref mut file) = self.current_file {
+            file.write_all(row_bytes)?;
+            self.current_file_size += row_bytes.len() as u64;
+        }
+
+        Ok(())
+    }
+}
+
+impl TraceRecorder for CsvTraceRecorder {
+    fn flush(&mut self, trace: &RotatingTrace) {
+        let df = trace.data();
+
+        if df.is_empty() {
+            return;
+        }
+
+        // Extract columns from the DataFrame
+        let pid_col = match df.column("pid") {
+            Ok(col) => col,
+            Err(e) => {
+                log::error!("Failed to get 'pid' column from trace: {}", e);
+                return;
+            }
+        };
+        let timestamp_col = match df.column("timestamp") {
+            Ok(col) => col,
+            Err(e) => {
+                log::error!("Failed to get 'timestamp' column from trace: {}", e);
+                return;
+            }
+        };
+        let device_col = match df.column("device") {
+            Ok(col) => col,
+            Err(e) => {
+                log::error!("Failed to get 'device' column from trace: {}", e);
+                return;
+            }
+        };
+        let energy_col = match df.column("energy") {
+            Ok(col) => col,
+            Err(e) => {
+                log::error!("Failed to get 'energy' column from trace: {}", e);
+                return;
+            }
+        };
+
+        // Get typed column iterators
+        let pids = match pid_col.u32() {
+            Ok(ca) => ca,
+            Err(e) => {
+                log::error!("Failed to cast 'pid' column to u32: {}", e);
+                return;
+            }
+        };
+        let timestamps = match timestamp_col.i64() {
+            Ok(ca) => ca,
+            Err(e) => {
+                log::error!("Failed to cast 'timestamp' column to i64: {}", e);
+                return;
+            }
+        };
+        let devices = match device_col.str() {
+            Ok(ca) => ca,
+            Err(e) => {
+                log::error!("Failed to cast 'device' column to str: {}", e);
+                return;
+            }
+        };
+        let energies = match energy_col.f64() {
+            Ok(ca) => ca,
+            Err(e) => {
+                log::error!("Failed to cast 'energy' column to f64: {}", e);
+                return;
+            }
+        };
+
+        // Ensure we have an open file
+        if let Err(e) = self.ensure_file_open() {
+            log::error!("Failed to open trace output file: {}", e);
+            return;
+        }
+
+        let mut max_timestamp = self.last_flushed_timestamp;
+
+        for row_idx in 0..df.height() {
+            let ts = match timestamps.get(row_idx) {
+                Some(v) => v,
+                None => continue,
+            };
+
+            // Skip records we have already flushed
+            if let Some(last_ts) = self.last_flushed_timestamp {
+                if ts <= last_ts {
+                    continue;
+                }
+            }
+
+            let pid = match pids.get(row_idx) {
+                Some(v) => v,
+                None => continue,
+            };
+            let device = match devices.get(row_idx) {
+                Some(v) => v,
+                None => continue,
+            };
+            let energy = match energies.get(row_idx) {
+                Some(v) => v,
+                None => continue,
+            };
+
+            if let Err(e) = self.write_row(pid, ts, device, energy) {
+                log::error!("Failed to write trace row: {}", e);
+                return;
+            }
+
+            // Track the maximum timestamp we flushed
+            max_timestamp = Some(match max_timestamp {
+                Some(current_max) => current_max.max(ts),
+                None => ts,
+            });
+        }
+
+        // Update last flushed timestamp
+        if max_timestamp != self.last_flushed_timestamp {
+            self.last_flushed_timestamp = max_timestamp;
+        }
+
+        // Flush the file to disk
+        if let Some(ref mut file) = self.current_file {
+            let _ = file.flush();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::trace_rotation::RotatingTrace;
+    use polars::df;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use tempfile::TempDir;
+
+    fn current_timestamp_secs() -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0)
+    }
+
+    fn make_trace_with_data(timestamps: Vec<i64>) -> RotatingTrace {
+        let mut trace = RotatingTrace::new(3600);
+        let n = timestamps.len();
+        let data = df![
+            "pid" => vec![1u32; n],
+            "timestamp" => timestamps,
+            "device" => vec!["cpu".to_string(); n],
+            "energy" => vec![10.0; n],
+        ]
+        .unwrap();
+        trace.append(&data).unwrap();
+        trace
+    }
+
+    #[test]
+    fn csv_recorder_creates_file_on_flush() {
+        let tmp_dir = TempDir::new().unwrap();
+        let mut recorder = CsvTraceRecorder::new(tmp_dir.path().to_path_buf(), None, None);
+
+        let now = current_timestamp_secs();
+        let trace = make_trace_with_data(vec![now]);
+
+        recorder.flush(&trace);
+
+        let file_path = tmp_dir.path().join("trace_0.csv");
+        assert!(file_path.exists(), "CSV file should be created on flush");
+    }
+
+    #[test]
+    fn csv_recorder_writes_valid_csv() {
+        let tmp_dir = TempDir::new().unwrap();
+        let mut recorder = CsvTraceRecorder::new(tmp_dir.path().to_path_buf(), None, None);
+
+        let now = current_timestamp_secs();
+        let mut trace = RotatingTrace::new(3600);
+        let data = df![
+            "pid" => vec![42u32, 43u32],
+            "timestamp" => vec![now, now + 1],
+            "device" => vec!["cpu".to_string(), "gpu".to_string()],
+            "energy" => vec![1.5, 2.5],
+        ]
+        .unwrap();
+        trace.append(&data).unwrap();
+
+        recorder.flush(&trace);
+
+        let file_path = tmp_dir.path().join("trace_0.csv");
+        let contents = fs::read_to_string(file_path).unwrap();
+        let lines: Vec<&str> = contents.lines().collect();
+
+        assert_eq!(lines[0], "pid,timestamp,device,energy");
+        assert_eq!(lines.len(), 3); // header + 2 data rows
+
+        // Verify first data row
+        let fields: Vec<&str> = lines[1].split(',').collect();
+        assert_eq!(fields[0], "42");
+        assert_eq!(fields[2], "cpu");
+        assert_eq!(fields[3], "1.5");
+
+        // Verify second data row
+        let fields: Vec<&str> = lines[2].split(',').collect();
+        assert_eq!(fields[0], "43");
+        assert_eq!(fields[2], "gpu");
+        assert_eq!(fields[3], "2.5");
+    }
+
+    #[test]
+    fn csv_recorder_rotates_files() {
+        let tmp_dir = TempDir::new().unwrap();
+        // Use a very small max file size to trigger rotation
+        let mut recorder = CsvTraceRecorder::new(tmp_dir.path().to_path_buf(), Some(50), Some(10));
+
+        let now = current_timestamp_secs();
+        let mut trace = RotatingTrace::new(3600);
+        let data = df![
+            "pid" => vec![1u32, 2u32, 3u32, 4u32, 5u32],
+            "timestamp" => vec![now, now + 1, now + 2, now + 3, now + 4],
+            "device" => vec!["cpu".to_string(); 5],
+            "energy" => vec![10.0; 5],
+        ]
+        .unwrap();
+        trace.append(&data).unwrap();
+
+        recorder.flush(&trace);
+
+        // With a 50-byte limit, the header alone is ~25 bytes, so rows should
+        // cause rotation. Check that multiple files were created.
+        let csv_files: Vec<_> = fs::read_dir(tmp_dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .is_some_and(|ext| ext == "csv")
+            })
+            .collect();
+
+        assert!(
+            csv_files.len() > 1,
+            "Expected multiple files after rotation, got {}",
+            csv_files.len()
+        );
+    }
+
+    #[test]
+    fn csv_recorder_respects_max_files() {
+        let tmp_dir = TempDir::new().unwrap();
+        // Very small file size + max 2 files
+        let mut recorder = CsvTraceRecorder::new(tmp_dir.path().to_path_buf(), Some(40), Some(2));
+
+        let now = current_timestamp_secs();
+        let mut trace = RotatingTrace::new(3600);
+        let data = df![
+            "pid" => vec![1u32; 10],
+            "timestamp" => (0..10).map(|i| now + i).collect::<Vec<_>>(),
+            "device" => vec!["cpu".to_string(); 10],
+            "energy" => vec![99.9; 10],
+        ]
+        .unwrap();
+        trace.append(&data).unwrap();
+
+        recorder.flush(&trace);
+
+        // Count remaining CSV files
+        let csv_files: Vec<_> = fs::read_dir(tmp_dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .is_some_and(|ext| ext == "csv")
+            })
+            .collect();
+
+        assert!(
+            csv_files.len() <= 2,
+            "Expected at most 2 files, got {}",
+            csv_files.len()
+        );
+    }
+
+    #[test]
+    fn csv_recorder_skips_empty_trace() {
+        let tmp_dir = TempDir::new().unwrap();
+        let mut recorder = CsvTraceRecorder::new(tmp_dir.path().to_path_buf(), None, None);
+
+        let trace = RotatingTrace::new(3600); // empty trace
+
+        recorder.flush(&trace);
+
+        // No file should be created for an empty trace
+        let entries: Vec<_> = fs::read_dir(tmp_dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+
+        assert_eq!(
+            entries.len(),
+            0,
+            "No files should be created for empty trace"
+        );
+    }
+
+    #[test]
+    fn csv_recorder_only_flushes_new_records() {
+        let tmp_dir = TempDir::new().unwrap();
+        let mut recorder = CsvTraceRecorder::new(tmp_dir.path().to_path_buf(), None, None);
+
+        let now = current_timestamp_secs();
+
+        // First flush with initial data
+        let mut trace = RotatingTrace::new(3600);
+        let data1 = df![
+            "pid" => vec![1u32, 2u32],
+            "timestamp" => vec![now, now + 1],
+            "device" => vec!["cpu".to_string(); 2],
+            "energy" => vec![10.0; 2],
+        ]
+        .unwrap();
+        trace.append(&data1).unwrap();
+
+        recorder.flush(&trace);
+
+        // Add more data to the same trace (simulating new records arriving)
+        let data2 = df![
+            "pid" => vec![3u32],
+            "timestamp" => vec![now + 2],
+            "device" => vec!["cpu".to_string()],
+            "energy" => vec![30.0],
+        ]
+        .unwrap();
+        trace.append(&data2).unwrap();
+
+        // Flush again - should only write the new record
+        recorder.flush(&trace);
+
+        let file_path = tmp_dir.path().join("trace_0.csv");
+        let contents = fs::read_to_string(file_path).unwrap();
+        let lines: Vec<&str> = contents.lines().collect();
+
+        // header + 2 original records + 1 new record = 4 lines
+        assert_eq!(
+            lines.len(),
+            4,
+            "Expected 4 lines (header + 3 records), got {}",
+            lines.len()
+        );
+
+        // Verify the third data row is the new record
+        let fields: Vec<&str> = lines[3].split(',').collect();
+        assert_eq!(fields[0], "3");
+        assert_eq!(fields[3], "30");
+    }
+}

--- a/src/utils/psutils.rs
+++ b/src/utils/psutils.rs
@@ -1,8 +1,15 @@
-use crate::energy_group::ProcessGroup;
 use crate::utils::errors::MonitoringError;
 use std::collections::HashMap;
 use sysinfo::System;
 use users::{Users, UsersCache};
+
+/// A group of processes belonging to the same user and application
+#[derive(Debug)]
+pub struct ProcessGroup {
+    pub user: String,
+    pub task: String,
+    pub pids: Vec<usize>,
+}
 
 pub fn resolve_username(uid: u32, users_cache: &UsersCache) -> String {
     users_cache

--- a/src/utils/psutils.rs
+++ b/src/utils/psutils.rs
@@ -1,8 +1,126 @@
 use crate::energy_group::ProcessGroup;
 use crate::utils::errors::MonitoringError;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::fs;
 use sysinfo::System;
 use users::{Users, UsersCache};
+
+// ─── New process discovery model (consumed by Monitor) ───────────────────────
+
+/// Represents a root process (tree top) identified during a full scan.
+/// A root is a process whose parent PID is not present in the system snapshot.
+#[derive(Debug, Clone)]
+pub struct ProcessRoot {
+    pub pid: u32,
+    pub user: String,
+    pub name: String,
+}
+
+/// Fast child-walk that reads /proc directly (no sysinfo overhead).
+/// Returns all descendant PIDs of the given root PIDs, including the roots themselves.
+/// Designed to be called at 10 Hz — must be sub-millisecond for ~20-50 roots.
+pub fn walk_child_pids(roots: &[u32]) -> Vec<u32> {
+    if roots.is_empty() {
+        return Vec::new();
+    }
+
+    // Build a parent -> children map by scanning /proc/*/status
+    let mut parent_to_children: HashMap<u32, Vec<u32>> = HashMap::new();
+
+    let proc_dir = match fs::read_dir("/proc") {
+        Ok(dir) => dir,
+        Err(_) => return roots.to_vec(),
+    };
+
+    for entry in proc_dir.flatten() {
+        let file_name = entry.file_name();
+        let name_str = file_name.to_string_lossy();
+
+        // Only process numeric directory entries (PIDs)
+        let pid: u32 = match name_str.parse() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+
+        // Read the status file and extract PPid
+        let status_path = format!("/proc/{}/status", pid);
+        let contents = match fs::read_to_string(&status_path) {
+            Ok(c) => c,
+            Err(_) => continue, // Process may have exited
+        };
+
+        for line in contents.lines() {
+            if let Some(ppid_str) = line.strip_prefix("PPid:\t") {
+                if let Ok(ppid) = ppid_str.trim().parse::<u32>() {
+                    parent_to_children.entry(ppid).or_default().push(pid);
+                }
+                break;
+            }
+        }
+    }
+
+    // BFS from each root to collect all descendants
+    let mut result: Vec<u32> = Vec::new();
+    let mut visited: HashSet<u32> = HashSet::new();
+    let mut queue: VecDeque<u32> = VecDeque::new();
+
+    for &root in roots {
+        if visited.insert(root) {
+            result.push(root);
+            queue.push_back(root);
+        }
+    }
+
+    while let Some(current) = queue.pop_front() {
+        if let Some(children) = parent_to_children.get(&current) {
+            for &child in children {
+                if visited.insert(child) {
+                    result.push(child);
+                    queue.push_back(child);
+                }
+            }
+        }
+    }
+
+    result
+}
+
+/// Full process scan to identify root PIDs (tree tops).
+/// A root is a process whose parent PID is NOT in the discovered set of all PIDs.
+/// Uses sysinfo for full metadata (user, name).
+pub fn scan_roots() -> Vec<ProcessRoot> {
+    let system = System::new_all();
+    let users_cache = UsersCache::new();
+
+    let all_pids: HashSet<u32> = system.processes().keys().map(|pid| pid.as_u32()).collect();
+
+    let mut roots = Vec::new();
+    for (pid, process) in system.processes() {
+        let is_root = match process.parent() {
+            Some(ppid) => !all_pids.contains(&ppid.as_u32()),
+            None => true,
+        };
+
+        if is_root {
+            let user = process
+                .user_id()
+                .map(|uid| resolve_username(**uid, &users_cache))
+                .unwrap_or_else(|| "unknown".to_string());
+            let name = process.name().to_string_lossy().to_string();
+
+            roots.push(ProcessRoot {
+                pid: pid.as_u32(),
+                user,
+                name,
+            });
+        }
+    }
+
+    roots
+}
+
+// ─── Legacy functions (still used by energy_group.rs and main.rs) ────────────
+// These will be removed once the Monitor integration is complete.
 
 pub fn resolve_username(uid: u32, users_cache: &UsersCache) -> String {
     users_cache
@@ -129,4 +247,63 @@ pub fn collect_process_groups(
         .collect();
 
     Ok(tracked_processes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn walk_child_pids_includes_roots() {
+        // Current process should appear in results when passed as root
+        let my_pid = std::process::id();
+        let result = walk_child_pids(&[my_pid]);
+        assert!(result.contains(&my_pid));
+    }
+
+    #[test]
+    fn walk_child_pids_empty_roots_returns_empty() {
+        let result = walk_child_pids(&[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn walk_child_pids_nonexistent_pid_returns_just_root() {
+        // A PID that almost certainly doesn't exist
+        let result = walk_child_pids(&[999_999_999]);
+        // The root is included even if it has no children in the system
+        assert!(result.contains(&999_999_999));
+    }
+
+    #[test]
+    fn walk_child_pids_pid_1_has_descendants() {
+        // PID 1 (init/systemd) should have many descendants
+        let result = walk_child_pids(&[1]);
+        assert!(result.contains(&1));
+        // init should have at least some children on any running Linux system
+        assert!(result.len() > 1);
+    }
+
+    #[test]
+    fn scan_roots_returns_nonempty() {
+        let roots = scan_roots();
+        // There should always be at least one root process (init/systemd)
+        assert!(!roots.is_empty());
+    }
+
+    #[test]
+    fn scan_roots_contains_init() {
+        let roots = scan_roots();
+        // PID 1 should always be a root
+        assert!(roots.iter().any(|r| r.pid == 1));
+    }
+
+    #[test]
+    fn scan_roots_have_metadata() {
+        let roots = scan_roots();
+        // All roots should have non-empty names
+        for root in &roots {
+            assert!(!root.name.is_empty(), "Root PID {} has empty name", root.pid);
+        }
+    }
 }

--- a/tests/test_verification_scripts.py
+++ b/tests/test_verification_scripts.py
@@ -74,7 +74,7 @@ def test_build_verification_methods_forwards_sudo_to_rust(monkeypatch):
 
 
 def test_measure_rust_cli_writes_output_under_artifacts_tmp(tmp_path, monkeypatch):
-    rust_binary = tmp_path / "energy-monitoring-tool"
+    rust_binary = tmp_path / "emt"
     rust_binary.write_text("#!/bin/sh\n", encoding="utf-8")
     output_dir = tmp_path / "rust-output"
     popen_calls = []


### PR DESCRIPTION
## Summary

- **ENE-31**: Slim `EnergyGroup` to channel + accumulate + RotatingTrace core
- **ENE-32**: Add `ProcessRoot`, `walk_child_pids`, and `scan_roots` to psutils
- **ENE-33**: YAML config with layered resolution (local → user → CLI override)
- **ENE-34**: `TraceRecorder` trait and `CsvTraceRecorder` with file rotation
- **ENE-35**: `Monitor` coordinator with `MonitorHandle` (self-driven tick loop)
- **ENE-36**: `MetricsSnapshot` with device-level energy breakdown (CPU/DRAM/GPU)
- **ENE-37**: Rewrite `main.rs` as `emt` CLI using Monitor pattern
- **ENE-9**: Replace `nvidia-smi` CLI parsing with `nvml-wrapper` crate
- Fix: Resolve `power_watts=0` (use average power) and empty workload metadata

## Architecture

```
CLI (main.rs)
 └── Monitor (self-driven coordinator)
      ├── EnergyGroup<Rapl>     — CPU/DRAM energy via powercap
      ├── EnergyGroup<NvidiaGpu> — GPU energy via NVML
      ├── Process discovery      — walk_child_pids / scan_roots
      └── MonitorHandle          — read-only snapshot access
```

- 10Hz tick loop with batched record delivery
- Cumulative energy tracking with average power computation
- Process tree attribution (child PIDs mapped to root workloads)
- Layered YAML config: `./emt.yml` → `~/.config/emt/config.yml` → CLI flags

## Test plan

- [x] 61 Rust tests pass (`cargo test`)
- [x] CLI tested with `--pid`, `--duration`, `--quiet`, and monitor-all mode
- [x] Power readings verified (~14W on test hardware)
- [x] Process metadata resolution confirmed (name + user)
- [ ] Verification parity run (`python scripts/verify.py`)
- [ ] CI green across all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)