### PR TITLE
ENE-25: Add grouped process energy table

### DIFF
--- a/src/energy_group.rs
+++ b/src/energy_group.rs
@@ -82,9 +82,14 @@ impl<T: EnergyCollector> EnergyGroup<T> {
         }
     }
 
-    /// Set the tracked PIDs by delegating to the collector
-    pub fn set_tracked_pids(&self, pids: Vec<u32>) {
+    /// Update the tracked PIDs by delegating to the collector.
+    pub fn update_tracked_pids(&self, pids: Vec<u32>) {
         self.energy_collector.set_tracked_pids(pids);
+    }
+
+    /// Set the tracked PIDs by delegating to the collector.
+    pub fn set_tracked_pids(&self, pids: Vec<u32>) {
+        self.update_tracked_pids(pids);
     }
 
     /// Register a trace recorder for persistent storage of energy data.
@@ -461,6 +466,17 @@ mod tests {
         fn is_available() -> bool {
             true
         }
+    }
+
+    #[test]
+    fn update_tracked_pids_delegates_to_collector() {
+        let group = EnergyGroup::new(TestCollector::new(123), 50.0, Some(1));
+
+        group.update_tracked_pids(vec![456, 789]);
+        assert_eq!(*group.energy_collector.pids.lock().unwrap(), vec![456, 789]);
+
+        group.set_tracked_pids(vec![321]);
+        assert_eq!(*group.energy_collector.pids.lock().unwrap(), vec![321]);
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@ pub mod collectors;
 pub mod config;
 pub mod energy_group;
 pub mod monitor;
+pub mod process;
+pub mod process_aggregation;
 pub mod trace_recorder;
 pub mod tui;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,6 +98,7 @@ mod tests {
             },
             workloads: vec![WorkloadSnapshot {
                 root_pid: 123,
+                group_id: "pid:123".to_string(),
                 name: "work".to_string(),
                 user: "user".to_string(),
                 energy: DeviceEnergy {
@@ -106,6 +107,7 @@ mod tests {
                     gpu_joules: 0.0,
                 },
                 power_watts: 360.0,
+                percentage_of_system: 100.0,
             }],
             unattributed: DeviceEnergy::default(),
             tracked_pids: vec![123],
@@ -119,8 +121,13 @@ mod tests {
         assert!((output.power - 360_000.0).abs() < 1e-9);
         assert!((output.devices.cpu - 0.00075).abs() < 1e-9);
         assert!((output.devices.dram - 0.00025).abs() < 1e-9);
+        assert_eq!(output.workloads[0].root_pid, 123);
+        assert_eq!(output.workloads[0].group_id, "pid:123");
+        assert_eq!(output.workloads[0].name, "work");
+        assert_eq!(output.workloads[0].user, "user");
         assert!((output.workloads[0].energy - 0.001).abs() < 1e-9);
         assert!((output.workloads[0].power - 360_000.0).abs() < 1e-9);
+        assert!((output.workloads[0].percentage_of_system - 100.0).abs() < 1e-9);
     }
 
     #[test]
@@ -209,10 +216,12 @@ struct DeviceBreakdown {
 #[derive(Serialize)]
 struct WorkloadOutput {
     root_pid: u32,
+    group_id: String,
     name: String,
     user: String,
     energy: f64,
     power: f64,
+    percentage_of_system: f64,
 }
 
 impl DeviceBreakdown {
@@ -243,6 +252,7 @@ fn build_cli_output(
         .iter()
         .map(|wl| WorkloadOutput {
             root_pid: wl.root_pid,
+            group_id: wl.group_id.clone(),
             name: wl.name.clone(),
             user: wl.user.clone(),
             energy: units.convert_energy_from_joules(wl.energy.total()),
@@ -251,6 +261,7 @@ fn build_cli_output(
             } else {
                 wl.power_watts
             }),
+            percentage_of_system: wl.percentage_of_system,
         })
         .collect();
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -184,6 +184,46 @@ fn explicit_pid_groups(root_pids: &[u32]) -> Vec<ProcessGroup> {
         .collect()
 }
 
+fn refresh_explicit_pid_groups(cached_groups: &[ProcessGroup]) -> Vec<ProcessGroup> {
+    cached_groups
+        .iter()
+        .filter_map(|group| {
+            let mut pids = walk_child_pids(&[group.representative_pid]);
+            if pids.is_empty() {
+                return None;
+            }
+            pids.sort_unstable();
+            pids.dedup();
+
+            let mut refreshed = group.clone();
+            refreshed.pids = pids;
+            Some(refreshed)
+        })
+        .collect()
+}
+
+fn cached_explicit_pid_groups(
+    root_pids: &[u32],
+    known_groups: &HashMap<String, ProcessGroup>,
+) -> Vec<ProcessGroup> {
+    root_pids
+        .iter()
+        .map(|pid| {
+            let id = format!("pid:{pid}");
+            known_groups
+                .get(&id)
+                .cloned()
+                .unwrap_or_else(|| ProcessGroup {
+                    id,
+                    name: format!("pid {pid}"),
+                    user: "unknown".to_string(),
+                    pids: vec![*pid],
+                    representative_pid: *pid,
+                })
+        })
+        .collect()
+}
+
 fn merge_pid_group_maps(
     current: &HashMap<u32, String>,
     previous: &HashMap<u32, String>,
@@ -517,8 +557,11 @@ impl Monitor {
 
             while is_running.load(Ordering::SeqCst) {
                 let groups = if let Some(ref pids) = root_pids {
-                    let pids = pids.clone();
-                    tokio::task::spawn_blocking(move || explicit_pid_groups(&pids))
+                    let cached_groups = {
+                        let known = known_groups.read().unwrap();
+                        cached_explicit_pid_groups(pids, &known)
+                    };
+                    tokio::task::spawn_blocking(move || refresh_explicit_pid_groups(&cached_groups))
                         .await
                         .unwrap_or_default()
                 } else {
@@ -681,6 +724,26 @@ mod tests {
         assert_eq!(result.cpu_joules, 0.0); // clamped
         assert!((result.dram_joules - 0.2).abs() < 1e-10);
         assert_eq!(result.gpu_joules, 0.0); // clamped
+    }
+
+    #[test]
+    fn refresh_explicit_pid_groups_keeps_cached_metadata() {
+        let pid = std::process::id();
+        let cached = vec![ProcessGroup {
+            id: format!("pid:{pid}"),
+            name: "cached-root".to_string(),
+            user: "cached-user".to_string(),
+            pids: Vec::new(),
+            representative_pid: pid,
+        }];
+
+        let refreshed = refresh_explicit_pid_groups(&cached);
+
+        assert_eq!(refreshed.len(), 1);
+        assert_eq!(refreshed[0].id, format!("pid:{pid}"));
+        assert_eq!(refreshed[0].name, "cached-root");
+        assert_eq!(refreshed[0].user, "cached-user");
+        assert!(refreshed[0].pids.contains(&pid));
     }
 
     #[test]

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,8 +1,12 @@
 use crate::collectors::{NvidiaGpu, Rapl};
 use crate::config::EmtConfig;
 use crate::energy_group::{EnergyCollector, EnergyGroup, EnergyRecord};
+use crate::process::{
+    ProcessGroup, group_processes, pid_to_group_map, scan_processes, tracked_pids,
+};
+use crate::process_aggregation::{aggregate_energy_records, percentage_of_system};
 use crate::utils::errors::MonitoringError;
-use crate::utils::psutils::{ProcessRoot, scan_roots, walk_child_pids};
+use crate::utils::psutils::{ProcessRoot, walk_child_pids};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
@@ -40,10 +44,12 @@ impl DeviceEnergy {
 #[derive(Debug, Clone)]
 pub struct WorkloadSnapshot {
     pub root_pid: u32,
+    pub group_id: String,
     pub name: String,
     pub user: String,
     pub energy: DeviceEnergy,
     pub power_watts: f64,
+    pub percentage_of_system: f64,
 }
 
 /// Full metrics snapshot shared via MonitorHandle.
@@ -56,35 +62,7 @@ pub struct MetricsSnapshot {
     pub tracked_pids: Vec<u32>,
 }
 
-// ─── Device classification ──────────────────────────────────────────────────
-
-/// Classify an EnergyRecord into a device category and return the energy value.
-fn classify_energy(record: &EnergyRecord) -> EnergyClass {
-    if record.device.starts_with("nvidia:") {
-        EnergyClass::Gpu
-    } else if record.device == "rapl:system:dram" {
-        EnergyClass::Dram
-    } else {
-        // rapl:socket:*:package, rapl:system:psys, or any other RAPL device
-        EnergyClass::Cpu
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum EnergyClass {
-    Cpu,
-    Dram,
-    Gpu,
-}
-
-/// Accumulate an energy record into a DeviceEnergy struct.
-fn accumulate_device_energy(device_energy: &mut DeviceEnergy, class: EnergyClass, joules: f64) {
-    match class {
-        EnergyClass::Cpu => device_energy.cpu_joules += joules,
-        EnergyClass::Dram => device_energy.dram_joules += joules,
-        EnergyClass::Gpu => device_energy.gpu_joules += joules,
-    }
-}
+// ─── Snapshot helpers ───────────────────────────────────────────────────────
 
 fn add_device_energy(total: &mut DeviceEnergy, delta: &DeviceEnergy) {
     total.cpu_joules += delta.cpu_joules;
@@ -92,38 +70,55 @@ fn add_device_energy(total: &mut DeviceEnergy, delta: &DeviceEnergy) {
     total.gpu_joules += delta.gpu_joules;
 }
 
-// ─── Child-to-root mapping ──────────────────────────────────────────────────
-
-/// Build a map from each child PID to its root PID.
-/// Each root is walked independently so that all descendants map back.
-fn build_child_to_root_map(roots: &[u32]) -> (HashMap<u32, u32>, Vec<u32>) {
-    let mut map: HashMap<u32, u32> = HashMap::new();
-    let mut all_pids: Vec<u32> = Vec::new();
-
-    for &root in roots {
-        let children = walk_child_pids(&[root]);
-        for &child in &children {
-            map.insert(child, root);
-        }
-        all_pids.extend(children);
+fn system_total_from_workloads(
+    workloads: &[WorkloadSnapshot],
+    unattributed: &DeviceEnergy,
+) -> DeviceEnergy {
+    DeviceEnergy {
+        cpu_joules: workloads
+            .iter()
+            .map(|workload| workload.energy.cpu_joules)
+            .sum::<f64>()
+            + unattributed.cpu_joules,
+        dram_joules: workloads
+            .iter()
+            .map(|workload| workload.energy.dram_joules)
+            .sum::<f64>()
+            + unattributed.dram_joules,
+        gpu_joules: workloads
+            .iter()
+            .map(|workload| workload.energy.gpu_joules)
+            .sum::<f64>()
+            + unattributed.gpu_joules,
     }
-
-    // Deduplicate all_pids while preserving order
-    let mut seen = std::collections::HashSet::new();
-    all_pids.retain(|pid| seen.insert(*pid));
-
-    (map, all_pids)
 }
 
-fn root_for_record(
-    pid: u32,
-    current_child_to_root: &HashMap<u32, u32>,
-    previous_child_to_root: &HashMap<u32, u32>,
-) -> Option<u32> {
-    current_child_to_root
-        .get(&pid)
-        .or_else(|| previous_child_to_root.get(&pid))
-        .copied()
+fn workload_snapshot(
+    group: &ProcessGroup,
+    energy: DeviceEnergy,
+    elapsed_s: f64,
+) -> WorkloadSnapshot {
+    let power_watts = if elapsed_s > 0.0 {
+        energy.total() / elapsed_s
+    } else {
+        0.0
+    };
+
+    WorkloadSnapshot {
+        root_pid: group.representative_pid,
+        group_id: group.id.clone(),
+        name: group.name.clone(),
+        user: group.user.clone(),
+        energy,
+        power_watts,
+        percentage_of_system: 0.0,
+    }
+}
+
+fn apply_workload_percentages(workloads: &mut [WorkloadSnapshot], system_total: &DeviceEnergy) {
+    for workload in workloads {
+        workload.percentage_of_system = percentage_of_system(&workload.energy, system_total);
+    }
 }
 
 fn resolve_process_roots(pids: &[u32]) -> Vec<ProcessRoot> {
@@ -155,6 +150,49 @@ fn resolve_process_roots(pids: &[u32]) -> Vec<ProcessRoot> {
             ProcessRoot { pid, user, name }
         })
         .collect()
+}
+
+fn explicit_pid_groups(root_pids: &[u32]) -> Vec<ProcessGroup> {
+    let roots = resolve_process_roots(root_pids);
+
+    roots
+        .into_iter()
+        .filter_map(|root| {
+            let mut pids = walk_child_pids(&[root.pid]);
+            if pids.is_empty() {
+                return None;
+            }
+            pids.sort_unstable();
+            pids.dedup();
+
+            Some(ProcessGroup {
+                id: format!("pid:{}", root.pid),
+                name: if root.name.is_empty() {
+                    format!("pid {}", root.pid)
+                } else {
+                    root.name
+                },
+                user: if root.user.is_empty() {
+                    "unknown".to_string()
+                } else {
+                    root.user
+                },
+                representative_pid: root.pid,
+                pids,
+            })
+        })
+        .collect()
+}
+
+fn merge_pid_group_maps(
+    current: &HashMap<u32, String>,
+    previous: &HashMap<u32, String>,
+) -> HashMap<u32, String> {
+    let mut merged = previous.clone();
+    for (pid, group_id) in current {
+        merged.insert(*pid, group_id.clone());
+    }
+    merged
 }
 
 // ─── MonitorHandle ──────────────────────────────────────────────────────────
@@ -195,7 +233,7 @@ impl MonitorHandle {
 #[derive(Debug, Clone)]
 struct TickState {
     start_timestamp: i64,
-    workload_energy: HashMap<u32, DeviceEnergy>,
+    workload_energy: HashMap<String, DeviceEnergy>,
 }
 
 impl Default for TickState {
@@ -215,12 +253,12 @@ pub struct Monitor {
     rapl_group: Arc<Mutex<EnergyGroup<Rapl>>>,
     gpu_group: Option<Arc<Mutex<EnergyGroup<NvidiaGpu>>>>,
     root_pids: Option<Vec<u32>>,
-    /// Shared state for scan task results
-    discovered_roots: Arc<RwLock<Vec<ProcessRoot>>>,
-    /// Root metadata retained after exit for cumulative reporting.
-    known_roots: Arc<RwLock<HashMap<u32, ProcessRoot>>>,
-    /// Last child PID to root PID map for final records from exited children.
-    last_child_to_root: Arc<RwLock<HashMap<u32, u32>>>,
+    /// Shared state for scan task results in monitor-all mode.
+    discovered_groups: Arc<RwLock<Vec<ProcessGroup>>>,
+    /// Group metadata retained for cumulative reporting.
+    known_groups: Arc<RwLock<HashMap<String, ProcessGroup>>>,
+    /// Last PID-to-group map for final records from exited children.
+    last_pid_to_group: Arc<RwLock<HashMap<u32, String>>>,
     /// First tick timestamp for average-power calculations.
     start_timestamp: Arc<RwLock<i64>>,
     /// Internal task handles
@@ -263,9 +301,9 @@ impl Monitor {
             rapl_group: Arc::new(Mutex::new(rapl_group)),
             gpu_group,
             root_pids,
-            discovered_roots: Arc::new(RwLock::new(Vec::new())),
-            known_roots: Arc::new(RwLock::new(HashMap::new())),
-            last_child_to_root: Arc::new(RwLock::new(HashMap::new())),
+            discovered_groups: Arc::new(RwLock::new(Vec::new())),
+            known_groups: Arc::new(RwLock::new(HashMap::new())),
+            last_pid_to_group: Arc::new(RwLock::new(HashMap::new())),
             start_timestamp: Arc::new(RwLock::new(0)),
             tick_handle: None,
             scan_handle: None,
@@ -284,33 +322,36 @@ impl Monitor {
             });
         }
 
-        *self.known_roots.write().unwrap() = HashMap::new();
-        *self.last_child_to_root.write().unwrap() = HashMap::new();
+        *self.known_groups.write().unwrap() = HashMap::new();
+        *self.last_pid_to_group.write().unwrap() = HashMap::new();
         *self.start_timestamp.write().unwrap() = 0;
         *self.snapshot.write().unwrap() = MetricsSnapshot::default();
 
-        if let Some(root_pids) = &self.root_pids {
+        let initial_groups = if let Some(root_pids) = &self.root_pids {
             let pids = root_pids.clone();
-            let roots = tokio::task::spawn_blocking(move || resolve_process_roots(&pids))
+            tokio::task::spawn_blocking(move || explicit_pid_groups(&pids))
                 .await
-                .unwrap_or_default();
-            let mut known = self.known_roots.write().unwrap();
-            for root in roots {
-                known.insert(root.pid, root);
+                .unwrap_or_default()
+        } else {
+            tokio::task::spawn_blocking(|| group_processes(&scan_processes()))
+                .await
+                .unwrap_or_default()
+        };
+
+        if self.root_pids.is_none() {
+            *self.discovered_groups.write().unwrap() = initial_groups.clone();
+        }
+
+        {
+            let mut known = self.known_groups.write().unwrap();
+            for group in &initial_groups {
+                known.insert(group.id.clone(), group.clone());
             }
         }
 
-        let initial_tracked_pids = if let Some(root_pids) = &self.root_pids {
-            let pids = root_pids.clone();
-            let (child_to_root, expanded_pids) =
-                tokio::task::spawn_blocking(move || build_child_to_root_map(&pids))
-                    .await
-                    .unwrap_or_default();
-            *self.last_child_to_root.write().unwrap() = child_to_root;
-            expanded_pids
-        } else {
-            Vec::new()
-        };
+        let initial_pid_to_group = pid_to_group_map(&initial_groups);
+        let initial_tracked_pids = tracked_pids(&initial_groups);
+        *self.last_pid_to_group.write().unwrap() = initial_pid_to_group;
 
         self.is_running.store(true, Ordering::SeqCst);
 
@@ -318,14 +359,14 @@ impl Monitor {
         {
             let mut rapl = self.rapl_group.lock().await;
             if !initial_tracked_pids.is_empty() {
-                rapl.set_tracked_pids(initial_tracked_pids.clone());
+                rapl.update_tracked_pids(initial_tracked_pids.clone());
             }
             rapl.commence().await?;
         }
         if let Some(gpu) = &self.gpu_group {
             let mut gpu_lock = gpu.lock().await;
             if !initial_tracked_pids.is_empty() {
-                gpu_lock.set_tracked_pids(initial_tracked_pids.clone());
+                gpu_lock.update_tracked_pids(initial_tracked_pids.clone());
             }
             gpu_lock.commence().await?;
         }
@@ -376,8 +417,12 @@ impl Monitor {
             return;
         }
 
-        let child_to_root = self.last_child_to_root.read().unwrap().clone();
-        let mut known_roots = self.known_roots.read().unwrap().clone();
+        let pid_to_group = self.last_pid_to_group.read().unwrap().clone();
+        let tick = aggregate_energy_records(final_records, &pid_to_group);
+        if tick.system_total.total() <= 0.0 && tick.group_energy.is_empty() {
+            return;
+        }
+
         let current_timestamp = chrono::Utc::now().timestamp_millis();
         let start_timestamp = *self.start_timestamp.read().unwrap();
         let elapsed_s = if start_timestamp > 0 {
@@ -386,99 +431,72 @@ impl Monitor {
             0.0
         };
 
-        let mut tick_system_total = DeviceEnergy::default();
-        let mut tick_workload_energy: HashMap<u32, DeviceEnergy> = HashMap::new();
+        let known_groups_snapshot = {
+            let mut known_groups = self.known_groups.write().unwrap();
+            for group_id in tick.group_energy.keys() {
+                if known_groups.contains_key(group_id) {
+                    continue;
+                }
 
-        for record in final_records {
-            let class = classify_energy(record);
-            accumulate_device_energy(&mut tick_system_total, class, record.energy);
+                let representative_pid = pid_to_group
+                    .iter()
+                    .find_map(|(pid, mapped_group)| (mapped_group == group_id).then_some(*pid))
+                    .unwrap_or_default();
+                let pids = if representative_pid == 0 {
+                    Vec::new()
+                } else {
+                    vec![representative_pid]
+                };
 
-            if let Some(root) = child_to_root.get(&record.pid).copied() {
-                let entry = tick_workload_energy.entry(root).or_default();
-                accumulate_device_energy(entry, class, record.energy);
+                known_groups.insert(
+                    group_id.clone(),
+                    ProcessGroup {
+                        id: group_id.clone(),
+                        name: group_id.clone(),
+                        user: "unknown".to_string(),
+                        pids,
+                        representative_pid,
+                    },
+                );
             }
-        }
+            known_groups.clone()
+        };
 
         let mut snap = self.snapshot.write().unwrap();
-        for workload in &snap.workloads {
-            known_roots.entry(workload.root_pid).or_insert(ProcessRoot {
-                pid: workload.root_pid,
-                user: workload.user.clone(),
-                name: workload.name.clone(),
-            });
-        }
-        for root_pid in tick_workload_energy.keys() {
-            known_roots.entry(*root_pid).or_insert(ProcessRoot {
-                pid: *root_pid,
-                user: "unknown".to_string(),
-                name: String::new(),
-            });
-        }
-
-        let mut cumulative_by_root: HashMap<u32, DeviceEnergy> = snap
+        let mut cumulative_by_group: HashMap<String, DeviceEnergy> = snap
             .workloads
             .iter()
-            .map(|workload| (workload.root_pid, workload.energy.clone()))
+            .map(|workload| (workload.group_id.clone(), workload.energy.clone()))
             .collect();
 
-        let mut workloads_sum = DeviceEnergy::default();
-        for (root_pid, tick_energy) in &tick_workload_energy {
-            add_device_energy(&mut workloads_sum, tick_energy);
-            let entry = cumulative_by_root.entry(*root_pid).or_default();
+        for (group_id, tick_energy) in &tick.group_energy {
+            let entry = cumulative_by_group.entry(group_id.clone()).or_default();
             add_device_energy(entry, tick_energy);
         }
+        add_device_energy(&mut snap.unattributed, &tick.unattributed);
 
-        let tick_unattributed = tick_system_total.saturating_sub(&workloads_sum);
-        add_device_energy(&mut snap.unattributed, &tick_unattributed);
-
-        let mut workloads: Vec<WorkloadSnapshot> = known_roots
+        let mut workloads: Vec<WorkloadSnapshot> = known_groups_snapshot
             .values()
-            .filter_map(|root| {
-                let energy = cumulative_by_root
-                    .get(&root.pid)
+            .filter_map(|group| {
+                let energy = cumulative_by_group
+                    .get(&group.id)
                     .cloned()
                     .unwrap_or_default();
                 if energy.total() <= 0.0 {
                     return None;
                 }
 
-                Some(WorkloadSnapshot {
-                    root_pid: root.pid,
-                    name: root.name.clone(),
-                    user: root.user.clone(),
-                    power_watts: if elapsed_s > 0.0 {
-                        energy.total() / elapsed_s
-                    } else {
-                        0.0
-                    },
-                    energy,
-                })
+                Some(workload_snapshot(group, energy, elapsed_s))
             })
             .collect();
-        workloads.sort_by_key(|workload| workload.root_pid);
+        workloads.sort_by(|left, right| left.group_id.cmp(&right.group_id));
+
+        let system_total = system_total_from_workloads(&workloads, &snap.unattributed);
+        apply_workload_percentages(&mut workloads, &system_total);
 
         snap.timestamp = current_timestamp;
         snap.workloads = workloads;
-        snap.system_total = DeviceEnergy {
-            cpu_joules: snap
-                .workloads
-                .iter()
-                .map(|workload| workload.energy.cpu_joules)
-                .sum::<f64>()
-                + snap.unattributed.cpu_joules,
-            dram_joules: snap
-                .workloads
-                .iter()
-                .map(|workload| workload.energy.dram_joules)
-                .sum::<f64>()
-                + snap.unattributed.dram_joules,
-            gpu_joules: snap
-                .workloads
-                .iter()
-                .map(|workload| workload.energy.gpu_joules)
-                .sum::<f64>()
-                + snap.unattributed.gpu_joules,
-        };
+        snap.system_total = system_total;
     }
 
     /// Spawn the tick task that runs the core polling and update loop.
@@ -487,9 +505,9 @@ impl Monitor {
         let rapl_group = Arc::clone(&self.rapl_group);
         let gpu_group = self.gpu_group.clone();
         let root_pids = self.root_pids.clone();
-        let discovered_roots = Arc::clone(&self.discovered_roots);
-        let known_roots = Arc::clone(&self.known_roots);
-        let last_child_to_root = Arc::clone(&self.last_child_to_root);
+        let discovered_groups = Arc::clone(&self.discovered_groups);
+        let known_groups = Arc::clone(&self.known_groups);
+        let last_pid_to_group = Arc::clone(&self.last_pid_to_group);
         let start_timestamp = Arc::clone(&self.start_timestamp);
         let snapshot = Arc::clone(&self.snapshot);
         let is_running = Arc::clone(&self.is_running);
@@ -498,83 +516,47 @@ impl Monitor {
             let mut tick_state = TickState::default();
 
             while is_running.load(Ordering::SeqCst) {
-                // 1. Determine current root PIDs and metadata
-                let roots_with_metadata: Vec<ProcessRoot> = if let Some(ref pids) = root_pids {
-                    let roots = known_roots.read().unwrap();
-                    pids.iter()
-                        .map(|&pid| {
-                            roots.get(&pid).cloned().unwrap_or(ProcessRoot {
-                                pid,
-                                user: String::new(),
-                                name: String::new(),
-                            })
-                        })
-                        .collect()
-                } else {
-                    discovered_roots.read().unwrap().clone()
-                };
-
-                let root_pid_list: Vec<u32> = roots_with_metadata.iter().map(|r| r.pid).collect();
-                {
-                    let mut roots = known_roots.write().unwrap();
-                    for root in &roots_with_metadata {
-                        roots.insert(root.pid, root.clone());
-                    }
-                }
-                let current_root_set: std::collections::HashSet<u32> =
-                    root_pid_list.iter().copied().collect();
-
-                // 2. Build child-to-root map and get expanded PID set
-                let (child_to_root, expanded_pids) = if root_pid_list.is_empty() {
-                    (HashMap::new(), Vec::new())
-                } else {
-                    let roots_for_walk = root_pid_list.clone();
-                    tokio::task::spawn_blocking(move || build_child_to_root_map(&roots_for_walk))
+                let groups = if let Some(ref pids) = root_pids {
+                    let pids = pids.clone();
+                    tokio::task::spawn_blocking(move || explicit_pid_groups(&pids))
                         .await
                         .unwrap_or_default()
+                } else {
+                    discovered_groups.read().unwrap().clone()
                 };
-                let previous_child_to_root = last_child_to_root.read().unwrap().clone();
 
-                // 3. Set tracked PIDs on collectors and poll data
+                {
+                    let mut known = known_groups.write().unwrap();
+                    for group in &groups {
+                        known.insert(group.id.clone(), group.clone());
+                    }
+                }
+
+                let current_pid_to_group = pid_to_group_map(&groups);
+                let expanded_pids = tracked_pids(&groups);
+                let previous_pid_to_group = last_pid_to_group.read().unwrap().clone();
+                let active_pid_to_group =
+                    merge_pid_group_maps(&current_pid_to_group, &previous_pid_to_group);
+
                 let rapl_records;
                 {
                     let mut rapl = rapl_group.lock().await;
-                    rapl.set_tracked_pids(expanded_pids.clone());
+                    rapl.update_tracked_pids(expanded_pids.clone());
                     rapl_records = rapl.poll_data();
                 }
 
                 let gpu_records = if let Some(ref gpu) = gpu_group {
                     let mut gpu_lock = gpu.lock().await;
-                    gpu_lock.set_tracked_pids(expanded_pids.clone());
+                    gpu_lock.update_tracked_pids(expanded_pids.clone());
                     gpu_lock.poll_data()
                 } else {
                     Vec::new()
                 };
 
-                // 4. Compute MetricsSnapshot from records
-                let all_records: Vec<&EnergyRecord> =
-                    rapl_records.iter().chain(gpu_records.iter()).collect();
+                let mut all_records = rapl_records;
+                all_records.extend(gpu_records);
+                let tick = aggregate_energy_records(&all_records, &active_pid_to_group);
 
-                // Compute system_total from all records
-                let mut system_total = DeviceEnergy::default();
-                for record in &all_records {
-                    let class = classify_energy(record);
-                    accumulate_device_energy(&mut system_total, class, record.energy);
-                }
-
-                // Compute per-root energy using child_to_root map
-                let mut workload_energy_map: HashMap<u32, DeviceEnergy> = HashMap::new();
-                for record in &all_records {
-                    if let Some(root) =
-                        root_for_record(record.pid, &child_to_root, &previous_child_to_root)
-                    {
-                        let class = classify_energy(record);
-                        let entry = workload_energy_map.entry(root).or_default();
-                        accumulate_device_energy(entry, class, record.energy);
-                    }
-                }
-
-                // Build workload snapshots with power computation
                 let current_timestamp = chrono::Utc::now().timestamp_millis();
                 if tick_state.start_timestamp == 0 {
                     tick_state.start_timestamp = current_timestamp;
@@ -582,83 +564,43 @@ impl Monitor {
                 }
                 let elapsed_s = (current_timestamp - tick_state.start_timestamp) as f64 / 1000.0;
 
+                let known_groups_snapshot = known_groups.read().unwrap().clone();
                 let mut workloads: Vec<WorkloadSnapshot> = Vec::new();
-                let mut workloads_sum = DeviceEnergy::default();
-                let known_roots_snapshot = known_roots.read().unwrap().clone();
 
-                for root_info in known_roots_snapshot.values() {
-                    let tick_energy = workload_energy_map
-                        .get(&root_info.pid)
+                for group in known_groups_snapshot.values() {
+                    let tick_energy = tick
+                        .group_energy
+                        .get(&group.id)
                         .cloned()
                         .unwrap_or_default();
-
-                    // Compute cumulative energy for this workload
-                    let prev_cumulative_energy = tick_state
+                    let mut cumulative_energy = tick_state
                         .workload_energy
-                        .get(&root_info.pid)
+                        .get(&group.id)
                         .cloned()
                         .unwrap_or_default();
-                    let cumulative_energy = DeviceEnergy {
-                        cpu_joules: prev_cumulative_energy.cpu_joules + tick_energy.cpu_joules,
-                        dram_joules: prev_cumulative_energy.dram_joules + tick_energy.dram_joules,
-                        gpu_joules: prev_cumulative_energy.gpu_joules + tick_energy.gpu_joules,
-                    };
+                    add_device_energy(&mut cumulative_energy, &tick_energy);
 
-                    if !current_root_set.contains(&root_info.pid)
-                        && cumulative_energy.total() <= 0.0
-                    {
+                    if cumulative_energy.total() <= 0.0 {
                         continue;
                     }
 
-                    // Average power = cumulative energy / total elapsed time
-                    let power_watts = if elapsed_s > 0.0 {
-                        cumulative_energy.total() / elapsed_s
-                    } else {
-                        0.0
-                    };
-
-                    workloads_sum.cpu_joules += tick_energy.cpu_joules;
-                    workloads_sum.dram_joules += tick_energy.dram_joules;
-                    workloads_sum.gpu_joules += tick_energy.gpu_joules;
-
-                    workloads.push(WorkloadSnapshot {
-                        root_pid: root_info.pid,
-                        name: root_info.name.clone(),
-                        user: root_info.user.clone(),
-                        energy: cumulative_energy,
-                        power_watts,
-                    });
+                    workloads.push(workload_snapshot(group, cumulative_energy, elapsed_s));
                 }
-                workloads.sort_by_key(|workload| workload.root_pid);
+                workloads.sort_by(|left, right| left.group_id.cmp(&right.group_id));
 
-                // Unattributed this tick = system_total - sum(workloads), clamped >= 0
-                let tick_unattributed = system_total.saturating_sub(&workloads_sum);
-
-                // Accumulate unattributed energy
                 let prev_unattributed = { snapshot.read().unwrap().unattributed.clone() };
-                let cumulative_unattributed = DeviceEnergy {
-                    cpu_joules: prev_unattributed.cpu_joules + tick_unattributed.cpu_joules,
-                    dram_joules: prev_unattributed.dram_joules + tick_unattributed.dram_joules,
-                    gpu_joules: prev_unattributed.gpu_joules + tick_unattributed.gpu_joules,
-                };
+                let mut cumulative_unattributed = prev_unattributed;
+                add_device_energy(&mut cumulative_unattributed, &tick.unattributed);
 
-                // system_total = sum(workload cumulative energies) + cumulative unattributed
-                let cumulative_system_total = DeviceEnergy {
-                    cpu_joules: workloads.iter().map(|w| w.energy.cpu_joules).sum::<f64>()
-                        + cumulative_unattributed.cpu_joules,
-                    dram_joules: workloads.iter().map(|w| w.energy.dram_joules).sum::<f64>()
-                        + cumulative_unattributed.dram_joules,
-                    gpu_joules: workloads.iter().map(|w| w.energy.gpu_joules).sum::<f64>()
-                        + cumulative_unattributed.gpu_joules,
-                };
+                let cumulative_system_total =
+                    system_total_from_workloads(&workloads, &cumulative_unattributed);
+                apply_workload_percentages(&mut workloads, &cumulative_system_total);
 
-                // Update tick state with cumulative energies for next iteration
                 tick_state.workload_energy = workloads
                     .iter()
-                    .map(|wl| (wl.root_pid, wl.energy.clone()))
+                    .map(|workload| (workload.group_id.clone(), workload.energy.clone()))
                     .collect();
 
-                // Write updated snapshot
                 {
                     let mut snap = snapshot.write().unwrap();
                     snap.timestamp = current_timestamp;
@@ -667,7 +609,7 @@ impl Monitor {
                     snap.unattributed = cumulative_unattributed;
                     snap.tracked_pids = expanded_pids;
                 }
-                *last_child_to_root.write().unwrap() = child_to_root;
+                *last_pid_to_group.write().unwrap() = current_pid_to_group;
 
                 tokio::time::sleep(interval).await;
             }
@@ -678,15 +620,15 @@ impl Monitor {
     /// Only spawned when `root_pids` is None (monitor-all mode).
     fn spawn_scan_task(&mut self) {
         let interval = Duration::from_secs_f64(self.config.discovery.scan_interval_secs);
-        let discovered_roots = Arc::clone(&self.discovered_roots);
+        let discovered_groups = Arc::clone(&self.discovered_groups);
         let is_running = Arc::clone(&self.is_running);
 
         self.scan_handle = Some(tokio::spawn(async move {
             while is_running.load(Ordering::SeqCst) {
-                let roots = tokio::task::spawn_blocking(scan_roots)
+                let groups = tokio::task::spawn_blocking(|| group_processes(&scan_processes()))
                     .await
                     .unwrap_or_default();
-                *discovered_roots.write().unwrap() = roots;
+                *discovered_groups.write().unwrap() = groups;
                 tokio::time::sleep(interval).await;
             }
         }));
@@ -739,93 +681,6 @@ mod tests {
         assert_eq!(result.cpu_joules, 0.0); // clamped
         assert!((result.dram_joules - 0.2).abs() < 1e-10);
         assert_eq!(result.gpu_joules, 0.0); // clamped
-    }
-
-    #[test]
-    fn classify_energy_rapl_package() {
-        let record = EnergyRecord {
-            pid: 1,
-            timestamp: 0,
-            device: "rapl:socket:0:package".to_string(),
-            energy: 5.0,
-        };
-        assert_eq!(classify_energy(&record), EnergyClass::Cpu);
-    }
-
-    #[test]
-    fn classify_energy_rapl_dram() {
-        let record = EnergyRecord {
-            pid: 1,
-            timestamp: 0,
-            device: "rapl:system:dram".to_string(),
-            energy: 2.0,
-        };
-        assert_eq!(classify_energy(&record), EnergyClass::Dram);
-    }
-
-    #[test]
-    fn classify_energy_rapl_psys() {
-        let record = EnergyRecord {
-            pid: 1,
-            timestamp: 0,
-            device: "rapl:system:psys".to_string(),
-            energy: 3.0,
-        };
-        assert_eq!(classify_energy(&record), EnergyClass::Cpu);
-    }
-
-    #[test]
-    fn classify_energy_nvidia() {
-        let record = EnergyRecord {
-            pid: 1,
-            timestamp: 0,
-            device: "nvidia:gpu:0".to_string(),
-            energy: 10.0,
-        };
-        assert_eq!(classify_energy(&record), EnergyClass::Gpu);
-    }
-
-    #[test]
-    fn unattributed_is_clamped_to_zero() {
-        // Simulate jitter: workloads sum exceeds system_total
-        let system_total = DeviceEnergy {
-            cpu_joules: 5.0,
-            dram_joules: 1.0,
-            gpu_joules: 0.0,
-        };
-        let workloads_sum = DeviceEnergy {
-            cpu_joules: 5.5, // exceeds system_total due to jitter
-            dram_joules: 1.2,
-            gpu_joules: 0.1,
-        };
-        let unattributed = system_total.saturating_sub(&workloads_sum);
-        assert_eq!(unattributed.cpu_joules, 0.0);
-        assert_eq!(unattributed.dram_joules, 0.0);
-        assert_eq!(unattributed.gpu_joules, 0.0);
-    }
-
-    #[test]
-    fn build_child_to_root_map_maps_self() {
-        let my_pid = std::process::id();
-        let (map, pids) = build_child_to_root_map(&[my_pid]);
-        // The root maps to itself
-        assert_eq!(map.get(&my_pid), Some(&my_pid));
-        assert!(pids.contains(&my_pid));
-    }
-
-    #[test]
-    fn build_child_to_root_map_empty_returns_empty() {
-        let (map, pids) = build_child_to_root_map(&[]);
-        assert!(map.is_empty());
-        assert!(pids.is_empty());
-    }
-
-    #[test]
-    fn root_for_record_falls_back_to_previous_child_map() {
-        let current = HashMap::new();
-        let previous = HashMap::from([(42, 7)]);
-
-        assert_eq!(root_for_record(42, &current, &previous), Some(7));
     }
 
     #[test]

--- a/src/process.rs
+++ b/src/process.rs
@@ -374,6 +374,10 @@ fn split_systemd_suffix(segment: &str) -> Option<(&str, &str)> {
 }
 
 fn strip_volatile_suffixes(value: &str) -> String {
+    if !should_strip_volatile_suffixes(value) {
+        return value.to_string();
+    }
+
     let mut parts: Vec<&str> = value.split('-').collect();
 
     while parts.len() > 1 {
@@ -388,6 +392,11 @@ fn strip_volatile_suffixes(value: &str) -> String {
     }
 
     parts.join("-")
+}
+
+fn should_strip_volatile_suffixes(value: &str) -> bool {
+    const PREFIXES: [&str; 3] = ["app-", "session-", "vte-spawn-"];
+    PREFIXES.iter().any(|prefix| value.starts_with(prefix))
 }
 
 fn is_volatile_token(token: &str) -> bool {
@@ -617,6 +626,28 @@ mod tests {
             .expect("scope label")
             .name,
             "app-firefox.scope"
+        );
+    }
+
+    #[test]
+    fn cgroup_labels_preserve_container_and_pod_identity() {
+        assert_eq!(
+            cgroup_label("/system.slice/docker-0123456789abcdef.scope")
+                .expect("docker scope")
+                .name,
+            "docker-0123456789abcdef.scope"
+        );
+        assert_eq!(
+            cgroup_label("/system.slice/cri-containerd-fedcba9876543210.scope")
+                .expect("containerd scope")
+                .name,
+            "cri-containerd-fedcba9876543210.scope"
+        );
+        assert_eq!(
+            cgroup_label("/kubepods.slice/kubepods-besteffort-pod0123456789abcdef.slice")
+                .expect("pod slice")
+                .name,
+            "kubepods-besteffort-pod0123456789abcdef.slice"
         );
     }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,687 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::fs;
+use std::path::Path;
+
+use sysinfo::{Process, System};
+use users::{Users, UsersCache};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessInfo {
+    pub pid: u32,
+    pub parent_pid: Option<u32>,
+    pub command: String,
+    pub user: String,
+    pub cgroup_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessGroup {
+    pub id: String,
+    pub name: String,
+    pub user: String,
+    pub pids: Vec<u32>,
+    pub representative_pid: u32,
+}
+
+pub trait GroupingStrategy {
+    fn group(&self, processes: &[ProcessInfo]) -> Vec<ProcessGroup>;
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CgroupGrouping;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ParentLineageGrouping;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CgroupLabel {
+    key: String,
+    name: String,
+    priority: u8,
+}
+
+impl GroupingStrategy for CgroupGrouping {
+    fn group(&self, processes: &[ProcessInfo]) -> Vec<ProcessGroup> {
+        let mut groups: BTreeMap<String, (String, Vec<&ProcessInfo>)> = BTreeMap::new();
+
+        for process in processes {
+            let label = cgroup_label(&process.cgroup_path).unwrap_or_else(unscoped_label);
+            groups
+                .entry(label.key)
+                .or_insert_with(|| (label.name, Vec::new()))
+                .1
+                .push(process);
+        }
+
+        groups
+            .into_iter()
+            .filter_map(|(key, (name, processes))| {
+                build_group(format!("cgroup:{key}"), name, &processes, None)
+            })
+            .collect()
+    }
+}
+
+impl GroupingStrategy for ParentLineageGrouping {
+    fn group(&self, processes: &[ProcessInfo]) -> Vec<ProcessGroup> {
+        let by_pid = process_index(processes);
+        let mut groups: BTreeMap<u32, Vec<&ProcessInfo>> = BTreeMap::new();
+
+        for process in processes {
+            let root_pid = lineage_representative(process.pid, &by_pid);
+            groups.entry(root_pid).or_default().push(process);
+        }
+
+        groups
+            .into_iter()
+            .filter_map(|(root_pid, processes)| {
+                let name = by_pid
+                    .get(&root_pid)
+                    .map(|process| command_name(&process.command, process.pid))
+                    .unwrap_or_else(|| format!("pid {root_pid}"));
+                build_group(
+                    format!("lineage:{root_pid}"),
+                    name,
+                    &processes,
+                    Some(root_pid),
+                )
+            })
+            .collect()
+    }
+}
+
+pub fn scan_processes() -> Vec<ProcessInfo> {
+    let system = System::new_all();
+    let users_cache = UsersCache::new();
+    let mut processes: Vec<ProcessInfo> = system
+        .processes()
+        .iter()
+        .map(|(pid, process)| {
+            let pid = pid.as_u32();
+            ProcessInfo {
+                pid,
+                parent_pid: process.parent().map(|parent| parent.as_u32()),
+                command: process_command(process),
+                user: process_user(process, &users_cache),
+                cgroup_path: read_cgroup_path(pid).unwrap_or_default(),
+            }
+        })
+        .collect();
+
+    processes.sort_by_key(|process| process.pid);
+    processes
+}
+
+pub fn scan_process_groups<S: GroupingStrategy + ?Sized>(strategy: &S) -> Vec<ProcessGroup> {
+    let processes = scan_processes();
+    group_processes_with_strategy(&processes, strategy)
+}
+
+pub fn group_processes_with_strategy<S: GroupingStrategy + ?Sized>(
+    processes: &[ProcessInfo],
+    strategy: &S,
+) -> Vec<ProcessGroup> {
+    strategy.group(processes)
+}
+
+pub fn group_processes(processes: &[ProcessInfo]) -> Vec<ProcessGroup> {
+    let cgroup_groups = group_processes_with_strategy(processes, &CgroupGrouping);
+    if cgroup_grouping_is_degenerate(processes, &cgroup_groups) {
+        let lineage_groups = group_processes_with_strategy(processes, &ParentLineageGrouping);
+        if !lineage_groups.is_empty() {
+            return lineage_groups;
+        }
+    }
+
+    cgroup_groups
+}
+
+pub fn pid_to_group_map(groups: &[ProcessGroup]) -> HashMap<u32, String> {
+    let mut map = HashMap::new();
+
+    for group in groups {
+        for pid in &group.pids {
+            map.entry(*pid).or_insert_with(|| group.id.clone());
+        }
+    }
+
+    map
+}
+
+pub fn tracked_pids(groups: &[ProcessGroup]) -> Vec<u32> {
+    let mut pids: Vec<u32> = groups
+        .iter()
+        .flat_map(|group| group.pids.iter().copied())
+        .collect();
+    pids.sort_unstable();
+    pids.dedup();
+    pids
+}
+
+fn read_cgroup_path(pid: u32) -> Option<String> {
+    let contents = fs::read_to_string(format!("/proc/{pid}/cgroup")).ok()?;
+    let path = select_cgroup_path(&contents);
+    if path.is_empty() { None } else { Some(path) }
+}
+
+fn select_cgroup_path(contents: &str) -> String {
+    let mut best: Option<(u8, usize, String)> = None;
+
+    for (index, line) in contents.lines().enumerate() {
+        let Some(path) = parse_cgroup_line(line) else {
+            continue;
+        };
+
+        let priority = cgroup_label(&path).map_or(0, |label| label.priority);
+        let replace_best = match &best {
+            Some((best_priority, _, _)) => priority > *best_priority,
+            None => true,
+        };
+
+        if replace_best {
+            best = Some((priority, index, path));
+        }
+    }
+
+    best.map(|(_, _, path)| path).unwrap_or_default()
+}
+
+fn parse_cgroup_line(line: &str) -> Option<String> {
+    let mut fields = line.splitn(3, ':');
+    fields.next()?;
+    fields.next()?;
+    let path = fields.next()?.trim();
+    if path.is_empty() {
+        None
+    } else {
+        Some(path.to_string())
+    }
+}
+
+fn process_command(process: &Process) -> String {
+    let command = process
+        .cmd()
+        .iter()
+        .map(|part| part.to_string_lossy())
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    if command.is_empty() {
+        process.name().to_string_lossy().to_string()
+    } else {
+        command
+    }
+}
+
+fn process_user(process: &Process, users_cache: &UsersCache) -> String {
+    process
+        .user_id()
+        .map(|uid| resolve_username(**uid, users_cache))
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn resolve_username(uid: u32, users_cache: &UsersCache) -> String {
+    users_cache
+        .get_user_by_uid(uid)
+        .map(|user| user.name().to_string_lossy().to_string())
+        .unwrap_or_else(|| uid.to_string())
+}
+
+fn cgroup_grouping_is_degenerate(processes: &[ProcessInfo], groups: &[ProcessGroup]) -> bool {
+    if processes.is_empty() {
+        return false;
+    }
+
+    if groups.is_empty() {
+        return true;
+    }
+
+    if groups.len() != 1 {
+        return false;
+    }
+
+    let labels: Vec<CgroupLabel> = processes
+        .iter()
+        .filter_map(|process| cgroup_label(&process.cgroup_path))
+        .collect();
+
+    if labels.is_empty() {
+        return true;
+    }
+
+    let unique_paths: HashSet<&str> = processes
+        .iter()
+        .map(|process| process.cgroup_path.trim())
+        .filter(|path| !path.is_empty())
+        .collect();
+    let only_low_signal_labels = labels.iter().all(|label| label.priority < 3);
+
+    if unique_paths.len() <= 1 && only_low_signal_labels {
+        return true;
+    }
+
+    unique_paths.len() <= 1 && ParentLineageGrouping.group(processes).len() > 1
+}
+
+fn cgroup_label(path: &str) -> Option<CgroupLabel> {
+    let segments = cgroup_segments(path);
+    if segments.is_empty() {
+        return None;
+    }
+
+    for segment in segments.iter().rev() {
+        if is_systemd_unit_or_scope_segment(segment) && !is_generic_systemd_segment(segment) {
+            let name = normalize_systemd_segment(segment);
+            return Some(CgroupLabel {
+                key: name.clone(),
+                name,
+                priority: 3,
+            });
+        }
+    }
+
+    for segment in segments.iter().rev() {
+        if segment.ends_with(".slice") && !is_generic_systemd_segment(segment) {
+            let name = normalize_systemd_segment(segment);
+            return Some(CgroupLabel {
+                key: name.clone(),
+                name,
+                priority: 2,
+            });
+        }
+    }
+
+    segments
+        .iter()
+        .rev()
+        .find(|segment| meaningful_path_segment(segment))
+        .map(|segment| {
+            let name = normalize_path_segment(segment);
+            CgroupLabel {
+                key: name.clone(),
+                name,
+                priority: 1,
+            }
+        })
+}
+
+fn cgroup_segments(path: &str) -> Vec<&str> {
+    path.trim_matches('/')
+        .split('/')
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .collect()
+}
+
+fn unscoped_label() -> CgroupLabel {
+    CgroupLabel {
+        key: "unscoped".to_string(),
+        name: "unscoped".to_string(),
+        priority: 0,
+    }
+}
+
+fn is_systemd_unit_or_scope_segment(segment: &str) -> bool {
+    const SUFFIXES: [&str; 9] = [
+        ".service", ".scope", ".socket", ".timer", ".mount", ".target", ".path", ".device", ".swap",
+    ];
+
+    SUFFIXES.iter().any(|suffix| segment.ends_with(suffix))
+}
+
+fn is_generic_systemd_segment(segment: &str) -> bool {
+    matches!(
+        segment,
+        "-.slice" | "system.slice" | "user.slice" | "machine.slice" | "init.scope"
+    ) || (segment.starts_with("user-") && segment.ends_with(".slice"))
+        || (segment.starts_with("user@") && segment.ends_with(".service"))
+}
+
+fn meaningful_path_segment(segment: &str) -> bool {
+    !matches!(segment, "." | "..") && !is_generic_systemd_segment(segment)
+}
+
+fn normalize_systemd_segment(segment: &str) -> String {
+    let Some((base, suffix)) = split_systemd_suffix(segment) else {
+        return normalize_path_segment(segment);
+    };
+    let base = strip_volatile_suffixes(base);
+    if base.is_empty() {
+        segment.to_string()
+    } else {
+        format!("{base}.{suffix}")
+    }
+}
+
+fn normalize_path_segment(segment: &str) -> String {
+    let segment = segment.trim();
+    let normalized = strip_volatile_suffixes(segment);
+    if normalized.is_empty() {
+        segment.to_string()
+    } else {
+        normalized
+    }
+}
+
+fn split_systemd_suffix(segment: &str) -> Option<(&str, &str)> {
+    let (base, suffix) = segment.rsplit_once('.')?;
+    if base.is_empty() || suffix.is_empty() {
+        None
+    } else {
+        Some((base, suffix))
+    }
+}
+
+fn strip_volatile_suffixes(value: &str) -> String {
+    let mut parts: Vec<&str> = value.split('-').collect();
+
+    while parts.len() > 1 {
+        let Some(last) = parts.last() else {
+            break;
+        };
+        if is_volatile_token(last) {
+            parts.pop();
+        } else {
+            break;
+        }
+    }
+
+    parts.join("-")
+}
+
+fn is_volatile_token(token: &str) -> bool {
+    let token = token.trim();
+    if token.is_empty() {
+        return false;
+    }
+
+    token.chars().all(|char| char.is_ascii_digit())
+        || (token.len() >= 8 && token.chars().all(|char| char.is_ascii_hexdigit()))
+        || looks_like_uuid_token(token)
+        || looks_like_pod_token(token)
+}
+
+fn looks_like_uuid_token(token: &str) -> bool {
+    let without_hyphens: String = token.chars().filter(|char| *char != '-').collect();
+    without_hyphens.len() >= 16 && without_hyphens.chars().all(|char| char.is_ascii_hexdigit())
+}
+
+fn looks_like_pod_token(token: &str) -> bool {
+    token
+        .strip_prefix("pod")
+        .is_some_and(|rest| rest.len() >= 8 && rest.chars().all(|char| char.is_ascii_hexdigit()))
+}
+
+fn process_index(processes: &[ProcessInfo]) -> BTreeMap<u32, &ProcessInfo> {
+    let mut by_pid = BTreeMap::new();
+    for process in processes {
+        by_pid.entry(process.pid).or_insert(process);
+    }
+    by_pid
+}
+
+fn lineage_representative(pid: u32, by_pid: &BTreeMap<u32, &ProcessInfo>) -> u32 {
+    let mut current = pid;
+    let mut visited = BTreeSet::new();
+
+    while visited.insert(current) {
+        let Some(process) = by_pid.get(&current) else {
+            return current;
+        };
+        let Some(parent_pid) = process.parent_pid else {
+            return current;
+        };
+
+        if parent_pid == 1 || parent_pid == 2 || !by_pid.contains_key(&parent_pid) {
+            return current;
+        }
+
+        current = parent_pid;
+    }
+
+    pid
+}
+
+fn build_group(
+    id: String,
+    name: String,
+    processes: &[&ProcessInfo],
+    representative_pid: Option<u32>,
+) -> Option<ProcessGroup> {
+    let mut pids: Vec<u32> = processes.iter().map(|process| process.pid).collect();
+    pids.sort_unstable();
+    pids.dedup();
+
+    let representative_pid = representative_pid.or_else(|| pids.first().copied())?;
+
+    Some(ProcessGroup {
+        id,
+        name,
+        user: common_user(processes),
+        pids,
+        representative_pid,
+    })
+}
+
+fn common_user(processes: &[&ProcessInfo]) -> String {
+    let users: BTreeSet<&str> = processes
+        .iter()
+        .map(|process| process.user.as_str())
+        .filter(|user| !user.is_empty())
+        .collect();
+
+    match users.len() {
+        0 => "unknown".to_string(),
+        1 => users.iter().next().unwrap().to_string(),
+        _ => "mixed".to_string(),
+    }
+}
+
+fn command_name(command: &str, pid: u32) -> String {
+    let first = command.split_whitespace().next().unwrap_or_default();
+    if first.is_empty() {
+        return format!("pid {pid}");
+    }
+
+    Path::new(first)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or(first)
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn process(
+        pid: u32,
+        parent_pid: Option<u32>,
+        command: &str,
+        user: &str,
+        cgroup_path: &str,
+    ) -> ProcessInfo {
+        ProcessInfo {
+            pid,
+            parent_pid,
+            command: command.to_string(),
+            user: user.to_string(),
+            cgroup_path: cgroup_path.to_string(),
+        }
+    }
+
+    #[test]
+    fn cgroup_grouping_uses_unit_and_scope_labels() {
+        let processes = vec![
+            process(100, Some(1), "nginx", "root", "/system.slice/nginx.service"),
+            process(
+                101,
+                Some(100),
+                "nginx",
+                "root",
+                "/system.slice/nginx.service",
+            ),
+            process(200, Some(1), "sshd", "root", "/system.slice/sshd.service"),
+            process(
+                300,
+                Some(1),
+                "gnome-terminal",
+                "alice",
+                "/user.slice/user-1000.slice/user@1000.service/app.slice/app-org.gnome.Terminal-1122.scope",
+            ),
+            process(
+                301,
+                Some(300),
+                "zsh",
+                "alice",
+                "/user.slice/user-1000.slice/user@1000.service/app.slice/app-org.gnome.Terminal-3344.scope",
+            ),
+        ];
+
+        let groups = CgroupGrouping.group(&processes);
+        let ids: Vec<&str> = groups.iter().map(|group| group.id.as_str()).collect();
+
+        assert_eq!(
+            ids,
+            vec![
+                "cgroup:app-org.gnome.Terminal.scope",
+                "cgroup:nginx.service",
+                "cgroup:sshd.service"
+            ]
+        );
+        assert_eq!(groups[0].pids, vec![300, 301]);
+        assert_eq!(groups[1].pids, vec![100, 101]);
+        assert_eq!(groups[1].representative_pid, 100);
+    }
+
+    #[test]
+    fn parent_lineage_grouping_uses_descendant_below_pid_one_or_two() {
+        let processes = vec![
+            process(1, None, "systemd", "root", "/"),
+            process(2, None, "kthreadd", "root", "/"),
+            process(100, Some(1), "bash", "alice", ""),
+            process(101, Some(100), "python workload.py", "alice", ""),
+            process(102, Some(101), "worker", "alice", ""),
+            process(200, Some(2), "kworker", "root", ""),
+        ];
+
+        let groups = ParentLineageGrouping.group(&processes);
+        let workload = groups
+            .iter()
+            .find(|group| group.id == "lineage:100")
+            .expect("user workload should be grouped below PID 1");
+
+        assert_eq!(workload.name, "bash");
+        assert_eq!(workload.representative_pid, 100);
+        assert_eq!(workload.pids, vec![100, 101, 102]);
+        assert!(!groups.iter().any(|group| {
+            group.id == "lineage:1" && group.pids.iter().any(|pid| *pid == 100 || *pid == 101)
+        }));
+        assert!(groups.iter().any(|group| group.id == "lineage:200"));
+    }
+
+    #[test]
+    fn group_processes_falls_back_from_single_degenerate_cgroup() {
+        let processes = vec![
+            process(100, Some(1), "bash", "alice", "/"),
+            process(101, Some(100), "python", "alice", "/"),
+            process(200, Some(1), "node", "alice", "/"),
+        ];
+
+        let groups = group_processes(&processes);
+        let ids: Vec<&str> = groups.iter().map(|group| group.id.as_str()).collect();
+
+        assert_eq!(ids, vec!["lineage:100", "lineage:200"]);
+        assert_eq!(groups[0].pids, vec![100, 101]);
+        assert_eq!(groups[1].pids, vec![200]);
+    }
+
+    #[test]
+    fn scanner_cgroup_parser_prefers_specific_systemd_path() {
+        let contents = "\
+12:memory:/
+11:cpu,cpuacct:/system.slice/ssh.service
+0::/user.slice/user-1000.slice/user@1000.service/app.slice/app-firefox-98765.scope
+";
+
+        assert_eq!(
+            select_cgroup_path(contents),
+            "/system.slice/ssh.service".to_string()
+        );
+        assert_eq!(
+            cgroup_label(
+                "/user.slice/user-1000.slice/user@1000.service/app.slice/app-firefox-98765.scope"
+            )
+            .expect("scope label")
+            .name,
+            "app-firefox.scope"
+        );
+    }
+
+    struct SingleGroupStrategy;
+
+    impl GroupingStrategy for SingleGroupStrategy {
+        fn group(&self, processes: &[ProcessInfo]) -> Vec<ProcessGroup> {
+            let pids: Vec<u32> = processes.iter().map(|process| process.pid).collect();
+            vec![ProcessGroup {
+                id: "strategy:single".to_string(),
+                name: format!("{} processes", processes.len()),
+                user: "synthetic".to_string(),
+                representative_pid: pids.first().copied().unwrap_or_default(),
+                pids,
+            }]
+        }
+    }
+
+    #[test]
+    fn grouping_with_strategy_delegates_to_injected_strategy() {
+        let processes = vec![
+            process(100, Some(1), "bash", "alice", "/system.slice/a.service"),
+            process(200, Some(1), "node", "bob", "/system.slice/b.service"),
+        ];
+
+        let groups = group_processes_with_strategy(&processes, &SingleGroupStrategy);
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].id, "strategy:single");
+        assert_eq!(groups[0].name, "2 processes");
+        assert_eq!(groups[0].pids, vec![100, 200]);
+    }
+
+    #[test]
+    fn scanner_delegates_to_injected_strategy() {
+        let groups = scan_process_groups(&SingleGroupStrategy);
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].id, "strategy:single");
+        assert!(!groups[0].pids.is_empty());
+    }
+
+    #[test]
+    fn helpers_return_deterministic_deduplicated_pids() {
+        let groups = vec![
+            ProcessGroup {
+                id: "b".to_string(),
+                name: "b".to_string(),
+                user: "alice".to_string(),
+                pids: vec![3, 1, 3],
+                representative_pid: 1,
+            },
+            ProcessGroup {
+                id: "a".to_string(),
+                name: "a".to_string(),
+                user: "alice".to_string(),
+                pids: vec![2, 1],
+                representative_pid: 2,
+            },
+        ];
+
+        let map = pid_to_group_map(&groups);
+        assert_eq!(map.get(&1), Some(&"b".to_string()));
+        assert_eq!(map.get(&2), Some(&"a".to_string()));
+        assert_eq!(map.get(&3), Some(&"b".to_string()));
+        assert_eq!(tracked_pids(&groups), vec![1, 2, 3]);
+    }
+}

--- a/src/process_aggregation.rs
+++ b/src/process_aggregation.rs
@@ -1,0 +1,175 @@
+use crate::energy_group::EnergyRecord;
+use crate::monitor::DeviceEnergy;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AggregatedDeviceClass {
+    Cpu,
+    Dram,
+    Gpu,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct GroupedEnergyTick {
+    pub system_total: DeviceEnergy,
+    pub group_energy: HashMap<String, DeviceEnergy>,
+    pub unattributed: DeviceEnergy,
+}
+
+pub fn classify_record_device(record: &EnergyRecord) -> AggregatedDeviceClass {
+    if record.device.starts_with("nvidia:") {
+        AggregatedDeviceClass::Gpu
+    } else if record.device == "rapl:system:dram" {
+        AggregatedDeviceClass::Dram
+    } else {
+        AggregatedDeviceClass::Cpu
+    }
+}
+
+pub fn aggregate_energy_records(
+    records: &[EnergyRecord],
+    pid_to_group: &HashMap<u32, String>,
+) -> GroupedEnergyTick {
+    let mut system_total = DeviceEnergy::default();
+    let mut group_energy: HashMap<String, DeviceEnergy> = HashMap::new();
+    let mut groups_sum = DeviceEnergy::default();
+
+    for record in records {
+        let device_class = classify_record_device(record);
+        accumulate_device_energy(&mut system_total, device_class, record.energy);
+
+        if let Some(group_id) = pid_to_group.get(&record.pid) {
+            let entry = group_energy.entry(group_id.clone()).or_default();
+            accumulate_device_energy(entry, device_class, record.energy);
+            accumulate_device_energy(&mut groups_sum, device_class, record.energy);
+        }
+    }
+
+    let unattributed = system_total.saturating_sub(&groups_sum);
+
+    GroupedEnergyTick {
+        system_total,
+        group_energy,
+        unattributed,
+    }
+}
+
+pub fn percentage_of_system(group: &DeviceEnergy, system_total: &DeviceEnergy) -> f64 {
+    let system_total_joules = system_total.total();
+    if system_total_joules <= 0.0 {
+        0.0
+    } else {
+        group.total() / system_total_joules * 100.0
+    }
+}
+
+fn accumulate_device_energy(
+    device_energy: &mut DeviceEnergy,
+    device_class: AggregatedDeviceClass,
+    joules: f64,
+) {
+    match device_class {
+        AggregatedDeviceClass::Cpu => device_energy.cpu_joules += joules,
+        AggregatedDeviceClass::Dram => device_energy.dram_joules += joules,
+        AggregatedDeviceClass::Gpu => device_energy.gpu_joules += joules,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(pid: u32, device: &str, energy: f64) -> EnergyRecord {
+        EnergyRecord {
+            pid,
+            timestamp: 0,
+            device: device.to_string(),
+            energy,
+        }
+    }
+
+    fn assert_close(actual: f64, expected: f64) {
+        assert!(
+            (actual - expected).abs() < 1e-10,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn classifies_cpu_dram_and_gpu_devices() {
+        assert_eq!(
+            classify_record_device(&record(1, "rapl:socket:0:package", 1.0)),
+            AggregatedDeviceClass::Cpu
+        );
+        assert_eq!(
+            classify_record_device(&record(1, "rapl:system:psys", 1.0)),
+            AggregatedDeviceClass::Cpu
+        );
+        assert_eq!(
+            classify_record_device(&record(1, "rapl:system:dram", 1.0)),
+            AggregatedDeviceClass::Dram
+        );
+        assert_eq!(
+            classify_record_device(&record(1, "nvidia:gpu:0", 1.0)),
+            AggregatedDeviceClass::Gpu
+        );
+    }
+
+    #[test]
+    fn sums_multiple_pids_into_same_group() {
+        let records = vec![
+            record(101, "rapl:socket:0:package", 2.0),
+            record(102, "rapl:system:dram", 0.5),
+            record(102, "nvidia:gpu:0", 3.0),
+        ];
+        let pid_to_group =
+            HashMap::from([(101, "compiler".to_string()), (102, "compiler".to_string())]);
+
+        let tick = aggregate_energy_records(&records, &pid_to_group);
+        let group = tick.group_energy.get("compiler").unwrap();
+
+        assert_close(group.cpu_joules, 2.0);
+        assert_close(group.dram_joules, 0.5);
+        assert_close(group.gpu_joules, 3.0);
+        assert_close(tick.system_total.total(), 5.5);
+        assert_close(tick.unattributed.total(), 0.0);
+    }
+
+    #[test]
+    fn unmapped_pid_contributes_to_unattributed() {
+        let records = vec![
+            record(101, "rapl:socket:0:package", 2.0),
+            record(999, "rapl:system:dram", 0.75),
+            record(999, "nvidia:gpu:0", 1.25),
+        ];
+        let pid_to_group = HashMap::from([(101, "compiler".to_string())]);
+
+        let tick = aggregate_energy_records(&records, &pid_to_group);
+
+        assert_close(tick.system_total.cpu_joules, 2.0);
+        assert_close(tick.system_total.dram_joules, 0.75);
+        assert_close(tick.system_total.gpu_joules, 1.25);
+        assert_close(tick.unattributed.cpu_joules, 0.0);
+        assert_close(tick.unattributed.dram_joules, 0.75);
+        assert_close(tick.unattributed.gpu_joules, 1.25);
+        assert!(!tick.group_energy.contains_key("999"));
+    }
+
+    #[test]
+    fn percentage_math_handles_zero_and_expected_percent() {
+        let group = DeviceEnergy {
+            cpu_joules: 2.0,
+            dram_joules: 1.0,
+            gpu_joules: 1.0,
+        };
+        let zero_total = DeviceEnergy::default();
+        let system_total = DeviceEnergy {
+            cpu_joules: 4.0,
+            dram_joules: 2.0,
+            gpu_joules: 2.0,
+        };
+
+        assert_close(percentage_of_system(&group, &zero_total), 0.0);
+        assert_close(percentage_of_system(&group, &system_total), 50.0);
+    }
+}

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -205,19 +205,25 @@ fn render_body(frame: &mut Frame, area: Rect, snapshot: &MetricsSnapshot) {
         return;
     }
 
-    let header = Row::new(vec!["PID", "Name", "User", "Energy (J)", "Avg Power (W)"])
-        .style(Style::default().add_modifier(Modifier::BOLD));
+    let header = Row::new(vec![
+        "Group",
+        "User",
+        "Energy (J)",
+        "Avg Power (W)",
+        "% Total",
+    ])
+    .style(Style::default().add_modifier(Modifier::BOLD));
 
     let rows: Vec<Row> = snapshot
         .workloads
         .iter()
         .map(|wl| {
             Row::new(vec![
-                wl.root_pid.to_string(),
                 wl.name.clone(),
                 wl.user.clone(),
                 format!("{:.4}", wl.energy.total()),
                 format!("{:.2}", wl.power_watts),
+                format!("{:.1}%", wl.percentage_of_system),
             ])
         })
         .collect();
@@ -225,11 +231,11 @@ fn render_body(frame: &mut Frame, area: Rect, snapshot: &MetricsSnapshot) {
     let table = Table::new(
         rows,
         [
-            Constraint::Length(8),
-            Constraint::Min(20),
+            Constraint::Min(24),
             Constraint::Length(12),
             Constraint::Length(12),
-            Constraint::Length(10),
+            Constraint::Length(14),
+            Constraint::Length(9),
         ],
     )
     .header(header)


### PR DESCRIPTION
Implements ENE-25. Adds process scanning/grouping with CgroupGrouping and ParentLineageGrouping, runtime EnergyGroup PID refresh, grouped energy aggregation, monitor-all grouped snapshots, JSON group fields, and a group-oriented TUI workload table. Verification: cargo test; cargo run -- --json-out .artifacts/ene25-monitor-all-smoke.json --duration 2.