### PR TITLE
feat: PyO3 RustMonitor + Python EnergyMonitor backend swap

### DIFF
--- a/emt/energy_monitor.py
+++ b/emt/energy_monitor.py
@@ -184,6 +184,7 @@ class EnergyMonitor:
             self._validate_trace_recorders(self._trace_recorders)
 
         self.pg_objs = None
+        self._rust_backend = None
 
     def _normalize_trace_recorders(self, trace_recorders):
         if trace_recorders is None:
@@ -196,18 +197,46 @@ class EnergyMonitor:
         if not all(isinstance(tr, TraceRecorder) for tr in trace_recorders):
             raise ValueError("Invalid trace emitters provided.")
 
+    def _try_rust_backend(self):
+        """Attempt to create and start the Rust-based monitor backend."""
+        try:
+            from emt._rust import RustMonitor
+
+            kwargs = {"name": self.context_name}
+            if self._pid is not None:
+                kwargs["pid"] = self._pid
+            if self._rate is not None:
+                kwargs["rate"] = self._rate
+            backend = RustMonitor(**kwargs)
+            backend.commence()
+            return backend
+        except ImportError:
+            logger.debug("Rust backend not available, falling back to Python.")
+            return None
+        except Exception as e:
+            logger.warning(
+                f"Rust backend failed to start ({e}), falling back to Python."
+            )
+            return None
+
     def __enter__(self):
         logger.info(f"EMT context manager invoked - {self.context_name} ...")
         self.start_time = time.time()
-        # get available powergroups
+
+        # Try Rust backend first (no Python threads needed)
+        self._rust_backend = self._try_rust_backend()
+        if self._rust_backend is not None:
+            if self._startup_delay_s:
+                time.sleep(self._startup_delay_s)
+            return self
+
+        # Pure-Python fallback
         pg_kwargs = {"pid": self._pid} if self._pid is not None else {}
         if self._rate is not None:
             pg_kwargs["rate"] = self._rate
         self.pg_objs = get_available_pgs(**pg_kwargs)
-        # log powergroup info in a tabular format
         logger.info("\n" + get_pg_table())
 
-        # set trace emitters
         for trace_emitter in self._trace_recorders:
             trace_emitter.power_groups = self.pg_objs
 
@@ -217,7 +246,6 @@ class EnergyMonitor:
             trace_recorders=self._trace_recorders,
         )
         self.energy_meter = energy_meter
-        # run EnergyMonitoring as a separate thread
         self.energy_meter_thread = threading.Thread(
             name="EnergyMonitoringThread", target=energy_meter.run
         )
@@ -225,9 +253,25 @@ class EnergyMonitor:
 
         if self._startup_delay_s:
             time.sleep(self._startup_delay_s)
-        return self.energy_meter
+        return self
 
     def __exit__(self, *_):
+        if self._rust_backend is not None:
+            self._rust_backend.shutdown()
+            execution_time = time.time() - self.start_time
+            logger.info(
+                f"{self.context_name}: Execution time: {execution_time:.2f} seconds"
+            )
+            logger.info(
+                f"{self.context_name}: Total energy consumption: "
+                f"{self._rust_backend.total_consumed_energy:.2f} Joules"
+            )
+            logger.info(
+                f"{self.context_name}: Device energy: {self._rust_backend.consumed_energy}"
+            )
+            return
+
+        # Pure-Python path
         self.energy_meter.conclude()
         self.energy_meter_thread.join()
         execution_time = time.time() - self.start_time
@@ -240,3 +284,35 @@ class EnergyMonitor:
         logger.info(
             f"{self.context_name}: Power group energy consumptions: {self.energy_meter.consumed_energy}"
         )
+
+    @property
+    def total_consumed_energy(self) -> float:
+        """Total energy consumed across all devices (Joules)."""
+        if hasattr(self, "_rust_backend") and self._rust_backend is not None:
+            return self._rust_backend.total_consumed_energy
+        if hasattr(self, "energy_meter"):
+            return self.energy_meter.total_consumed_energy
+        return 0.0
+
+    @property
+    def consumed_energy(self) -> Mapping[str, float]:
+        """Per-device energy breakdown."""
+        if hasattr(self, "_rust_backend") and self._rust_backend is not None:
+            return self._rust_backend.consumed_energy
+        if hasattr(self, "energy_meter"):
+            return self.energy_meter.consumed_energy
+        return {}
+
+    @property
+    def trace_recorders(self):
+        """Expose trace recorders for backwards compatibility."""
+        if hasattr(self, "energy_meter") and self.energy_meter is not None:
+            return self.energy_meter.trace_recorders
+        return self._trace_recorders
+
+    @property
+    def energy_unit(self) -> str:
+        """Returns the energy unit."""
+        if hasattr(self, "energy_meter") and self.energy_meter is not None:
+            return self.energy_meter.energy_unit
+        return "Joules"

