### PR TITLE
feat: add TUI header power sparklines

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,9 +1,15 @@
-use crate::monitor::{MetricsSnapshot, MonitorHandle};
+use crate::monitor::{DeviceEnergy, MetricsSnapshot, MonitorHandle};
+use std::cell::RefCell;
+use std::collections::VecDeque;
 use std::time::Instant;
+
+const POWER_HISTORY_WINDOW_SECS: f64 = 60.0;
+const POWER_HISTORY_MAX_SAMPLES: usize = 120;
 
 pub struct App {
     handle: MonitorHandle,
     start_time: Instant,
+    power_history: RefCell<RollingPowerHistory>,
     pub should_quit: bool,
 }
 
@@ -12,19 +18,284 @@ impl App {
         Self {
             handle,
             start_time: Instant::now(),
+            power_history: RefCell::new(RollingPowerHistory::default()),
             should_quit: false,
         }
     }
 
     pub fn snapshot(&self) -> MetricsSnapshot {
-        self.handle.snapshot()
+        let snapshot = self.handle.snapshot();
+        if snapshot.timestamp > 0 {
+            self.power_history
+                .borrow_mut()
+                .record(snapshot.timestamp as f64 / 1_000.0, &snapshot.system_total);
+        }
+        snapshot
     }
 
     pub fn uptime_secs(&self) -> f64 {
         self.start_time.elapsed().as_secs_f64()
     }
 
