### PR TITLE
docs: clarify parity backend selection

### DIFF
--- a/verification/summary.md
+++ b/verification/summary.md
@@ -28,6 +28,12 @@ both methods run in isolated phases with settling time between phases. Each
 method monitors the `scripts/verification_workload.py` subprocess PID directly
 so verifier-process overhead is not charged to only one side of the comparison.
 
+After the PyO3 backend swap, the `python emt` method means the public
+`EnergyMonitor` API. If `emt._rust.RustMonitor` is importable and no
+Python-only feature is requested, that API may delegate to the Rust backend.
+Future parity work should add explicit backend selection before treating this
+method as a pure-Python reference.
+
 ## output
 
 `scripts/verify.py` writes results to


### PR DESCRIPTION
## Summary

Clarifies the parity verification docs after ENE-38: the public Python `EnergyMonitor` path may now delegate to `emt._rust.RustMonitor` when the extension is importable.

This makes ENE-41's future long-running parity work explicit about needing backend selection before treating the Python API path as the pure-Python reference.

## Validation

- `.venv/bin/python -m pytest tests/test_verification_scripts.py`
- `.venv/bin/python -m pytest -q`
- `git diff --check`