--- a/emt/energy_monitor.py
+++ b/emt/energy_monitor.py
@@ -199,6 +199,12 @@ class EnergyMonitor:
 
     def _try_rust_backend(self):
         """Attempt to create and start the Rust-based monitor backend."""
+        if self._trace_recorders:
+            logger.debug(
+                "Trace recorders require the Python backend; skipping Rust backend."
+            )
+            return None
+
         try:
             from emt._rust import RustMonitor
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,10 +1,13 @@
 use crate::collectors::{NvidiaGpu, Rapl};
+use crate::config::EmtConfig;
 use crate::energy_group::{EnergyCollector, EnergyGroup};
+use crate::monitor::{Monitor, MonitorHandle};
 use crate::utils::errors::MonitoringError;
 use polars::prelude::DataFrame;
 use pyo3::exceptions::{PyRuntimeError, PyTypeError};
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyDict, PyType};
+use std::collections::HashMap;
 use tokio::runtime::{Builder, Runtime};
 
 fn to_py_err(err: MonitoringError) -> PyErr {
@@ -262,10 +265,95 @@ impl PyEnergyGroup {
     }
 }
 
+// ─── RustMonitor: high-level PyO3 wrapper around Monitor ───────────────────
+
+#[pyclass(name = "RustMonitor", module = "emt._rust")]
+pub struct PyRustMonitor {
+    runtime: Runtime,
+    monitor: Option<Monitor>,
+    handle: Option<MonitorHandle>,
+}
+
+#[pymethods]
+impl PyRustMonitor {
+    #[new]
+    #[pyo3(signature = (*, name=None, pid=None, rate=None))]
+    fn new(name: Option<&str>, pid: Option<u32>, rate: Option<f64>) -> PyResult<Self> {
+        let _ = name;
+        let mut config = EmtConfig::load();
+        if let Some(rate_hz) = rate {
+            config.collection.rate_hz = rate_hz;
+        }
+        let root_pids = pid.map(|p| vec![p]);
+        let monitor = Monitor::new(config, root_pids);
+        let runtime = build_runtime()?;
+        Ok(Self {
+            runtime,
+            monitor: Some(monitor),
+            handle: None,
+        })
+    }
+
+    fn commence(&mut self, py: Python<'_>) -> PyResult<()> {
+        let monitor = self
+            .monitor
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("Monitor already consumed"))?;
+        let handle = py.detach(|| {
+            self.runtime
+                .block_on(monitor.commence())
+                .map_err(to_py_err)
+        })?;
+        self.handle = Some(handle);
+        Ok(())
+    }
+
+    fn shutdown(&mut self, py: Python<'_>) -> PyResult<()> {
+        let monitor = self
+            .monitor
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("Monitor already consumed"))?;
+        py.detach(|| {
+            self.runtime
+                .block_on(monitor.shutdown())
+                .map_err(to_py_err)
+        })
+    }
+
+    #[getter]
+    fn total_consumed_energy(&self) -> PyResult<f64> {
+        let handle = self
+            .handle
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("Monitor not commenced"))?;
+        Ok(handle.total_consumed_energy())
+    }
+
+    #[getter]
+    fn consumed_energy(&self) -> PyResult<HashMap<String, f64>> {
+        let handle = self
+            .handle
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("Monitor not commenced"))?;
+        let snapshot = handle.snapshot();
+        let mut result = HashMap::new();
+        result.insert("cpu".to_string(), snapshot.system_total.cpu_joules);
+        result.insert("dram".to_string(), snapshot.system_total.dram_joules);
+        result.insert("gpu".to_string(), snapshot.system_total.gpu_joules);
+        Ok(result)
+    }
+
+    #[getter]
+    fn is_running(&self) -> bool {
+        self.handle.is_some()
+    }
+}
+
 #[pymodule]
 fn _rust(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<PyEnergyGroup>()?;
     module.add_class::<PyRaplCollector>()?;
     module.add_class::<PyNvidiaGpuCollector>()?;
+    module.add_class::<PyRustMonitor>()?;
     Ok(())
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -272,6 +272,7 @@ pub struct PyRustMonitor {
     runtime: Runtime,
     monitor: Option<Monitor>,
     handle: Option<MonitorHandle>,
+    running: bool,
 }
 
 #[pymethods]
@@ -284,6 +285,9 @@ impl PyRustMonitor {
         if let Some(rate_hz) = rate {
             config.collection.rate_hz = rate_hz;
         }
+        config
+            .validate()
+            .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
         let root_pids = pid.map(|p| vec![p]);
         let monitor = Monitor::new(config, root_pids);
         let runtime = build_runtime()?;
@@ -291,6 +295,7 @@ impl PyRustMonitor {
             runtime,
             monitor: Some(monitor),
             handle: None,
+            running: false,
         })
     }
 