+    pub fn power_history(&self) -> PowerHistorySnapshot {
+        self.power_history.borrow().snapshot()
+    }
+
     pub fn quit(&mut self) {
         self.should_quit = true;
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct PowerHistorySnapshot {
+    pub cpu: Vec<f64>,
+    pub dram: Vec<f64>,
+    pub gpu: Vec<f64>,
+}
+
+impl PowerHistorySnapshot {
+    pub fn has_samples(&self) -> bool {
+        !self.cpu.is_empty() || !self.dram.is_empty() || !self.gpu.is_empty()
+    }
+
+    pub fn latest_cpu(&self) -> Option<f64> {
+        self.cpu.last().copied()
+    }
+
+    pub fn latest_dram(&self) -> Option<f64> {
+        self.dram.last().copied()
+    }
+
+    pub fn latest_gpu(&self) -> Option<f64> {
+        self.gpu.last().copied()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RollingPowerHistory {
+    window_secs: f64,
+    max_samples: usize,
+    previous: Option<EnergySample>,
+    cpu: VecDeque<PowerSample>,
+    dram: VecDeque<PowerSample>,
+    gpu: VecDeque<PowerSample>,
+}
+
+impl Default for RollingPowerHistory {
+    fn default() -> Self {
+        Self::new(POWER_HISTORY_WINDOW_SECS, POWER_HISTORY_MAX_SAMPLES)
+    }
+}
+
+impl RollingPowerHistory {
+    fn new(window_secs: f64, max_samples: usize) -> Self {
+        Self {
+            window_secs,
+            max_samples,
+            previous: None,
+            cpu: VecDeque::new(),
+            dram: VecDeque::new(),
+            gpu: VecDeque::new(),
+        }
+    }
+
+    fn record(&mut self, at_secs: f64, energy: &DeviceEnergy) {
+        if !at_secs.is_finite() || at_secs < 0.0 {
+            return;
+        }
+
+        let current = EnergySample {
+            at_secs,
+            energy: energy.clone(),
+        };
+
+        let Some(previous) = &self.previous else {
+            self.previous = Some(current);
+            return;
+        };
+
+        let elapsed_secs = at_secs - previous.at_secs;
+        if elapsed_secs <= f64::EPSILON {
+            return;
+        }
+
+        let delta = energy.saturating_sub(&previous.energy);
+        Self::record_component(
+            &mut self.cpu,
+            at_secs,
+            delta.cpu_joules,
+            energy.cpu_joules,
+            elapsed_secs,
+        );
+        Self::record_component(
+            &mut self.dram,
+            at_secs,
+            delta.dram_joules,
+            energy.dram_joules,
+            elapsed_secs,
+        );
+        Self::record_component(
+            &mut self.gpu,
+            at_secs,
+            delta.gpu_joules,
+            energy.gpu_joules,
+            elapsed_secs,
+        );
+
+        self.previous = Some(current);
+        self.prune(at_secs);
+    }
+
+    fn snapshot(&self) -> PowerHistorySnapshot {
+        PowerHistorySnapshot {
+            cpu: Self::values(&self.cpu),
+            dram: Self::values(&self.dram),
+            gpu: Self::values(&self.gpu),
+        }
+    }
+
+    fn record_component(
+        samples: &mut VecDeque<PowerSample>,
+        at_secs: f64,
+        delta_joules: f64,
+        cumulative_joules: f64,
+        elapsed_secs: f64,
+    ) {
+        if cumulative_joules <= 0.0 && samples.is_empty() {
+            return;
+        }
+
+        samples.push_back(PowerSample {
+            at_secs,
+            watts: (delta_joules / elapsed_secs).max(0.0),
+        });
+    }
+
+    fn prune(&mut self, current_secs: f64) {
+        Self::prune_component(
+            &mut self.cpu,
+            current_secs,
+            self.window_secs,
+            self.max_samples,
+        );
+        Self::prune_component(
+            &mut self.dram,
+            current_secs,
+            self.window_secs,
+            self.max_samples,
+        );
+        Self::prune_component(
+            &mut self.gpu,
+            current_secs,
+            self.window_secs,
+            self.max_samples,
+        );
+    }
+
+    fn prune_component(
+        samples: &mut VecDeque<PowerSample>,
+        current_secs: f64,
+        window_secs: f64,
+        max_samples: usize,
+    ) {
+        while samples
+            .front()
+            .is_some_and(|sample| current_secs - sample.at_secs > window_secs)
+        {
+            samples.pop_front();
+        }
+
+        while samples.len() > max_samples {
+            samples.pop_front();
+        }
+    }
+
+    fn values(samples: &VecDeque<PowerSample>) -> Vec<f64> {
+        samples.iter().map(|sample| sample.watts).collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct EnergySample {
+    at_secs: f64,
+    energy: DeviceEnergy,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PowerSample {
+    at_secs: f64,
+    watts: f64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn energy(cpu: f64, dram: f64, gpu: f64) -> DeviceEnergy {
+        DeviceEnergy {
+            cpu_joules: cpu,
+            dram_joules: dram,
+            gpu_joules: gpu,
+        }
+    }
+
+    #[test]
+    fn records_power_from_cumulative_energy_deltas() {
+        let mut history = RollingPowerHistory::new(60.0, 120);
+
+        history.record(0.0, &energy(0.0, 0.0, 0.0));
+        history.record(2.0, &energy(10.0, 2.0, 0.0));
+
+        let snapshot = history.snapshot();
+        assert_eq!(snapshot.cpu, vec![5.0]);
+        assert_eq!(snapshot.dram, vec![1.0]);
+        assert!(snapshot.gpu.is_empty());
+    }
+
+    #[test]
+    fn records_zero_power_after_component_has_values() {
+        let mut history = RollingPowerHistory::new(60.0, 120);
+
+        history.record(0.0, &energy(0.0, 0.0, 0.0));
+        history.record(1.0, &energy(2.0, 0.0, 0.0));
+        history.record(2.0, &energy(2.0, 0.0, 0.0));
+
+        assert_eq!(history.snapshot().cpu, vec![2.0, 0.0]);
+    }
+
+    #[test]
+    fn keeps_component_history_bounded_by_sample_count() {
+        let mut history = RollingPowerHistory::new(60.0, 3);
+
+        history.record(0.0, &energy(0.0, 0.0, 0.0));
+        for sample in 1..=5 {
+            history.record(sample as f64, &energy(sample as f64, 0.0, 0.0));
+        }
+
+        assert_eq!(history.snapshot().cpu, vec![1.0, 1.0, 1.0]);
+    }
+
+    #[test]
+    fn prunes_component_history_outside_window() {
+        let mut history = RollingPowerHistory::new(2.0, 120);
+
+        history.record(0.0, &energy(0.0, 0.0, 0.0));
+        for sample in 1..=4 {
+            history.record(sample as f64, &energy(sample as f64, 0.0, 0.0));
+        }
+
+        assert_eq!(history.snapshot().cpu, vec![1.0, 1.0, 1.0]);
+        assert_eq!(history.cpu.front().map(|sample| sample.at_secs), Some(2.0));
+    }
+
+    #[test]
+    fn ignores_non_advancing_timestamps() {
+        let mut history = RollingPowerHistory::new(60.0, 120);
+
+        history.record(1.0, &energy(0.0, 0.0, 0.0));
+        history.record(1.0, &energy(5.0, 0.0, 0.0));
+        history.record(0.5, &energy(10.0, 0.0, 0.0));
+
+        assert!(history.snapshot().cpu.is_empty());
     }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,34 +1,37 @@
 use crate::monitor::MetricsSnapshot;
 use crate::tui::App;
+use crate::tui::app::PowerHistorySnapshot;
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Paragraph, Row, Table};
+use ratatui::widgets::{Block, Borders, Paragraph, Row, Sparkline, Table};
 
 pub fn render(frame: &mut Frame, app: &App) {
     let snapshot = app.snapshot();
     let uptime = app.uptime_secs();
+    let power_history = app.power_history();
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(5),
+            Constraint::Length(7),
             Constraint::Min(3),
             Constraint::Length(1),
         ])
         .split(frame.area());
 
-    render_header(frame, chunks[0], &snapshot, uptime);
+    render_header(frame, chunks[0], &snapshot, uptime, &power_history);
     render_body(frame, chunks[1], &snapshot);
     render_footer(frame, chunks[2]);
 }
 
 fn render_header(
     frame: &mut Frame,
-    area: ratatui::layout::Rect,
+    area: Rect,
     snapshot: &MetricsSnapshot,
     uptime: f64,
+    power_history: &PowerHistorySnapshot,
 ) {
     let total_energy = snapshot.system_total.total();
     let power = if uptime > 0.0 {
@@ -68,11 +71,133 @@ fn render_header(
     let block = Block::default()
         .borders(Borders::ALL)
         .title(" EMT - Energy Monitoring Tool ");
-    let paragraph = Paragraph::new(lines).block(block);
-    frame.render_widget(paragraph, area);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let header_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+
+    frame.render_widget(Paragraph::new(lines), header_chunks[0]);
+    if power_history.has_samples() {
+        render_power_history(frame, header_chunks[1], header_chunks[2], power_history);
+    }
 }
 
-fn render_body(frame: &mut Frame, area: ratatui::layout::Rect, snapshot: &MetricsSnapshot) {
+fn render_power_history(
+    frame: &mut Frame,
+    label_area: Rect,
+    sparkline_area: Rect,
+    power_history: &PowerHistorySnapshot,
+) {
+    let label_chunks = split_power_columns(label_area);
+    let sparkline_chunks = split_power_columns(sparkline_area);
+
+    render_power_label(
+        frame,
+        label_chunks[0],
+        "CPU",
+        power_history.latest_cpu(),
+        Color::Yellow,
+    );
+    render_power_label(
+        frame,
+        label_chunks[1],
+        "DRAM",
+        power_history.latest_dram(),
+        Color::Magenta,
+    );
+    render_power_label(
+        frame,
+        label_chunks[2],
+        "GPU",
+        power_history.latest_gpu(),
+        Color::Green,
+    );
+
+    render_component_sparkline(
+        frame,
+        sparkline_chunks[0],
+        &power_history.cpu,
+        Color::Yellow,
+    );
+    render_component_sparkline(
+        frame,
+        sparkline_chunks[1],
+        &power_history.dram,
+        Color::Magenta,
+    );
+    render_component_sparkline(frame, sparkline_chunks[2], &power_history.gpu, Color::Green);
+}
+
+fn split_power_columns(area: Rect) -> std::rc::Rc<[Rect]> {
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(34),
+            Constraint::Percentage(33),
+            Constraint::Percentage(33),
+        ])
+        .split(area)
+}
+
+fn render_power_label(
+    frame: &mut Frame,
+    area: Rect,
+    label: &str,
+    latest_watts: Option<f64>,
+    color: Color,
+) {
+    let value = latest_watts
+        .map(|watts| format!("{watts:.2} W"))
+        .unwrap_or_else(|| "--".to_string());
+    let label = Paragraph::new(Line::from(vec![Span::styled(
+        format!("{label}: {value}"),
+        Style::default().fg(color),
+    )]));
+    frame.render_widget(label, area);
+}
+
+fn render_component_sparkline(frame: &mut Frame, area: Rect, samples: &[f64], color: Color) {
+    if samples.is_empty() {
+        return;
+    }
+
+    let data = sparkline_data(samples);
+    let max = data.iter().copied().max().unwrap_or(1).max(1);
+    let sparkline = Sparkline::default()
+        .data(data)
+        .max(max)
+        .style(Style::default().fg(color));
+    frame.render_widget(sparkline, area);
+}
+
+fn sparkline_data(samples: &[f64]) -> Vec<u64> {
+    samples
+        .iter()
+        .map(|watts| power_to_sparkline_value(*watts))
+        .collect()
+}
+
+fn power_to_sparkline_value(watts: f64) -> u64 {
+    if !watts.is_finite() || watts <= 0.0 {
+        return 0;
+    }
+
+    let milliwatts = (watts * 1_000.0).round().max(1.0);
+    if milliwatts >= u64::MAX as f64 {
+        u64::MAX
+    } else {
+        milliwatts as u64
+    }
+}
+
+fn render_body(frame: &mut Frame, area: Rect, snapshot: &MetricsSnapshot) {
     if snapshot.workloads.is_empty() {
         let block = Block::default().borders(Borders::ALL).title(" Workloads ");
         let paragraph = Paragraph::new("  No process data yet...").block(block);
@@ -113,10 +238,28 @@ fn render_body(frame: &mut Frame, area: ratatui::layout::Rect, snapshot: &Metric
     frame.render_widget(table, area);
 }
 
-fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect) {
+fn render_footer(frame: &mut Frame, area: Rect) {
     let footer = Paragraph::new(Line::from(vec![
         Span::styled(" q", Style::default().fg(Color::Red)),
         Span::raw(" quit"),
     ]));
     frame.render_widget(footer, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sparkline_data_uses_milliwatts_to_keep_sub_watt_values_visible() {
+        assert_eq!(sparkline_data(&[0.0, 0.001, 1.25]), vec![0, 1, 1_250]);
+    }
+
+    #[test]
+    fn sparkline_data_drops_invalid_or_negative_values_to_zero() {
+        assert_eq!(
+            sparkline_data(&[f64::NAN, f64::INFINITY, -1.0]),
+            vec![0, 0, 0]
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Adds bounded rolling CPU/DRAM/GPU power history to the TUI header and renders Ratatui sparklines for the current system-wide buckets.

The change preserves the existing `Avg Power` semantics while adding short-term visual history derived from `MetricsSnapshot.system_total`.

## Validation

- `cargo test tui`
- `cargo test`
- `cargo fmt --check`
- `git diff --check`

## Notes

A distinct RAPL uncore/iGPU sparkline still needs upstream snapshot support; this slice only uses the CPU/DRAM/GPU buckets already exposed by the monitor snapshot.