### PR TITLE
ENE-30: Add headless Prometheus export mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,6 +775,7 @@ name = "emt"
 version = "0.0.1-alpha.3"
 dependencies = [
  "async-trait",
+ "axum",
  "chrono",
  "clap",
  "crossterm 0.29.0",
@@ -732,6 +785,7 @@ dependencies = [
  "log",
  "nvml-wrapper",
  "polars",
+ "prometheus",
  "pyo3",
  "rand 0.8.6",
  "ratatui",
@@ -742,6 +796,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tower",
  "uzers",
 ]
 
@@ -1115,6 +1170,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,6 +1195,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1423,6 +1485,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,6 +1601,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1546,6 +1620,12 @@ checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2326,6 +2406,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2938,6 +3053,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_stacker"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3383,6 +3509,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3421,6 +3548,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ pyo3 = ["dep:pyo3"]
 
 [dependencies]
 async-trait = "0.1.88"
+axum = "0.8"
 log = "0.4.27"
 sysinfo = "0.35.1"
 env_logger = "0.10"
@@ -23,6 +24,7 @@ users = { package = "uzers", version = "0.12" }
 rand = "0.8.6"
 thiserror = "1.0"
 polars = "0.50.0"
+prometheus = "0.14.0"
 tokio = { version = "1.45.1", features = ["full"] }
 itertools = "0.14.0"
 chrono = "0.4"
@@ -38,3 +40,4 @@ crossterm = "0.29"
 
 [dev-dependencies]
 tempfile = "3"
+tower = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod collectors;
 pub mod config;
 pub mod energy_group;
+pub mod metrics_sink;
 pub mod monitor;
 pub mod process;
 pub mod process_aggregation;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,17 @@
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use emt::config::{EmtConfig, MeasurementUnitsConfig};
-use emt::monitor::{DeviceEnergy, MetricsSnapshot, Monitor};
+use emt::metrics_sink::{MetricsSink, PrometheusSink, SharedPrometheusSink, prometheus_router};
+use emt::monitor::{DeviceEnergy, MetricsSnapshot, Monitor, MonitorHandle};
 use emt::tui::{self, App};
 use serde::Serialize;
 use std::fs::File;
 use std::io::Write;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 const DEFAULT_BATCH_DURATION_SECS: u64 = 10;
+const DEFAULT_PROMETHEUS_PORT: u16 = 9101;
 
 #[derive(Parser, Debug)]
 #[command(name = "emt")]
@@ -32,9 +37,26 @@ struct Args {
     #[arg(long, conflicts_with_all = ["tui", "json_out"])]
     headless: bool,
 
+    /// Export sink for headless daemon mode
+    #[arg(long, value_enum, requires = "headless")]
+    export: Option<ExportMode>,
+
+    /// TCP port for headless Prometheus export
+    #[arg(long, default_value_t = DEFAULT_PROMETHEUS_PORT)]
+    port: u16,
+
+    /// Bind address for headless Prometheus export
+    #[arg(long, default_value = "0.0.0.0")]
+    bind: IpAddr,
+
     /// Run once and write JSON results to PATH
     #[arg(long = "json-out", value_name = "PATH", conflicts_with_all = ["tui", "headless"])]
     json_out: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum ExportMode {
+    Prometheus,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -58,10 +80,8 @@ fn validate_args(args: &Args) -> Result<(), &'static str> {
     if args.duration.is_some() && selected_mode(args) != Mode::JsonOut {
         return Err("--duration can only be used with --json-out");
     }
-    if selected_mode(args) == Mode::Headless {
-        return Err(
-            "--headless is reserved for future daemon export modes; use --json-out <PATH> --duration <SECONDS> for finite JSON output",
-        );
+    if selected_mode(args) == Mode::Headless && args.export != Some(ExportMode::Prometheus) {
+        return Err("--headless requires --export prometheus");
     }
     Ok(())
 }
@@ -83,6 +103,9 @@ mod tests {
             rate: None,
             tui: false,
             headless: false,
+            export: None,
+            port: DEFAULT_PROMETHEUS_PORT,
+            bind: "0.0.0.0".parse().unwrap(),
             json_out: Some("results.json".to_string()),
         };
         let units = MeasurementUnitsConfig {
@@ -138,6 +161,9 @@ mod tests {
             rate: Some(5.0),
             tui: false,
             headless: false,
+            export: None,
+            port: DEFAULT_PROMETHEUS_PORT,
+            bind: "0.0.0.0".parse().unwrap(),
             json_out: None,
         };
         let mut config = EmtConfig::default();
@@ -169,6 +195,33 @@ mod tests {
 
         assert_eq!(selected_mode(&args), Mode::Headless);
         assert!(validate_args(&args).is_err());
+    }
+
+    #[test]
+    fn cli_accepts_headless_prometheus_export() {
+        let args = Args::parse_from([
+            "emt",
+            "--headless",
+            "--export",
+            "prometheus",
+            "--bind",
+            "127.0.0.1",
+            "--port",
+            "9200",
+        ]);
+
+        assert_eq!(selected_mode(&args), Mode::Headless);
+        assert_eq!(args.export, Some(ExportMode::Prometheus));
+        assert_eq!(args.bind, "127.0.0.1".parse::<IpAddr>().unwrap());
+        assert_eq!(args.port, 9200);
+        assert!(validate_args(&args).is_ok());
+    }
+
+    #[test]
+    fn cli_requires_headless_for_export() {
+        let result = Args::try_parse_from(["emt", "--export", "prometheus"]);
+
+        assert!(result.is_err());
     }
 
     #[test]
@@ -301,7 +354,7 @@ async fn main() {
 
     match mode {
         Mode::Tui => run_tui(config, args.pid).await,
-        Mode::Headless => unreachable!("headless mode is rejected by validate_args"),
+        Mode::Headless => run_prometheus_export(config, args.pid, args.bind, args.port).await,
         Mode::JsonOut => {
             let duration = batch_duration_seconds(&args);
             let path = args
@@ -348,6 +401,7 @@ async fn run_tui(config: EmtConfig, pid: Option<u32>) {
         std::env::var_os("EMT_TUI_FORCE_PANIC_AFTER_FIRST_DRAW").is_some();
 
     while !app.should_quit {
+        app.refresh();
         terminal
             .draw(|frame| tui::ui::render(frame, &app))
             .expect("Failed to draw");
@@ -407,4 +461,100 @@ async fn run_json_out(config: EmtConfig, args: &Args, duration_secs: u64, output
     file.write_all(json_output.as_bytes())
         .expect("Failed to write JSON output");
     eprintln!("JSON results written to: {output_path}");
+}
+
+async fn run_prometheus_export(config: EmtConfig, pid: Option<u32>, bind: IpAddr, port: u16) {
+    let update_interval = Duration::from_secs_f64((1.0 / config.collection.rate_hz).max(0.1));
+    let root_pids = pid.map(|p| vec![p]);
+    let mut monitor = Monitor::new(config, root_pids);
+
+    let handle = match monitor.commence().await {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("Failed to start monitoring: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let sink = Arc::new(Mutex::new(
+        PrometheusSink::new().expect("Failed to create Prometheus sink"),
+    ));
+    update_prometheus_sink(&sink, &handle.snapshot());
+
+    let app = prometheus_router(Arc::clone(&sink));
+    let address = SocketAddr::new(bind, port);
+    let listener = match tokio::net::TcpListener::bind(address).await {
+        Ok(listener) => listener,
+        Err(e) => {
+            eprintln!("Failed to bind Prometheus exporter on {address}: {e}");
+            let _ = monitor.shutdown().await;
+            std::process::exit(1);
+        }
+    };
+
+    eprintln!("Prometheus exporter listening on http://{address}/metrics");
+
+    let update_task = tokio::spawn(update_prometheus_sink_loop(
+        Arc::clone(&sink),
+        handle,
+        update_interval,
+    ));
+    let serve_result = axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await;
+
+    update_task.abort();
+    let _ = update_task.await;
+
+    if let Err(e) = monitor.shutdown().await {
+        eprintln!("Warning: Shutdown error: {e}");
+    }
+
+    if let Err(e) = serve_result {
+        eprintln!("Prometheus exporter error: {e}");
+        std::process::exit(1);
+    }
+}
+
+async fn update_prometheus_sink_loop(
+    sink: SharedPrometheusSink,
+    handle: MonitorHandle,
+    interval: Duration,
+) {
+    loop {
+        update_prometheus_sink(&sink, &handle.snapshot());
+        tokio::time::sleep(interval).await;
+    }
+}
+
+fn update_prometheus_sink(sink: &SharedPrometheusSink, snapshot: &MetricsSnapshot) {
+    sink.lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .update(snapshot);
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl-C handler");
+    };
+
+    #[cfg(unix)]
+    {
+        let terminate = async {
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                .expect("failed to install SIGTERM handler")
+                .recv()
+                .await;
+        };
+
+        tokio::select! {
+            _ = ctrl_c => {},
+            _ = terminate => {},
+        }
+    }
+
+    #[cfg(not(unix))]
+    ctrl_c.await;
 }

--- a/src/metrics_sink.rs
+++ b/src/metrics_sink.rs
@@ -149,7 +149,7 @@ impl From<&MetricsSnapshot> for PreviousSnapshot {
             workloads: snapshot
                 .workloads
                 .iter()
-                .map(|workload| (workload_label(workload), workload.energy.clone()))
+                .map(|workload| (workload_key(workload), workload.energy.clone()))
                 .collect(),
         }
     }
@@ -187,13 +187,14 @@ impl<T> LockUnpoisoned<T> for Mutex<T> {
 }
 
 fn energy_samples(snapshot: &MetricsSnapshot) -> Vec<MetricSample> {
-    let mut samples = device_samples("system", None, &snapshot.system_total);
+    let mut samples = device_samples("system", None, None, &snapshot.system_total);
 
     for workload in &snapshot.workloads {
-        let label = workload_label(workload);
+        let key = workload_key(workload);
         samples.extend(device_samples(
             "workload",
-            Some(label.as_str()),
+            Some(key.as_str()),
+            workload_name(workload),
             &workload.energy,
         ));
     }
@@ -215,19 +216,20 @@ fn power_samples(
     }
 
     let system_power = snapshot.system_total.saturating_sub(&previous.system_total);
-    let mut samples = device_power_samples("system", None, &system_power, elapsed_seconds);
+    let mut samples = device_power_samples("system", None, None, &system_power, elapsed_seconds);
 
     for workload in &snapshot.workloads {
-        let label = workload_label(workload);
+        let key = workload_key(workload);
         let power = previous
             .workloads
-            .get(&label)
+            .get(&key)
             .map(|previous_energy| workload.energy.saturating_sub(previous_energy))
             .unwrap_or_default();
 
         samples.extend(device_power_samples(
             "workload",
-            Some(label.as_str()),
+            Some(key.as_str()),
+            workload_name(workload),
             &power,
             elapsed_seconds,
         ));
@@ -238,13 +240,14 @@ fn power_samples(
 
 fn zero_power_samples(snapshot: &MetricsSnapshot) -> Vec<MetricSample> {
     let zero = DeviceEnergy::default();
-    let mut samples = device_power_samples("system", None, &zero, 1.0);
+    let mut samples = device_power_samples("system", None, None, &zero, 1.0);
 
     for workload in &snapshot.workloads {
-        let label = workload_label(workload);
+        let key = workload_key(workload);
         samples.extend(device_power_samples(
             "workload",
-            Some(label.as_str()),
+            Some(key.as_str()),
+            workload_name(workload),
             &zero,
             1.0,
         ));
@@ -255,13 +258,15 @@ fn zero_power_samples(snapshot: &MetricsSnapshot) -> Vec<MetricSample> {
 
 fn device_power_samples(
     scope: &'static str,
-    workload: Option<&str>,
+    workload_id: Option<&str>,
+    workload_name: Option<&str>,
     energy_delta: &DeviceEnergy,
     elapsed_seconds: f64,
 ) -> Vec<MetricSample> {
     device_samples(
         scope,
-        workload,
+        workload_id,
+        workload_name,
         &DeviceEnergy {
             cpu_joules: energy_delta.cpu_joules / elapsed_seconds,
             dram_joules: energy_delta.dram_joules / elapsed_seconds,
@@ -272,19 +277,27 @@ fn device_power_samples(
 
 fn device_samples(
     scope: &'static str,
-    workload: Option<&str>,
+    workload_id: Option<&str>,
+    workload_name: Option<&str>,
     energy: &DeviceEnergy,
 ) -> Vec<MetricSample> {
     vec![
-        metric_sample(scope, workload, "cpu", energy.cpu_joules),
-        metric_sample(scope, workload, "dram", energy.dram_joules),
-        metric_sample(scope, workload, "gpu", energy.gpu_joules),
+        metric_sample(scope, workload_id, workload_name, "cpu", energy.cpu_joules),
+        metric_sample(
+            scope,
+            workload_id,
+            workload_name,
+            "dram",
+            energy.dram_joules,
+        ),
+        metric_sample(scope, workload_id, workload_name, "gpu", energy.gpu_joules),
     ]
 }
 
 fn metric_sample(
     scope: &'static str,
-    workload: Option<&str>,
+    workload_id: Option<&str>,
+    workload_name: Option<&str>,
     device: &'static str,
     value: f64,
 ) -> MetricSample {
@@ -294,18 +307,29 @@ fn metric_sample(
         ("socket", SOCKET_LABEL.to_string()),
     ];
 
-    if let Some(workload) = workload {
-        labels.push(("workload", workload.to_string()));
+    if let Some(workload_id) = workload_id {
+        labels.push(("workload", workload_id.to_string()));
+    }
+    if let Some(workload_name) = workload_name {
+        labels.push(("workload_name", workload_name.to_string()));
     }
 
     MetricSample { value, labels }
 }
 
-fn workload_label(workload: &WorkloadSnapshot) -> String {
-    if workload.name.is_empty() {
-        workload.group_id.clone()
+fn workload_key(workload: &WorkloadSnapshot) -> String {
+    if workload.group_id.is_empty() {
+        format!("pid:{}", workload.root_pid)
     } else {
-        workload.name.clone()
+        workload.group_id.clone()
+    }
+}
+
+fn workload_name(workload: &WorkloadSnapshot) -> Option<&str> {
+    if workload.name.is_empty() {
+        None
+    } else {
+        Some(workload.name.as_str())
     }
 }
 
@@ -408,7 +432,7 @@ mod tests {
         );
         assert!(
             exposition.contains(
-                "emt_energy_joules_total{device=\"gpu\",scope=\"workload\",socket=\"0\",workload=\"render\"} 6"
+                "emt_energy_joules_total{device=\"gpu\",scope=\"workload\",socket=\"0\",workload=\"group-a\",workload_name=\"render\"} 6"
             ),
             "{exposition}"
         );
@@ -418,7 +442,7 @@ mod tests {
         );
         assert!(
             exposition.contains(
-                "emt_power_watts{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"render\"} 1"
+                "emt_power_watts{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"group-a\",workload_name=\"render\"} 1"
             ),
             "{exposition}"
         );
@@ -451,10 +475,57 @@ mod tests {
         );
         assert!(
             exposition.contains(
-                "emt_power_watts{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"render\"} 0"
+                "emt_power_watts{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"group-a\",workload_name=\"render\"} 0"
             ),
             "{exposition}"
         );
+    }
+
+    #[test]
+    fn prometheus_sink_keys_workloads_by_group_id_not_display_name() {
+        let mut sink = PrometheusSink::new().unwrap();
+        sink.update(&multi_workload_snapshot(
+            1_000,
+            vec![
+                workload("group-a", "python", energy(1.0, 0.0, 0.0)),
+                workload("group-b", "python", energy(100.0, 0.0, 0.0)),
+            ],
+        ));
+        sink.update(&multi_workload_snapshot(
+            3_000,
+            vec![
+                workload("group-a", "python", energy(3.0, 0.0, 0.0)),
+                workload("group-b", "python", energy(101.0, 0.0, 0.0)),
+            ],
+        ));
+
+        let exposition = sink.encode_text().unwrap();
+
+        assert!(
+            exposition.contains(
+                "emt_energy_joules_total{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"group-a\",workload_name=\"python\"} 3"
+            ),
+            "{exposition}"
+        );
+        assert!(
+            exposition.contains(
+                "emt_energy_joules_total{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"group-b\",workload_name=\"python\"} 101"
+            ),
+            "{exposition}"
+        );
+        assert!(
+            exposition.contains(
+                "emt_power_watts{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"group-a\",workload_name=\"python\"} 1"
+            ),
+            "{exposition}"
+        );
+        assert!(
+            exposition.contains(
+                "emt_power_watts{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"group-b\",workload_name=\"python\"} 0.5"
+            ),
+            "{exposition}"
+        );
+        assert!(!exposition.contains("workload=\"python\""));
     }
 
     #[tokio::test]
@@ -517,20 +588,61 @@ mod tests {
         system_total: DeviceEnergy,
         workload_energy: DeviceEnergy,
     ) -> MetricsSnapshot {
+        multi_workload_snapshot(
+            timestamp,
+            vec![workload("group-a", "render", workload_energy)],
+        )
+        .with_system_total(system_total)
+    }
+
+    fn multi_workload_snapshot(
+        timestamp: i64,
+        workloads: Vec<WorkloadSnapshot>,
+    ) -> MetricsSnapshot {
+        let system_total = DeviceEnergy {
+            cpu_joules: workloads
+                .iter()
+                .map(|workload| workload.energy.cpu_joules)
+                .sum(),
+            dram_joules: workloads
+                .iter()
+                .map(|workload| workload.energy.dram_joules)
+                .sum(),
+            gpu_joules: workloads
+                .iter()
+                .map(|workload| workload.energy.gpu_joules)
+                .sum(),
+        };
+
         MetricsSnapshot {
             timestamp,
             system_total,
-            workloads: vec![WorkloadSnapshot {
-                root_pid: 123,
-                group_id: "group-a".to_string(),
-                name: "render".to_string(),
-                user: "user".to_string(),
-                energy: workload_energy,
-                power_watts: 0.0,
-                percentage_of_system: 0.0,
-            }],
+            workloads,
             unattributed: DeviceEnergy::default(),
             tracked_pids: vec![123],
+        }
+    }
+
+    fn workload(group_id: &str, name: &str, energy: DeviceEnergy) -> WorkloadSnapshot {
+        WorkloadSnapshot {
+            root_pid: 123,
+            group_id: group_id.to_string(),
+            name: name.to_string(),
+            user: "user".to_string(),
+            energy,
+            power_watts: 0.0,
+            percentage_of_system: 0.0,
+        }
+    }
+
+    trait WithSystemTotal {
+        fn with_system_total(self, system_total: DeviceEnergy) -> Self;
+    }
+
+    impl WithSystemTotal for MetricsSnapshot {
+        fn with_system_total(mut self, system_total: DeviceEnergy) -> Self {
+            self.system_total = system_total;
+            self
         }
     }
 }

--- a/src/metrics_sink.rs
+++ b/src/metrics_sink.rs
@@ -1,0 +1,536 @@
+use crate::monitor::{DeviceEnergy, MetricsSnapshot, WorkloadSnapshot};
+use axum::Router;
+use axum::extract::State;
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use prometheus::core::{Collector, Desc};
+use prometheus::proto::{Counter, Gauge, LabelPair, Metric, MetricFamily, MetricType};
+use prometheus::{Encoder, Registry, TextEncoder};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+const SOCKET_LABEL: &str = "0";
+const ENERGY_METRIC: &str = "emt_energy_joules_total";
+const POWER_METRIC: &str = "emt_power_watts";
+const ENERGY_HELP: &str = "Cumulative EMT energy attribution in joules.";
+const POWER_HELP: &str = "EMT attributed power in watts.";
+
+pub type SharedPrometheusSink = Arc<Mutex<PrometheusSink>>;
+
+/// Receives point-in-time monitor snapshots and exports them to another system.
+pub trait MetricsSink {
+    fn update(&mut self, snapshot: &MetricsSnapshot);
+}
+
+/// Prometheus-backed sink for EMT monitor snapshots.
+///
+/// The sink owns a registry and registers one internal collector. It is ready to
+/// be wired into a future HTTP handler by calling [`PrometheusSink::gather`] or
+/// [`PrometheusSink::encode_text`].
+pub struct PrometheusSink {
+    registry: Registry,
+    state: Arc<Mutex<PrometheusState>>,
+}
+
+impl PrometheusSink {
+    pub fn new() -> Result<Self, prometheus::Error> {
+        Self::with_registry(Registry::new())
+    }
+
+    pub fn with_registry(registry: Registry) -> Result<Self, prometheus::Error> {
+        let state = Arc::new(Mutex::new(PrometheusState::default()));
+        registry.register(Box::new(SnapshotCollector {
+            state: Arc::clone(&state),
+        }))?;
+
+        Ok(Self { registry, state })
+    }
+
+    pub fn registry(&self) -> &Registry {
+        &self.registry
+    }
+
+    pub fn gather(&self) -> Vec<MetricFamily> {
+        self.registry.gather()
+    }
+
+    pub fn encode_text(&self) -> Result<String, prometheus::Error> {
+        TextEncoder::new().encode_to_string(&self.gather())
+    }
+}
+
+impl MetricsSink for PrometheusSink {
+    fn update(&mut self, snapshot: &MetricsSnapshot) {
+        self.state.lock_unpoisoned().update(snapshot);
+    }
+}
+
+pub fn prometheus_router(sink: SharedPrometheusSink) -> Router {
+    Router::new()
+        .route("/metrics", get(metrics_handler))
+        .route("/health", get(health_handler))
+        .with_state(sink)
+}
+
+async fn health_handler() -> StatusCode {
+    StatusCode::OK
+}
+
+async fn metrics_handler(State(sink): State<SharedPrometheusSink>) -> Response {
+    let encoded = sink
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .encode_text();
+
+    match encoded {
+        Ok(body) => (
+            [(
+                header::CONTENT_TYPE,
+                TextEncoder::new().format_type().to_string(),
+            )],
+            body,
+        )
+            .into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to encode metrics: {error}"),
+        )
+            .into_response(),
+    }
+}
+
+#[derive(Debug, Default)]
+struct PrometheusState {
+    previous: Option<PreviousSnapshot>,
+    energy_samples: Vec<MetricSample>,
+    power_samples: Vec<MetricSample>,
+}
+
+impl PrometheusState {
+    fn update(&mut self, snapshot: &MetricsSnapshot) {
+        let previous = self.previous.as_ref();
+
+        self.energy_samples = energy_samples(snapshot);
+        self.power_samples = power_samples(snapshot, previous);
+        self.previous = Some(PreviousSnapshot::from(snapshot));
+    }
+
+    fn collect(&self) -> Vec<MetricFamily> {
+        vec![
+            metric_family(
+                ENERGY_METRIC,
+                ENERGY_HELP,
+                MetricType::COUNTER,
+                &self.energy_samples,
+            ),
+            metric_family(
+                POWER_METRIC,
+                POWER_HELP,
+                MetricType::GAUGE,
+                &self.power_samples,
+            ),
+        ]
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PreviousSnapshot {
+    timestamp: i64,
+    system_total: DeviceEnergy,
+    workloads: HashMap<String, DeviceEnergy>,
+}
+
+impl From<&MetricsSnapshot> for PreviousSnapshot {
+    fn from(snapshot: &MetricsSnapshot) -> Self {
+        Self {
+            timestamp: snapshot.timestamp,
+            system_total: snapshot.system_total.clone(),
+            workloads: snapshot
+                .workloads
+                .iter()
+                .map(|workload| (workload_label(workload), workload.energy.clone()))
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct MetricSample {
+    value: f64,
+    labels: Vec<(&'static str, String)>,
+}
+
+#[derive(Clone)]
+struct SnapshotCollector {
+    state: Arc<Mutex<PrometheusState>>,
+}
+
+impl Collector for SnapshotCollector {
+    fn desc(&self) -> Vec<&Desc> {
+        Vec::new()
+    }
+
+    fn collect(&self) -> Vec<MetricFamily> {
+        self.state.lock_unpoisoned().collect()
+    }
+}
+
+trait LockUnpoisoned<T> {
+    fn lock_unpoisoned(&self) -> MutexGuard<'_, T>;
+}
+
+impl<T> LockUnpoisoned<T> for Mutex<T> {
+    fn lock_unpoisoned(&self) -> MutexGuard<'_, T> {
+        self.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+fn energy_samples(snapshot: &MetricsSnapshot) -> Vec<MetricSample> {
+    let mut samples = device_samples("system", None, &snapshot.system_total);
+
+    for workload in &snapshot.workloads {
+        let label = workload_label(workload);
+        samples.extend(device_samples(
+            "workload",
+            Some(label.as_str()),
+            &workload.energy,
+        ));
+    }
+
+    samples
+}
+
+fn power_samples(
+    snapshot: &MetricsSnapshot,
+    previous: Option<&PreviousSnapshot>,
+) -> Vec<MetricSample> {
+    let Some(previous) = previous else {
+        return zero_power_samples(snapshot);
+    };
+
+    let elapsed_seconds = (snapshot.timestamp - previous.timestamp) as f64 / 1_000.0;
+    if elapsed_seconds <= f64::EPSILON {
+        return zero_power_samples(snapshot);
+    }
+
+    let system_power = snapshot.system_total.saturating_sub(&previous.system_total);
+    let mut samples = device_power_samples("system", None, &system_power, elapsed_seconds);
+
+    for workload in &snapshot.workloads {
+        let label = workload_label(workload);
+        let power = previous
+            .workloads
+            .get(&label)
+            .map(|previous_energy| workload.energy.saturating_sub(previous_energy))
+            .unwrap_or_default();
+
+        samples.extend(device_power_samples(
+            "workload",
+            Some(label.as_str()),
+            &power,
+            elapsed_seconds,
+        ));
+    }
+
+    samples
+}
+
+fn zero_power_samples(snapshot: &MetricsSnapshot) -> Vec<MetricSample> {
+    let zero = DeviceEnergy::default();
+    let mut samples = device_power_samples("system", None, &zero, 1.0);
+
+    for workload in &snapshot.workloads {
+        let label = workload_label(workload);
+        samples.extend(device_power_samples(
+            "workload",
+            Some(label.as_str()),
+            &zero,
+            1.0,
+        ));
+    }
+
+    samples
+}
+
+fn device_power_samples(
+    scope: &'static str,
+    workload: Option<&str>,
+    energy_delta: &DeviceEnergy,
+    elapsed_seconds: f64,
+) -> Vec<MetricSample> {
+    device_samples(
+        scope,
+        workload,
+        &DeviceEnergy {
+            cpu_joules: energy_delta.cpu_joules / elapsed_seconds,
+            dram_joules: energy_delta.dram_joules / elapsed_seconds,
+            gpu_joules: energy_delta.gpu_joules / elapsed_seconds,
+        },
+    )
+}
+
+fn device_samples(
+    scope: &'static str,
+    workload: Option<&str>,
+    energy: &DeviceEnergy,
+) -> Vec<MetricSample> {
+    vec![
+        metric_sample(scope, workload, "cpu", energy.cpu_joules),
+        metric_sample(scope, workload, "dram", energy.dram_joules),
+        metric_sample(scope, workload, "gpu", energy.gpu_joules),
+    ]
+}
+
+fn metric_sample(
+    scope: &'static str,
+    workload: Option<&str>,
+    device: &'static str,
+    value: f64,
+) -> MetricSample {
+    let mut labels = vec![
+        ("scope", scope.to_string()),
+        ("device", device.to_string()),
+        ("socket", SOCKET_LABEL.to_string()),
+    ];
+
+    if let Some(workload) = workload {
+        labels.push(("workload", workload.to_string()));
+    }
+
+    MetricSample { value, labels }
+}
+
+fn workload_label(workload: &WorkloadSnapshot) -> String {
+    if workload.name.is_empty() {
+        workload.group_id.clone()
+    } else {
+        workload.name.clone()
+    }
+}
+
+fn metric_family(
+    name: &str,
+    help: &str,
+    metric_type: MetricType,
+    samples: &[MetricSample],
+) -> MetricFamily {
+    let mut family = MetricFamily::default();
+    family.set_name(name.to_string());
+    family.set_help(help.to_string());
+    family.set_field_type(metric_type);
+    family.set_metric(
+        samples
+            .iter()
+            .map(|sample| metric(metric_type, sample))
+            .collect(),
+    );
+    family
+}
+
+fn metric(metric_type: MetricType, sample: &MetricSample) -> Metric {
+    let mut metric = Metric::from_label(label_pairs(&sample.labels));
+    match metric_type {
+        MetricType::COUNTER => {
+            let mut counter = Counter::default();
+            counter.set_value(sample.value);
+            metric.set_counter(counter);
+        }
+        MetricType::GAUGE => {
+            let mut gauge = Gauge::default();
+            gauge.set_value(sample.value);
+            metric.set_gauge(gauge);
+        }
+        _ => unreachable!("metrics sink only exports counters and gauges"),
+    }
+    metric
+}
+
+fn label_pairs(labels: &[(&'static str, String)]) -> Vec<LabelPair> {
+    let mut pairs: Vec<LabelPair> = labels
+        .iter()
+        .map(|(name, value)| {
+            let mut label_pair = LabelPair::default();
+            label_pair.set_name((*name).to_string());
+            label_pair.set_value(value.clone());
+            label_pair
+        })
+        .collect();
+    pairs.sort();
+    pairs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::{Body, to_bytes};
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    #[test]
+    fn prometheus_sink_exports_energy_and_power_for_system_and_workloads() {
+        let mut sink = PrometheusSink::new().unwrap();
+        sink.update(&snapshot(
+            1_000,
+            DeviceEnergy {
+                cpu_joules: 10.0,
+                dram_joules: 4.0,
+                gpu_joules: 2.0,
+            },
+            DeviceEnergy {
+                cpu_joules: 2.0,
+                dram_joules: 1.0,
+                gpu_joules: 0.0,
+            },
+        ));
+        sink.update(&snapshot(
+            3_000,
+            DeviceEnergy {
+                cpu_joules: 16.0,
+                dram_joules: 10.0,
+                gpu_joules: 10.0,
+            },
+            DeviceEnergy {
+                cpu_joules: 4.0,
+                dram_joules: 3.0,
+                gpu_joules: 6.0,
+            },
+        ));
+
+        let exposition = sink.encode_text().unwrap();
+
+        assert!(exposition.contains("# HELP emt_energy_joules_total"));
+        assert!(
+            exposition.contains(
+                "emt_energy_joules_total{device=\"cpu\",scope=\"system\",socket=\"0\"} 16"
+            ),
+            "{exposition}"
+        );
+        assert!(
+            exposition.contains(
+                "emt_energy_joules_total{device=\"gpu\",scope=\"workload\",socket=\"0\",workload=\"render\"} 6"
+            ),
+            "{exposition}"
+        );
+        assert!(
+            exposition.contains("emt_power_watts{device=\"dram\",scope=\"system\",socket=\"0\"} 3"),
+            "{exposition}"
+        );
+        assert!(
+            exposition.contains(
+                "emt_power_watts{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"render\"} 1"
+            ),
+            "{exposition}"
+        );
+        assert!(!exposition.contains("root_pid"));
+        assert!(!exposition.contains("pid=\""));
+    }
+
+    #[test]
+    fn prometheus_sink_exports_zero_power_on_first_snapshot() {
+        let mut sink = PrometheusSink::new().unwrap();
+        sink.update(&snapshot(
+            1_000,
+            DeviceEnergy {
+                cpu_joules: 1.0,
+                dram_joules: 0.0,
+                gpu_joules: 0.0,
+            },
+            DeviceEnergy {
+                cpu_joules: 0.5,
+                dram_joules: 0.0,
+                gpu_joules: 0.0,
+            },
+        ));
+
+        let exposition = sink.encode_text().unwrap();
+
+        assert!(
+            exposition.contains("emt_power_watts{device=\"cpu\",scope=\"system\",socket=\"0\"} 0"),
+            "{exposition}"
+        );
+        assert!(
+            exposition.contains(
+                "emt_power_watts{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"render\"} 0"
+            ),
+            "{exposition}"
+        );
+    }
+
+    #[tokio::test]
+    async fn prometheus_router_serves_metrics_and_health() {
+        let sink = Arc::new(Mutex::new(PrometheusSink::new().unwrap()));
+        sink.lock().unwrap().update(&snapshot(
+            1_000,
+            energy(1.0, 0.0, 0.0),
+            energy(0.5, 0.0, 0.0),
+        ));
+        let app = prometheus_router(sink);
+
+        let metrics_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(metrics_response.status(), StatusCode::OK);
+        assert_eq!(
+            metrics_response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .unwrap(),
+            TextEncoder::new().format_type()
+        );
+        let metrics_body = to_bytes(metrics_response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let metrics_text = String::from_utf8(metrics_body.to_vec()).unwrap();
+        assert!(metrics_text.contains("# TYPE emt_energy_joules_total counter"));
+        assert!(metrics_text.contains("emt_energy_joules_total"));
+
+        let health_response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(health_response.status(), StatusCode::OK);
+    }
+
+    fn energy(cpu: f64, dram: f64, gpu: f64) -> DeviceEnergy {
+        DeviceEnergy {
+            cpu_joules: cpu,
+            dram_joules: dram,
+            gpu_joules: gpu,
+        }
+    }
+
+    fn snapshot(
+        timestamp: i64,
+        system_total: DeviceEnergy,
+        workload_energy: DeviceEnergy,
+    ) -> MetricsSnapshot {
+        MetricsSnapshot {
+            timestamp,
+            system_total,
+            workloads: vec![WorkloadSnapshot {
+                root_pid: 123,
+                group_id: "group-a".to_string(),
+                name: "render".to_string(),
+                user: "user".to_string(),
+                energy: workload_energy,
+                power_watts: 0.0,
+                percentage_of_system: 0.0,
+            }],
+            unattributed: DeviceEnergy::default(),
+            tracked_pids: vec![123],
+        }
+    }
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,5 +1,5 @@
+use crate::metrics_sink::MetricsSink;
 use crate::monitor::{DeviceEnergy, MetricsSnapshot, MonitorHandle};
-use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::time::Instant;
 
@@ -9,7 +9,7 @@ const POWER_HISTORY_MAX_SAMPLES: usize = 120;
 pub struct App {
     handle: MonitorHandle,
     start_time: Instant,
-    power_history: RefCell<RollingPowerHistory>,
+    sink: TuiSink,
     pub should_quit: bool,
 }
 
@@ -18,19 +18,18 @@ impl App {
         Self {
             handle,
             start_time: Instant::now(),
-            power_history: RefCell::new(RollingPowerHistory::default()),
+            sink: TuiSink::default(),
             should_quit: false,
         }
     }
 
-    pub fn snapshot(&self) -> MetricsSnapshot {
+    pub fn refresh(&mut self) {
         let snapshot = self.handle.snapshot();
-        if snapshot.timestamp > 0 {
-            self.power_history
-                .borrow_mut()
-                .record(snapshot.timestamp as f64 / 1_000.0, &snapshot.system_total);
-        }
-        snapshot
+        self.sink.update(&snapshot);
+    }
+
+    pub fn snapshot(&self) -> MetricsSnapshot {
+        self.sink.snapshot().clone()
     }
 
     pub fn uptime_secs(&self) -> f64 {
@@ -38,11 +37,37 @@ impl App {
     }
 
     pub fn power_history(&self) -> PowerHistorySnapshot {
-        self.power_history.borrow().snapshot()
+        self.sink.power_history()
     }
 
     pub fn quit(&mut self) {
         self.should_quit = true;
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TuiSink {
+    snapshot: MetricsSnapshot,
+    power_history: RollingPowerHistory,
+}
+
+impl TuiSink {
+    pub fn snapshot(&self) -> &MetricsSnapshot {
+        &self.snapshot
+    }
+
+    pub fn power_history(&self) -> PowerHistorySnapshot {
+        self.power_history.snapshot()
+    }
+}
+
+impl MetricsSink for TuiSink {
+    fn update(&mut self, snapshot: &MetricsSnapshot) {
+        if snapshot.timestamp > 0 {
+            self.power_history
+                .record(snapshot.timestamp as f64 / 1_000.0, &snapshot.system_total);
+        }
+        self.snapshot = snapshot.clone();
     }
 }
 
@@ -237,6 +262,26 @@ mod tests {
             dram_joules: dram,
             gpu_joules: gpu,
         }
+    }
+
+    fn snapshot(timestamp: i64, energy: DeviceEnergy) -> MetricsSnapshot {
+        MetricsSnapshot {
+            timestamp,
+            system_total: energy,
+            ..MetricsSnapshot::default()
+        }
+    }
+
+    #[test]
+    fn tui_sink_stores_latest_snapshot_and_power_history() {
+        let mut sink = TuiSink::default();
+
+        sink.update(&snapshot(1_000, energy(1.0, 0.0, 0.0)));
+        sink.update(&snapshot(3_000, energy(11.0, 4.0, 0.0)));
+
+        assert_eq!(sink.snapshot().system_total.cpu_joules, 11.0);
+        assert_eq!(sink.power_history().cpu, vec![5.0]);
+        assert_eq!(sink.power_history().dram, vec![2.0]);
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -2,4 +2,4 @@ pub mod app;
 pub mod event;
 pub mod ui;
 
-pub use app::App;
+pub use app::{App, TuiSink};


### PR DESCRIPTION
## Summary

- Add a `MetricsSink` trait plus `PrometheusSink` for `MetricsSnapshot` updates.
- Add `TuiSink` and refactor the TUI app refresh path through the sink abstraction.
- Implement `emt --headless --export prometheus` with `--bind` and `--port` flags.
- Serve Prometheus exposition at `/metrics` and health checks at `/health` with graceful SIGINT/SIGTERM shutdown.
- Export system and workload-level energy/power metrics without per-PID labels.

Linear: ENE-30

## Validation

```bash
cargo test metrics_sink
cargo test tui_sink --lib
cargo test cli_ --bin emt
cargo test
```

Live smoke:

```bash
cargo run -- --headless --export prometheus --bind 127.0.0.1 --port 19101
curl -fsS -i http://127.0.0.1:19101/health
curl -fsS http://127.0.0.1:19101/metrics
kill -TERM <exporter-pid>
```

Observed `/health` returned `HTTP/1.1 200 OK`, `/metrics` emitted Prometheus exposition with `emt_energy_joules_total` system/workload samples, and SIGTERM shut the process down cleanly.