@@ -299,12 +304,9 @@ impl PyRustMonitor {
             .monitor
             .as_mut()
             .ok_or_else(|| PyRuntimeError::new_err("Monitor already consumed"))?;
-        let handle = py.detach(|| {
-            self.runtime
-                .block_on(monitor.commence())
-                .map_err(to_py_err)
-        })?;
+        let handle = py.detach(|| self.runtime.block_on(monitor.commence()).map_err(to_py_err))?;
         self.handle = Some(handle);
+        self.running = true;
         Ok(())
     }
 
@@ -313,39 +315,43 @@ impl PyRustMonitor {
             .monitor
             .as_mut()
             .ok_or_else(|| PyRuntimeError::new_err("Monitor already consumed"))?;
-        py.detach(|| {
-            self.runtime
-                .block_on(monitor.shutdown())
-                .map_err(to_py_err)
+        let result = py.detach(|| self.runtime.block_on(monitor.shutdown()).map_err(to_py_err));
+        if result.is_ok() {
+            self.running = false;
+        }
+        result
+    }
+
+    #[getter]
+    fn total_consumed_energy(&self, py: Python<'_>) -> PyResult<f64> {
+        let handle = self
+            .handle
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("Monitor not commenced"))?
+            .clone();
+        py.detach(move || Ok(handle.total_consumed_energy()))
+    }
+
+    #[getter]
+    fn consumed_energy(&self, py: Python<'_>) -> PyResult<HashMap<String, f64>> {
+        let handle = self
+            .handle
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("Monitor not commenced"))?
+            .clone();
+        py.detach(move || {
+            let snapshot = handle.snapshot();
+            let mut result = HashMap::new();
+            result.insert("cpu".to_string(), snapshot.system_total.cpu_joules);
+            result.insert("dram".to_string(), snapshot.system_total.dram_joules);
+            result.insert("gpu".to_string(), snapshot.system_total.gpu_joules);
+            Ok(result)
         })
     }
 
     #[getter]
-    fn total_consumed_energy(&self) -> PyResult<f64> {
-        let handle = self
-            .handle
-            .as_ref()
-            .ok_or_else(|| PyRuntimeError::new_err("Monitor not commenced"))?;
-        Ok(handle.total_consumed_energy())
-    }
-
-    #[getter]
-    fn consumed_energy(&self) -> PyResult<HashMap<String, f64>> {
-        let handle = self
-            .handle
-            .as_ref()
-            .ok_or_else(|| PyRuntimeError::new_err("Monitor not commenced"))?;
-        let snapshot = handle.snapshot();
-        let mut result = HashMap::new();
-        result.insert("cpu".to_string(), snapshot.system_total.cpu_joules);
-        result.insert("dram".to_string(), snapshot.system_total.dram_joules);
-        result.insert("gpu".to_string(), snapshot.system_total.gpu_joules);
-        Ok(result)
-    }
-
-    #[getter]
     fn is_running(&self) -> bool {
-        self.handle.is_some()
+        self.running
     }
 }
 

--- a/tests/test_energy_meter.py
+++ b/tests/test_energy_meter.py
@@ -1,5 +1,7 @@
 import pytest
 import asyncio
+import sys
+import types
 from collections import defaultdict
 import threading
 
@@ -9,6 +11,12 @@ from emt.power_groups import PowerGroup
 from emt.utils import TraceRecorder
 
 TOLERANCE = 1e-9
+
+
+def install_fake_rust_module(monkeypatch, rust_monitor_cls):
+    module = types.ModuleType("emt._rust")
+    module.RustMonitor = rust_monitor_cls
+    monkeypatch.setitem(sys.modules, "emt._rust", module)
 
 
 class MockPGCPU(PowerGroup):
@@ -267,10 +275,108 @@ def test_enter_method_passes_pid_to_power_groups():
         ) as mock_get_available_pgs,
         patch("emt.energy_monitor.get_pg_table", return_value=""),
         patch("threading.Thread", return_value=MagicMock()),
+        patch.object(EnergyMonitor, "_try_rust_backend", return_value=None),
     ):
         energy_monitor.__enter__()
 
     mock_get_available_pgs.assert_called_once_with(pid=4321)
