### PR TITLE
Fix ENE-25 grouped attribution review feedback

### DIFF
--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -184,6 +184,46 @@ fn explicit_pid_groups(root_pids: &[u32]) -> Vec<ProcessGroup> {
         .collect()
 }
 
+fn refresh_explicit_pid_groups(cached_groups: &[ProcessGroup]) -> Vec<ProcessGroup> {
+    cached_groups
+        .iter()
+        .filter_map(|group| {
+            let mut pids = walk_child_pids(&[group.representative_pid]);
+            if pids.is_empty() {
+                return None;
+            }
+            pids.sort_unstable();
+            pids.dedup();
+
+            let mut refreshed = group.clone();
+            refreshed.pids = pids;
+            Some(refreshed)
+        })
+        .collect()
+}
+
+fn cached_explicit_pid_groups(
+    root_pids: &[u32],
+    known_groups: &HashMap<String, ProcessGroup>,
+) -> Vec<ProcessGroup> {
+    root_pids
+        .iter()
+        .map(|pid| {
+            let id = format!("pid:{pid}");
+            known_groups
+                .get(&id)
+                .cloned()
+                .unwrap_or_else(|| ProcessGroup {
+                    id,
+                    name: format!("pid {pid}"),
+                    user: "unknown".to_string(),
+                    pids: vec![*pid],
+                    representative_pid: *pid,
+                })
+        })
+        .collect()
+}
+
 fn merge_pid_group_maps(
     current: &HashMap<u32, String>,
     previous: &HashMap<u32, String>,
@@ -517,8 +557,11 @@ impl Monitor {
 
             while is_running.load(Ordering::SeqCst) {
                 let groups = if let Some(ref pids) = root_pids {
-                    let pids = pids.clone();
-                    tokio::task::spawn_blocking(move || explicit_pid_groups(&pids))
+                    let cached_groups = {
+                        let known = known_groups.read().unwrap();
+                        cached_explicit_pid_groups(pids, &known)
+                    };
+                    tokio::task::spawn_blocking(move || refresh_explicit_pid_groups(&cached_groups))
                         .await
                         .unwrap_or_default()
                 } else {
@@ -681,6 +724,26 @@ mod tests {
         assert_eq!(result.cpu_joules, 0.0); // clamped
         assert!((result.dram_joules - 0.2).abs() < 1e-10);
         assert_eq!(result.gpu_joules, 0.0); // clamped
+    }
+
+    #[test]
+    fn refresh_explicit_pid_groups_keeps_cached_metadata() {
+        let pid = std::process::id();
+        let cached = vec![ProcessGroup {
+            id: format!("pid:{pid}"),
+            name: "cached-root".to_string(),
+            user: "cached-user".to_string(),
+            pids: Vec::new(),
+            representative_pid: pid,
+        }];
+
+        let refreshed = refresh_explicit_pid_groups(&cached);
+
+        assert_eq!(refreshed.len(), 1);
+        assert_eq!(refreshed[0].id, format!("pid:{pid}"));
+        assert_eq!(refreshed[0].name, "cached-root");
+        assert_eq!(refreshed[0].user, "cached-user");
+        assert!(refreshed[0].pids.contains(&pid));
     }
 
     #[test]

--- a/src/process.rs
+++ b/src/process.rs
@@ -374,6 +374,10 @@ fn split_systemd_suffix(segment: &str) -> Option<(&str, &str)> {
 }
 
 fn strip_volatile_suffixes(value: &str) -> String {
+    if !should_strip_volatile_suffixes(value) {
+        return value.to_string();
+    }
+
     let mut parts: Vec<&str> = value.split('-').collect();
 
     while parts.len() > 1 {
@@ -388,6 +392,11 @@ fn strip_volatile_suffixes(value: &str) -> String {
     }
 
     parts.join("-")
+}
+
+fn should_strip_volatile_suffixes(value: &str) -> bool {
+    const PREFIXES: [&str; 3] = ["app-", "session-", "vte-spawn-"];
+    PREFIXES.iter().any(|prefix| value.starts_with(prefix))
 }
 
 fn is_volatile_token(token: &str) -> bool {
@@ -617,6 +626,28 @@ mod tests {
             .expect("scope label")
             .name,
             "app-firefox.scope"
+        );
+    }
+
+    #[test]
+    fn cgroup_labels_preserve_container_and_pod_identity() {
+        assert_eq!(
+            cgroup_label("/system.slice/docker-0123456789abcdef.scope")
+                .expect("docker scope")
+                .name,
+            "docker-0123456789abcdef.scope"
+        );
+        assert_eq!(
+            cgroup_label("/system.slice/cri-containerd-fedcba9876543210.scope")
+                .expect("containerd scope")
+                .name,
+            "cri-containerd-fedcba9876543210.scope"
+        );
+        assert_eq!(
+            cgroup_label("/kubepods.slice/kubepods-besteffort-pod0123456789abcdef.slice")
+                .expect("pod slice")
+                .name,
+            "kubepods-besteffort-pod0123456789abcdef.slice"
         );
     }
 


### PR DESCRIPTION
Stacked on PR #56 to resolve review feedback.\n\nFixes:\n- Preserve container and pod identity in cgroup group labels by limiting volatile suffix stripping to known desktop/session scope prefixes.\n- Avoid full process-table metadata scans in explicit PID mode by caching root metadata and refreshing only descendant PIDs on the collection tick path.\n\nVerification:\n- cargo test cgroup_labels_preserve_container_and_pod_identity\n- cargo test refresh_explicit_pid_groups_keeps_cached_metadata\n- cargo test\n- git diff --check