### PR TITLE
feat: interactive TUI with live RAPL power display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,9 +395,23 @@ version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03b7db8e0b4b2fdad6c551e634134e99ec000e5c8c3b6856c65e8bbaded7a3b"
 dependencies = [
- "crossterm",
+ "crossterm 0.29.0",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -423,6 +443,15 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -512,15 +541,35 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
+ "derive_more",
  "document-features",
+ "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
+ "signal-hook",
+ "signal-hook-mio",
  "winapi",
 ]
 
@@ -585,6 +634,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,7 +683,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -654,14 +725,16 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
+ "crossterm 0.29.0",
  "dirs",
  "env_logger",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "nvml-wrapper",
  "polars",
  "pyo3",
  "rand 0.8.6",
+ "ratatui",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -698,7 +771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -789,7 +862,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.59.0",
 ]
 
@@ -1259,6 +1332,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,7 +1367,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1280,6 +1375,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1357,6 +1461,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1387,6 +1497,15 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1445,6 +1564,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1535,7 +1655,7 @@ dependencies = [
  "http-body-util",
  "humantime",
  "hyper",
- "itertools",
+ "itertools 0.14.0",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
@@ -1606,6 +1726,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1701,7 +1827,7 @@ dependencies = [
  "serde",
  "simdutf8",
  "streaming-iterator",
- "strum_macros",
+ "strum_macros 0.27.2",
  "version_check",
  "zstd",
 ]
@@ -1738,7 +1864,7 @@ dependencies = [
  "serde",
  "skiplist",
  "strength_reduce",
- "strum_macros",
+ "strum_macros 0.27.2",
  "version_check",
 ]
 
@@ -1772,7 +1898,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "strum_macros",
+ "strum_macros 0.27.2",
  "uuid",
  "version_check",
  "xxhash-rust",
@@ -1944,7 +2070,7 @@ dependencies = [
  "rayon",
  "regex",
  "regex-syntax",
- "strum_macros",
+ "strum_macros 0.27.2",
  "unicode-normalization",
  "unicode-reverse",
  "version_check",
@@ -2011,7 +2137,7 @@ dependencies = [
  "recursive",
  "regex",
  "sha2",
- "strum_macros",
+ "strum_macros 0.27.2",
  "version_check",
 ]
 
@@ -2121,7 +2247,7 @@ dependencies = [
  "polars-utils",
  "rayon",
  "regex",
- "strum_macros",
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -2133,7 +2259,7 @@ dependencies = [
  "bincode",
  "bytemuck",
  "bytes",
- "compact_str",
+ "compact_str 0.9.0",
  "flate2",
  "foldhash",
  "hashbrown 0.15.5",
@@ -2328,7 +2454,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2419,6 +2545,27 @@ checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.4",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str 0.8.1",
+ "crossterm 0.28.1",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2601,6 +2748,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2609,8 +2778,8 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys 0.52.0",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2832,6 +3001,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2925,7 +3105,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -2961,6 +3140,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "strum_macros"
@@ -3040,8 +3241,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
- "windows-sys 0.52.0",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3288,10 +3489,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-truncate"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -3562,7 +3780,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ pyo3 = { version = "0.28.3", features = ["extension-module"], optional = true }
 serde_yml = { package = "serde_yaml_ng", version = "0.10" }
 dirs = "6"
 nvml-wrapper = "0.10"
+ratatui = "0.29"
+crossterm = "0.29"
 
 [dev-dependencies]
 tempfile = "3"

--- a/docs/how_EMT_works.md
+++ b/docs/how_EMT_works.md
@@ -124,7 +124,7 @@ The Rust implementation consolidates several concerns that are spread across mul
 | `psutil` Python calls for CPU utilisation | Direct `/proc/stat` and `/proc/<pid>/stat` reads in Rust |
 | `psutil` process tree walk on every `EnergyMonitor.__enter__` | `collect_process_groups()` with recursive child expansion, refreshable on demand |
 | Python `RotatingTrace` list of dicts | Polars `DataFrame` — columnar, zero-copy, easily exported to CSV / Arrow / Parquet |
-| CLI written in Python (`python -m emt --pid …`) | Native binary (`energy-monitoring-tool --pid …`) compiled from `src/main.rs` |
+| CLI written in Python (`python -m emt --pid …`) | Native binary (`emt --pid …`) compiled from `src/main.rs` |
 
 ### PyO3 Integration Points
 
@@ -147,11 +147,11 @@ The Python context manager (`with EnergyMonitor(…) as monitor:`) remains the p
 
 ### CLI Path (Rust Binary)
 
-The Rust binary (`energy-monitoring-tool`) is built directly from `src/main.rs` and does not depend on Python. It provides a standalone CLI for monitoring a PID without writing Python code:
+The Rust binary (`emt`) is built directly from `src/main.rs` and does not depend on Python. It provides a standalone CLI for monitoring a PID without writing Python code:
 
 ```bash
 # Monitor PID 1234 for 30 seconds at 10 Hz, write JSON to results.json
-energy-monitoring-tool --pid 1234 --duration 30 --rate 10 --output results.json
+emt --pid 1234 --duration 30 --rate 10 --json-out results.json
 ```
 
 The Python CLI (`python -m emt …`) will delegate to the same Rust binary once the PyO3 bridge is complete.

--- a/docs/virtualization_strategies.md
+++ b/docs/virtualization_strategies.md
@@ -79,7 +79,7 @@ VM energy ≈ total_socket_energy × (vm_vcpu_cpu_time / total_host_cpu_time)
    ```
 3. Start the Rust CLI with the QEMU PID to attribute energy to that VM:
    ```bash
-   energy-monitoring-tool --pid <qemu_pid> --duration 60 --json
+   emt --pid <qemu_pid> --json-out vm-energy.json --duration 60
    ```
 4. The CLI outputs per-socket RAPL energy weighted by the QEMU process's CPU utilisation share.
 

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -387,9 +387,8 @@ def measure_rust_cli(
         str(rust_duration),
         "--rate",
         "10.0",
-        "--output",
+        "--json-out",
         str(output_file),
-        "--quiet",
     ]
     if use_sudo:
         rust_cmd.insert(0, "sudo")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod energy_group;
 pub mod monitor;
 pub mod trace_recorder;
+pub mod tui;
 
 pub mod utils {
     pub mod errors;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use emt::config::{EmtConfig, MeasurementUnitsConfig};
 use emt::monitor::{DeviceEnergy, MetricsSnapshot, Monitor};
+use emt::tui::{self, App};
 use serde::Serialize;
 use std::fs::File;
 use std::io::Write;
@@ -13,7 +14,7 @@ struct Args {
     #[arg(short, long)]
     pid: Option<u32>,
 
-    /// Duration to monitor in seconds
+    /// Duration to monitor in seconds (headless mode only)
     #[arg(short, long, default_value = "10")]
     duration: u64,
 
@@ -21,13 +22,21 @@ struct Args {
     #[arg(short, long)]
     rate: Option<f64>,
 
-    /// Output file for JSON results (optional)
+    /// Output file for JSON results (optional, implies headless)
     #[arg(short, long)]
     output: Option<String>,
 
-    /// Quiet mode - only output JSON result
+    /// Quiet mode - only output JSON result (implies headless)
     #[arg(short, long)]
     quiet: bool,
+
+    /// Launch interactive TUI (default when no --output or --quiet)
+    #[arg(long)]
+    tui: bool,
+
+    /// Run in headless mode (print results after duration)
+    #[arg(long)]
+    headless: bool,
 }
 
 #[cfg(test)]
@@ -43,6 +52,8 @@ mod tests {
             rate: None,
             output: None,
             quiet: true,
+            tui: false,
+            headless: false,
         };
         let units = MeasurementUnitsConfig {
             energy: "kWh".to_string(),
@@ -90,6 +101,8 @@ mod tests {
             rate: Some(5.0),
             output: None,
             quiet: true,
+            tui: false,
+            headless: false,
         };
         let mut config = EmtConfig::default();
         config.collection.rate_hz = 0.0;
@@ -227,7 +240,10 @@ fn print_human_readable(output: &CliOutput) {
 async fn main() {
     let args = Args::parse();
 
-    if !args.quiet {
+    // Determine mode: TUI vs headless
+    let use_tui = args.tui || (!args.headless && !args.quiet && args.output.is_none());
+
+    if !args.quiet && !use_tui {
         emt::utils::logger::setup_logger();
     }
 
@@ -238,13 +254,18 @@ async fn main() {
         eprintln!("Invalid configuration: {e}");
         std::process::exit(2);
     }
-    let measurement_units = config.measurement_units.clone();
 
-    // Create Monitor with optional root PIDs
-    let root_pids = args.pid.map(|p| vec![p]);
+    if use_tui {
+        run_tui(config, args.pid).await;
+    } else {
+        run_headless(config, &args).await;
+    }
+}
+
+async fn run_tui(config: EmtConfig, pid: Option<u32>) {
+    let root_pids = pid.map(|p| vec![p]);
     let mut monitor = Monitor::new(config, root_pids);
 
-    // Start monitoring
     let handle = match monitor.commence().await {
         Ok(h) => h,
         Err(e) => {
@@ -253,23 +274,79 @@ async fn main() {
         }
     };
 
-    // Sleep for the requested duration
+    // Install panic hook that restores terminal
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = crossterm::terminal::disable_raw_mode();
+        let _ = crossterm::execute!(
+            std::io::stdout(),
+            crossterm::terminal::LeaveAlternateScreen
+        );
+        original_hook(info);
+    }));
+
+    // Enter TUI
+    crossterm::terminal::enable_raw_mode().expect("Failed to enable raw mode");
+    let mut stdout = std::io::stdout();
+    crossterm::execute!(stdout, crossterm::terminal::EnterAlternateScreen)
+        .expect("Failed to enter alternate screen");
+    let backend = ratatui::backend::CrosstermBackend::new(stdout);
+    let mut terminal = ratatui::Terminal::new(backend).expect("Failed to create terminal");
+
+    let mut app = App::new(handle);
+    let tick_rate = std::time::Duration::from_millis(500);
+
+    while !app.should_quit {
+        terminal
+            .draw(|frame| tui::ui::render(frame, &app))
+            .expect("Failed to draw");
+
+        if let Some(event) = tui::event::poll(tick_rate) {
+            match event {
+                tui::event::AppEvent::Quit => app.quit(),
+                tui::event::AppEvent::Tick => {}
+            }
+        }
+    }
+
+    // Restore terminal
+    crossterm::terminal::disable_raw_mode().expect("Failed to disable raw mode");
+    crossterm::execute!(
+        terminal.backend_mut(),
+        crossterm::terminal::LeaveAlternateScreen
+    )
+    .expect("Failed to leave alternate screen");
+
+    if let Err(e) = monitor.shutdown().await {
+        eprintln!("Warning: Shutdown error: {e}");
+    }
+}
+
+async fn run_headless(config: EmtConfig, args: &Args) {
+    let measurement_units = config.measurement_units.clone();
+    let root_pids = args.pid.map(|p| vec![p]);
+    let mut monitor = Monitor::new(config, root_pids);
+
+    let handle = match monitor.commence().await {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("Failed to start monitoring: {e}");
+            std::process::exit(1);
+        }
+    };
+
     tokio::time::sleep(tokio::time::Duration::from_secs(args.duration)).await;
 
-    // Shutdown monitor
     if let Err(e) = monitor.shutdown().await {
         eprintln!("Warning: Shutdown error: {e}");
     }
 
-    // Capture final snapshot after shutdown drains collector buffers.
     let snapshot = handle.snapshot();
     let duration = args.duration as f64;
 
-    // Build output
-    let output = build_cli_output(&args, duration, &snapshot, &measurement_units);
+    let output = build_cli_output(args, duration, &snapshot, &measurement_units);
     let json_output = serde_json::to_string_pretty(&output).expect("Failed to serialize output");
 
-    // Write to file if requested
     if let Some(output_path) = &args.output {
         let mut file = File::create(output_path).expect("Failed to create output file");
         file.write_all(json_output.as_bytes())
@@ -279,7 +356,6 @@ async fn main() {
         }
     }
 
-    // Print output
     if args.quiet {
         println!("{json_output}");
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@ use serde::Serialize;
 use std::fs::File;
 use std::io::Write;
 
+const DEFAULT_BATCH_DURATION_SECS: u64 = 10;
+
 #[derive(Parser, Debug)]
 #[command(name = "emt")]
 #[command(about = "Monitor energy consumption of processes")]
@@ -14,29 +16,58 @@ struct Args {
     #[arg(short, long)]
     pid: Option<u32>,
 
-    /// Duration to monitor in seconds (headless mode only)
-    #[arg(short, long, default_value = "10")]
-    duration: u64,
+    /// Duration to monitor in seconds (JSON output mode only)
+    #[arg(short, long)]
+    duration: Option<u64>,
 
     /// Collection rate in Hz (overrides config file)
     #[arg(short, long)]
     rate: Option<f64>,
 
-    /// Output file for JSON results (optional, implies headless)
-    #[arg(short, long)]
-    output: Option<String>,
-
-    /// Quiet mode - only output JSON result (implies headless)
-    #[arg(short, long)]
-    quiet: bool,
-
-    /// Launch interactive TUI (default when no --output or --quiet)
-    #[arg(long)]
+    /// Launch interactive TUI (default mode)
+    #[arg(long, conflicts_with_all = ["headless", "json_out"])]
     tui: bool,
 
-    /// Run in headless mode (print results after duration)
-    #[arg(long)]
+    /// Reserved for future daemon export modes
+    #[arg(long, conflicts_with_all = ["tui", "json_out"])]
     headless: bool,
+
+    /// Run once and write JSON results to PATH
+    #[arg(long = "json-out", value_name = "PATH", conflicts_with_all = ["tui", "headless"])]
+    json_out: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Mode {
+    Tui,
+    Headless,
+    JsonOut,
+}
+
+fn selected_mode(args: &Args) -> Mode {
+    if args.json_out.is_some() {
+        Mode::JsonOut
+    } else if args.headless {
+        Mode::Headless
+    } else {
+        Mode::Tui
+    }
+}
+
+fn validate_args(args: &Args) -> Result<(), &'static str> {
+    if args.duration.is_some() && selected_mode(args) != Mode::JsonOut {
+        return Err("--duration can only be used with --json-out");
+    }
+    if selected_mode(args) == Mode::Headless {
+        return Err(
+            "--headless is reserved for future daemon export modes; use --json-out <PATH> --duration <SECONDS> for finite JSON output",
+        );
+    }
+    Ok(())
+}
+
+fn batch_duration_seconds(args: &Args) -> u64 {
+    args.duration.unwrap_or(DEFAULT_BATCH_DURATION_SECS)
 }
 
 #[cfg(test)]
@@ -48,12 +79,11 @@ mod tests {
     fn cli_output_uses_configured_units_and_unit_neutral_fields() {
         let args = Args {
             pid: Some(123),
-            duration: 10,
+            duration: Some(10),
             rate: None,
-            output: None,
-            quiet: true,
             tui: false,
             headless: false,
+            json_out: Some("results.json".to_string()),
         };
         let units = MeasurementUnitsConfig {
             energy: "kWh".to_string(),
@@ -97,12 +127,11 @@ mod tests {
     fn cli_rate_override_wins_over_loaded_config() {
         let args = Args {
             pid: None,
-            duration: 1,
+            duration: None,
             rate: Some(5.0),
-            output: None,
-            quiet: true,
             tui: false,
             headless: false,
+            json_out: None,
         };
         let mut config = EmtConfig::default();
         config.collection.rate_hz = 0.0;
@@ -111,6 +140,50 @@ mod tests {
 
         assert_eq!(config.collection.rate_hz, 5.0);
         config.validate().unwrap();
+    }
+
+    #[test]
+    fn cli_defaults_to_tui_mode() {
+        let args = Args::parse_from(["emt"]);
+
+        assert_eq!(selected_mode(&args), Mode::Tui);
+    }
+
+    #[test]
+    fn cli_accepts_explicit_tui_mode() {
+        let args = Args::parse_from(["emt", "--tui"]);
+
+        assert_eq!(selected_mode(&args), Mode::Tui);
+    }
+
+    #[test]
+    fn cli_reserves_headless_mode_for_future_exports() {
+        let args = Args::parse_from(["emt", "--headless"]);
+
+        assert_eq!(selected_mode(&args), Mode::Headless);
+        assert!(validate_args(&args).is_err());
+    }
+
+    #[test]
+    fn cli_accepts_json_out_mode_with_duration() {
+        let args = Args::parse_from(["emt", "--json-out", "results.json", "--duration", "30"]);
+
+        assert_eq!(selected_mode(&args), Mode::JsonOut);
+        assert_eq!(batch_duration_seconds(&args), 30);
+    }
+
+    #[test]
+    fn cli_rejects_multiple_modes() {
+        let result = Args::try_parse_from(["emt", "--tui", "--json-out", "results.json"]);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn cli_rejects_duration_outside_json_out_mode() {
+        let args = Args::parse_from(["emt", "--headless", "--duration", "30"]);
+
+        assert!(validate_args(&args).is_err());
     }
 }
 
@@ -199,55 +272,15 @@ fn apply_cli_overrides(config: &mut EmtConfig, args: &Args) {
     }
 }
 
-fn print_human_readable(output: &CliOutput) {
-    println!("\n=== Energy Consumption Results ===");
-    println!(
-        "PID: {}",
-        output
-            .pid
-            .map(|p| p.to_string())
-            .unwrap_or_else(|| "all".to_string())
-    );
-    println!("Duration: {:.2} s", output.duration_seconds);
-    println!(
-        "Total Energy: {:.4} {}",
-        output.total_energy, output.energy_unit
-    );
-    println!("Average Power: {:.2} {}", output.power, output.power_unit);
-    println!("Device breakdown:");
-    println!("  CPU: {:.4} {}", output.devices.cpu, output.energy_unit);
-    println!("  DRAM: {:.4} {}", output.devices.dram, output.energy_unit);
-    println!("  GPU: {:.4} {}", output.devices.gpu, output.energy_unit);
-
-    if !output.workloads.is_empty() {
-        println!("Workloads:");
-        for wl in &output.workloads {
-            println!(
-                "  PID {} ({}, {}): {:.4} {}, {:.2} {}",
-                wl.root_pid,
-                wl.name,
-                wl.user,
-                wl.energy,
-                output.energy_unit,
-                wl.power,
-                output.power_unit
-            );
-        }
-    }
-}
-
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
-
-    // Determine mode: TUI vs headless
-    let use_tui = args.tui || (!args.headless && !args.quiet && args.output.is_none());
-
-    if !args.quiet && !use_tui {
-        emt::utils::logger::setup_logger();
+    if let Err(message) = validate_args(&args) {
+        eprintln!("{message}");
+        std::process::exit(2);
     }
+    let mode = selected_mode(&args);
 
-    // Load config and apply CLI rate override
     let mut config = EmtConfig::load();
     apply_cli_overrides(&mut config, &args);
     if let Err(e) = config.validate() {
@@ -255,10 +288,17 @@ async fn main() {
         std::process::exit(2);
     }
 
-    if use_tui {
-        run_tui(config, args.pid).await;
-    } else {
-        run_headless(config, &args).await;
+    match mode {
+        Mode::Tui => run_tui(config, args.pid).await,
+        Mode::Headless => unreachable!("headless mode is rejected by validate_args"),
+        Mode::JsonOut => {
+            let duration = batch_duration_seconds(&args);
+            let path = args
+                .json_out
+                .as_deref()
+                .expect("json_out is present in JsonOut mode");
+            run_json_out(config, &args, duration, path.to_string()).await;
+        }
     }
 }
 
@@ -278,10 +318,7 @@ async fn run_tui(config: EmtConfig, pid: Option<u32>) {
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         let _ = crossterm::terminal::disable_raw_mode();
-        let _ = crossterm::execute!(
-            std::io::stdout(),
-            crossterm::terminal::LeaveAlternateScreen
-        );
+        let _ = crossterm::execute!(std::io::stdout(), crossterm::terminal::LeaveAlternateScreen);
         original_hook(info);
     }));
 
@@ -322,7 +359,7 @@ async fn run_tui(config: EmtConfig, pid: Option<u32>) {
     }
 }
 
-async fn run_headless(config: EmtConfig, args: &Args) {
+async fn run_json_out(config: EmtConfig, args: &Args, duration_secs: u64, output_path: String) {
     let measurement_units = config.measurement_units.clone();
     let root_pids = args.pid.map(|p| vec![p]);
     let mut monitor = Monitor::new(config, root_pids);
@@ -335,30 +372,20 @@ async fn run_headless(config: EmtConfig, args: &Args) {
         }
     };
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(args.duration)).await;
+    tokio::time::sleep(tokio::time::Duration::from_secs(duration_secs)).await;
 
     if let Err(e) = monitor.shutdown().await {
         eprintln!("Warning: Shutdown error: {e}");
     }
 
     let snapshot = handle.snapshot();
-    let duration = args.duration as f64;
+    let duration = duration_secs as f64;
+    let cli_output = build_cli_output(args, duration, &snapshot, &measurement_units);
 
-    let output = build_cli_output(args, duration, &snapshot, &measurement_units);
-    let json_output = serde_json::to_string_pretty(&output).expect("Failed to serialize output");
-
-    if let Some(output_path) = &args.output {
-        let mut file = File::create(output_path).expect("Failed to create output file");
-        file.write_all(json_output.as_bytes())
-            .expect("Failed to write output");
-        if !args.quiet {
-            eprintln!("Results written to: {output_path}");
-        }
-    }
-
-    if args.quiet {
-        println!("{json_output}");
-    } else {
-        print_human_readable(&output);
-    }
+    let json_output =
+        serde_json::to_string_pretty(&cli_output).expect("Failed to serialize output");
+    let mut file = File::create(&output_path).expect("Failed to create JSON output file");
+    file.write_all(json_output.as_bytes())
+        .expect("Failed to write JSON output");
+    eprintln!("JSON results written to: {output_path}");
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,0 +1,30 @@
+use crate::monitor::{MetricsSnapshot, MonitorHandle};
+use std::time::Instant;
+
+pub struct App {
+    handle: MonitorHandle,
+    start_time: Instant,
+    pub should_quit: bool,
+}
+
+impl App {
+    pub fn new(handle: MonitorHandle) -> Self {
+        Self {
+            handle,
+            start_time: Instant::now(),
+            should_quit: false,
+        }
+    }
+
+    pub fn snapshot(&self) -> MetricsSnapshot {
+        self.handle.snapshot()
+    }
+
+    pub fn uptime_secs(&self) -> f64 {
+        self.start_time.elapsed().as_secs_f64()
+    }
+
+    pub fn quit(&mut self) {
+        self.should_quit = true;
+    }
+}

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -1,0 +1,24 @@
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+use std::time::Duration;
+
+pub enum AppEvent {
+    Tick,
+    Quit,
+}
+
+pub fn poll(timeout: Duration) -> Option<AppEvent> {
+    if event::poll(timeout).ok()? {
+        if let Ok(Event::Key(key)) = event::read() {
+            return Some(handle_key(key));
+        }
+    }
+    Some(AppEvent::Tick)
+}
+
+fn handle_key(key: KeyEvent) -> AppEvent {
+    match key.code {
+        KeyCode::Char('q') => AppEvent::Quit,
+        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => AppEvent::Quit,
+        _ => AppEvent::Tick,
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,0 +1,5 @@
+pub mod app;
+pub mod event;
+pub mod ui;
+
+pub use app::App;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,0 +1,132 @@
+use crate::monitor::MetricsSnapshot;
+use crate::tui::App;
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Row, Table};
+
+pub fn render(frame: &mut Frame, app: &App) {
+    let snapshot = app.snapshot();
+    let uptime = app.uptime_secs();
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(5),
+            Constraint::Min(3),
+            Constraint::Length(1),
+        ])
+        .split(frame.area());
+
+    render_header(frame, chunks[0], &snapshot, uptime);
+    render_body(frame, chunks[1], &snapshot);
+    render_footer(frame, chunks[2]);
+}
+
+fn render_header(
+    frame: &mut Frame,
+    area: ratatui::layout::Rect,
+    snapshot: &MetricsSnapshot,
+    uptime: f64,
+) {
+    let total_energy = snapshot.system_total.total();
+    let power = if uptime > 0.0 {
+        total_energy / uptime
+    } else {
+        0.0
+    };
+
+    let mins = (uptime as u64) / 60;
+    let secs = (uptime as u64) % 60;
+
+    let lines = vec![
+        Line::from(vec![
+            Span::styled("  Power: ", Style::default().fg(Color::Cyan)),
+            Span::raw(format!("{power:.2} W")),
+            Span::raw("    "),
+            Span::styled("Energy: ", Style::default().fg(Color::Cyan)),
+            Span::raw(format!("{total_energy:.4} J")),
+        ]),
+        Line::from(vec![
+            Span::styled("    CPU: ", Style::default().fg(Color::Yellow)),
+            Span::raw(format!("{:.4} J", snapshot.system_total.cpu_joules)),
+            Span::raw("    "),
+            Span::styled("DRAM: ", Style::default().fg(Color::Yellow)),
+            Span::raw(format!("{:.4} J", snapshot.system_total.dram_joules)),
+            Span::raw("    "),
+            Span::styled("GPU: ", Style::default().fg(Color::Yellow)),
+            Span::raw(format!("{:.4} J", snapshot.system_total.gpu_joules)),
+        ]),
+        Line::from(vec![
+            Span::styled("Uptime: ", Style::default().fg(Color::Green)),
+            Span::raw(format!("{mins:02}:{secs:02}")),
+            Span::raw(format!(
+                "    Tracked PIDs: {}",
+                snapshot.tracked_pids.len()
+            )),
+        ]),
+    ];
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" EMT - Energy Monitoring Tool ");
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+fn render_body(frame: &mut Frame, area: ratatui::layout::Rect, snapshot: &MetricsSnapshot) {
+    if snapshot.workloads.is_empty() {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(" Workloads ");
+        let paragraph =
+            Paragraph::new("  No process data yet...").block(block);
+        frame.render_widget(paragraph, area);
+        return;
+    }
+
+    let header = Row::new(vec!["PID", "Name", "User", "Energy (J)", "Power (W)"])
+        .style(Style::default().add_modifier(Modifier::BOLD));
+
+    let rows: Vec<Row> = snapshot
+        .workloads
+        .iter()
+        .map(|wl| {
+            Row::new(vec![
+                wl.root_pid.to_string(),
+                wl.name.clone(),
+                wl.user.clone(),
+                format!("{:.4}", wl.energy.total()),
+                format!("{:.2}", wl.power_watts),
+            ])
+        })
+        .collect();
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(8),
+            Constraint::Min(20),
+            Constraint::Length(12),
+            Constraint::Length(12),
+            Constraint::Length(10),
+        ],
+    )
+    .header(header)
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(" Workloads "),
+    );
+
+    frame.render_widget(table, area);
+}
+
+fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect) {
+    let footer = Paragraph::new(Line::from(vec![
+        Span::styled(" q", Style::default().fg(Color::Red)),
+        Span::raw(" quit"),
+    ]));
+    frame.render_widget(footer, area);
+}

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -42,7 +42,7 @@ fn render_header(
 
     let lines = vec![
         Line::from(vec![
-            Span::styled("  Power: ", Style::default().fg(Color::Cyan)),
+            Span::styled("  Avg Power: ", Style::default().fg(Color::Cyan)),
             Span::raw(format!("{power:.2} W")),
             Span::raw("    "),
             Span::styled("Energy: ", Style::default().fg(Color::Cyan)),
@@ -80,7 +80,7 @@ fn render_body(frame: &mut Frame, area: ratatui::layout::Rect, snapshot: &Metric
         return;
     }
 
-    let header = Row::new(vec!["PID", "Name", "User", "Energy (J)", "Power (W)"])
+    let header = Row::new(vec!["PID", "Name", "User", "Energy (J)", "Avg Power (W)"])
         .style(Style::default().add_modifier(Modifier::BOLD));
 
     let rows: Vec<Row> = snapshot

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -61,10 +61,7 @@ fn render_header(
         Line::from(vec![
             Span::styled("Uptime: ", Style::default().fg(Color::Green)),
             Span::raw(format!("{mins:02}:{secs:02}")),
-            Span::raw(format!(
-                "    Tracked PIDs: {}",
-                snapshot.tracked_pids.len()
-            )),
+            Span::raw(format!("    Tracked PIDs: {}", snapshot.tracked_pids.len())),
         ]),
     ];
 
@@ -77,11 +74,8 @@ fn render_header(
 
 fn render_body(frame: &mut Frame, area: ratatui::layout::Rect, snapshot: &MetricsSnapshot) {
     if snapshot.workloads.is_empty() {
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .title(" Workloads ");
-        let paragraph =
-            Paragraph::new("  No process data yet...").block(block);
+        let block = Block::default().borders(Borders::ALL).title(" Workloads ");
+        let paragraph = Paragraph::new("  No process data yet...").block(block);
         frame.render_widget(paragraph, area);
         return;
     }
@@ -114,11 +108,7 @@ fn render_body(frame: &mut Frame, area: ratatui::layout::Rect, snapshot: &Metric
         ],
     )
     .header(header)
-    .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .title(" Workloads "),
-    );
+    .block(Block::default().borders(Borders::ALL).title(" Workloads "));
 
     frame.render_widget(table, area);
 }

--- a/tests/test_verification_scripts.py
+++ b/tests/test_verification_scripts.py
@@ -88,7 +88,7 @@ def test_measure_rust_cli_writes_output_under_artifacts_tmp(tmp_path, monkeypatc
             popen_calls.append((cmd, kwargs))
 
             if str(rust_binary) in cmd:
-                output_file = Path(cmd[cmd.index("--output") + 1])
+                output_file = Path(cmd[cmd.index("--json-out") + 1])
                 output_file.write_text(
                     json.dumps(
                         {
@@ -119,7 +119,7 @@ def test_measure_rust_cli_writes_output_under_artifacts_tmp(tmp_path, monkeypatc
     assert output_dir.is_dir()
     assert list(output_dir.iterdir()) == []
     rust_cmd, rust_kwargs = popen_calls[1]
-    assert rust_cmd[rust_cmd.index("--output") + 1].startswith(str(output_dir))
+    assert rust_cmd[rust_cmd.index("--json-out") + 1].startswith(str(output_dir))
     assert rust_kwargs["env"]["EMT_DISABLE_GPU"] == "1"
 
 


### PR DESCRIPTION
## Summary

- Add `src/tui/` module with `App` state, crossterm event handling, and ratatui renderer
- TUI is the default mode; `--tui` is explicit/default-equivalent
- Reserve `--headless` for future daemon/export mode and use finite JSON output through `--json-out <PATH> [--duration N]`
- Update verification scripts and docs from `--output`/`--quiet` to `--json-out`
- Displays average power, cumulative energy, CPU/DRAM/GPU breakdown, uptime, tracked PIDs, and per-workload table
- Panic hook restores terminal state; `q`/`Ctrl+C` for clean exit

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo test`
- [x] `.venv/bin/python -m pytest`
- [x] `git diff --check`
- [x] `cargo run -- --help`
- [x] `cargo run -- --headless` exits with reserved-mode message
- [x] `cargo run -- --json-out .artifacts/cli-smoke.json --duration 2` writes valid JSON
- [x] `cargo run -- --tui` launches TUI and exits cleanly with `q`
- [ ] Manual: verify terminal is restored after forced panic in debug build

## Follow-up

Refs ENE-23. Product acceptance is still pending for the live power semantics: implementation currently shows average power derived from cumulative energy, unless we decide to change it to true interval power.