+
+
+def test_enter_method_uses_rust_backend_without_python_thread(monkeypatch):
+    """EnergyMonitor prefers RustMonitor when no Python-only feature is requested."""
+    instances = []
+
+    class FakeRustMonitor:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.commenced = False
+            self.shutdown_called = False
+            self.total_consumed_energy = 12.5
+            self.consumed_energy = {"cpu": 10.0, "dram": 2.5, "gpu": 0.0}
+            instances.append(self)
+
+        def commence(self):
+            self.commenced = True
+
+        def shutdown(self):
+            self.shutdown_called = True
+
+    install_fake_rust_module(monkeypatch, FakeRustMonitor)
+    monitor = EnergyMonitor(
+        name="RustContext",
+        pid=4321,
+        rate=5.0,
+        startup_delay_s=0.0,
+    )
+
+    with (
+        patch("emt.energy_monitor.get_available_pgs") as mock_get_available_pgs,
+        patch("threading.Thread") as mock_thread,
+    ):
+        entered = monitor.__enter__()
+
+    assert entered is monitor
+    assert len(instances) == 1
+    assert instances[0].kwargs == {
+        "name": "RustContext",
+        "pid": 4321,
+        "rate": 5.0,
+    }
+    assert instances[0].commenced is True
+    mock_get_available_pgs.assert_not_called()
+    mock_thread.assert_not_called()
+    assert monitor.total_consumed_energy == 12.5
+    assert monitor.consumed_energy == {"cpu": 10.0, "dram": 2.5, "gpu": 0.0}
+
+    monitor.__exit__()
+    assert instances[0].shutdown_called is True
+
+
+def test_import_error_falls_back_to_python_backend(monkeypatch):
+    """ImportError on emt._rust keeps the existing pure-Python path working."""
+    monkeypatch.setitem(sys.modules, "emt._rust", None)
+    energy_monitor = EnergyMonitor(name="FallbackContext", startup_delay_s=0.0)
+
+    with (
+        patch(
+            "emt.energy_monitor.get_available_pgs", return_value=[]
+        ) as mock_get_available_pgs,
+        patch("emt.energy_monitor.get_pg_table", return_value=""),
+        patch("threading.Thread", return_value=MagicMock()) as mock_thread,
+    ):
+        energy_monitor.__enter__()
+
+    mock_get_available_pgs.assert_called_once_with()
+    mock_thread.assert_called_once_with(
+        name="EnergyMonitoringThread", target=energy_monitor.energy_meter.run
+    )
+    assert energy_monitor._rust_backend is None
+
+
+def test_trace_recorders_force_python_backend(monkeypatch, mock_trace_recorders):
+    """Python trace recorders are not silently bypassed by the Rust backend."""
+    rust_monitor = MagicMock()
+    install_fake_rust_module(monkeypatch, rust_monitor)
+    energy_monitor = EnergyMonitor(
+        name="TraceContext",
+        trace_recorders=mock_trace_recorders,
+        startup_delay_s=0.0,
+    )
+
+    with (
+        patch(
+            "emt.energy_monitor.get_available_pgs", return_value=[]
+        ) as mock_get_available_pgs,
+        patch("emt.energy_monitor.get_pg_table", return_value=""),
+        patch("threading.Thread", return_value=MagicMock()) as mock_thread,
+    ):
+        energy_monitor.__enter__()
+
+    rust_monitor.assert_not_called()
+    mock_get_available_pgs.assert_called_once_with()
+    mock_thread.assert_called_once_with(
+        name="EnergyMonitoringThread", target=energy_monitor.energy_meter.run
+    )
 
 
 def test_exit_method(mock_trace_recorders):

--- a/tests/test_energy_meter.py
+++ b/tests/test_energy_meter.py
@@ -248,7 +248,7 @@ def test_enter_method(mock_trace_recorders):
         assert trace_emitter.trace_location is not None
     # 4. Thread starting should be mocked
     mock_thread.assert_called_once_with(
-        name="EnergyMonitoringThread", target=energy_meter.run
+        name="EnergyMonitoringThread", target=energy_monitor.energy_meter.run
     )
     assert energy_meter is not None
 


### PR DESCRIPTION
## Summary

- Add `RustMonitor` PyO3 class in `src/python.rs` wrapping the Rust `Monitor`/`MonitorHandle` with GIL-released methods
- Update `EnergyMonitor.__enter__` to try `emt._rust.RustMonitor` first, falling back to pure-Python `PowerGroups` on `ImportError`
- `EnergyMonitor` now returns `self` from `__enter__` with `total_consumed_energy`, `consumed_energy`, `trace_recorders`, and `energy_unit` properties delegating to the active backend

## Test plan

- [x] `cargo build --features pyo3` compiles cleanly
- [x] All 74 Rust tests pass
- [x] All 88 Python tests pass (fallback path exercised since Rust extension not installed in venv)
- [x] Black formatting verified
- [ ] Integration test with maturin-built wheel: `with EnergyMonitor(name="test") as m: busy_work(); assert m.total_consumed_energy > 0`
- [ ] Verify GIL release: concurrent Python threads not blocked during `commence()`/`shutdown()`

Closes ENE-38

🤖 Generated with [Claude Code](https://claude.com/claude-code)