### PR TITLE
ENE-27 Add TUI sort and reset controls

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -415,6 +415,8 @@ async fn run_tui(config: EmtConfig, pid: Option<u32>) {
         if let Some(event) = tui::event::poll(tick_rate) {
             match event {
                 tui::event::AppEvent::Quit => app.quit(),
+                tui::event::AppEvent::CycleSortMode => app.cycle_sort_mode(),
+                tui::event::AppEvent::ResetDisplay => app.reset_display(),
                 tui::event::AppEvent::Tick => {}
             }
         }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,5 +1,8 @@
 use crate::metrics_sink::MetricsSink;
 use crate::monitor::{DeviceEnergy, MetricsSnapshot, MonitorHandle};
+use crate::process_aggregation::percentage_of_system;
+use std::cmp::Ordering;
+use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::time::Instant;
 
@@ -10,6 +13,7 @@ pub struct App {
     handle: MonitorHandle,
     start_time: Instant,
     sink: TuiSink,
+    state: AppState,
     pub should_quit: bool,
 }
 
@@ -19,6 +23,7 @@ impl App {
             handle,
             start_time: Instant::now(),
             sink: TuiSink::default(),
+            state: AppState::default(),
             should_quit: false,
         }
     }
@@ -29,15 +34,33 @@ impl App {
     }
 
     pub fn snapshot(&self) -> MetricsSnapshot {
-        self.sink.snapshot().clone()
+        self.sink.display_snapshot(self.state.sort_mode)
     }
 
     pub fn uptime_secs(&self) -> f64 {
         self.start_time.elapsed().as_secs_f64()
     }
 
+    pub fn display_elapsed_secs(&self) -> f64 {
+        self.sink.display_elapsed_secs(self.uptime_secs())
+    }
+
     pub fn power_history(&self) -> PowerHistorySnapshot {
         self.sink.power_history()
+    }
+
+    pub fn sort_mode(&self) -> SortMode {
+        self.state.sort_mode
+    }
+
+    pub fn cycle_sort_mode(&mut self) {
+        self.state.cycle_sort_mode();
+    }
+
+    pub fn reset_display(&mut self) {
+        let snapshot = self.handle.snapshot();
+        self.sink.update(&snapshot);
+        self.sink.reset();
     }
 
     pub fn quit(&mut self) {
@@ -46,8 +69,46 @@ impl App {
 }
 
 #[derive(Debug, Clone, Default)]
+struct AppState {
+    sort_mode: SortMode,
+}
+
+impl AppState {
+    fn cycle_sort_mode(&mut self) {
+        self.sort_mode = self.sort_mode.next();
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SortMode {
+    #[default]
+    Energy,
+    Power,
+    Name,
+}
+
+impl SortMode {
+    fn next(self) -> Self {
+        match self {
+            Self::Energy => Self::Power,
+            Self::Power => Self::Name,
+            Self::Name => Self::Energy,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Energy => "energy",
+            Self::Power => "power",
+            Self::Name => "name",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
 pub struct TuiSink {
     snapshot: MetricsSnapshot,
+    baseline: Option<ResetBaseline>,
     power_history: RollingPowerHistory,
 }
 
@@ -56,8 +117,63 @@ impl TuiSink {
         &self.snapshot
     }
 
+    pub fn display_snapshot(&self, sort_mode: SortMode) -> MetricsSnapshot {
+        let mut snapshot = self.baseline_adjusted_snapshot();
+        sort_workloads(&mut snapshot.workloads, sort_mode);
+        snapshot
+    }
+
     pub fn power_history(&self) -> PowerHistorySnapshot {
         self.power_history.snapshot()
+    }
+
+    pub fn reset(&mut self) {
+        if self.snapshot.timestamp > 0 {
+            self.power_history.reset(Some((
+                timestamp_to_secs(self.snapshot.timestamp),
+                self.snapshot.system_total.clone(),
+            )));
+            self.baseline = Some(ResetBaseline::from(&self.snapshot));
+        } else {
+            self.power_history.reset(None);
+            self.baseline = None;
+        }
+    }
+
+    pub fn display_elapsed_secs(&self, fallback_secs: f64) -> f64 {
+        self.baseline
+            .as_ref()
+            .and_then(|baseline| baseline.elapsed_secs(self.snapshot.timestamp))
+            .unwrap_or(fallback_secs)
+    }
+
+    fn baseline_adjusted_snapshot(&self) -> MetricsSnapshot {
+        let mut snapshot = self.snapshot.clone();
+        let Some(baseline) = &self.baseline else {
+            return snapshot;
+        };
+
+        snapshot.system_total = snapshot.system_total.saturating_sub(&baseline.system_total);
+        snapshot.unattributed = snapshot.unattributed.saturating_sub(&baseline.unattributed);
+
+        let elapsed_secs = baseline.elapsed_secs(snapshot.timestamp).unwrap_or(0.0);
+        for workload in &mut snapshot.workloads {
+            let baseline_energy = baseline
+                .workloads
+                .get(&workload.group_id)
+                .cloned()
+                .unwrap_or_default();
+            workload.energy = workload.energy.saturating_sub(&baseline_energy);
+            workload.power_watts = if elapsed_secs > f64::EPSILON {
+                workload.energy.total() / elapsed_secs
+            } else {
+                0.0
+            };
+            workload.percentage_of_system =
+                percentage_of_system(&workload.energy, &snapshot.system_total);
+        }
+
+        snapshot
     }
 }
 
@@ -68,6 +184,40 @@ impl MetricsSink for TuiSink {
                 .record(snapshot.timestamp as f64 / 1_000.0, &snapshot.system_total);
         }
         self.snapshot = snapshot.clone();
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ResetBaseline {
+    timestamp: i64,
+    system_total: DeviceEnergy,
+    unattributed: DeviceEnergy,
+    workloads: HashMap<String, DeviceEnergy>,
+}
+
+impl ResetBaseline {
+    fn elapsed_secs(&self, timestamp: i64) -> Option<f64> {
+        let elapsed_secs = timestamp_to_secs(timestamp) - timestamp_to_secs(self.timestamp);
+        if elapsed_secs.is_finite() && elapsed_secs >= 0.0 {
+            Some(elapsed_secs)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<&MetricsSnapshot> for ResetBaseline {
+    fn from(snapshot: &MetricsSnapshot) -> Self {
+        Self {
+            timestamp: snapshot.timestamp,
+            system_total: snapshot.system_total.clone(),
+            unattributed: snapshot.unattributed.clone(),
+            workloads: snapshot
+                .workloads
+                .iter()
+                .map(|workload| (workload.group_id.clone(), workload.energy.clone()))
+                .collect(),
+        }
     }
 }
 
@@ -179,6 +329,15 @@ impl RollingPowerHistory {
         }
     }
 
+    fn reset(&mut self, previous: Option<(f64, DeviceEnergy)>) {
+        self.previous = previous
+            .filter(|(at_secs, _)| at_secs.is_finite() && *at_secs >= 0.0)
+            .map(|(at_secs, energy)| EnergySample { at_secs, energy });
+        self.cpu.clear();
+        self.dram.clear();
+        self.gpu.clear();
+    }
+
     fn record_component(
         samples: &mut VecDeque<PowerSample>,
         at_secs: f64,
@@ -240,6 +399,34 @@ impl RollingPowerHistory {
     }
 }
 
+fn timestamp_to_secs(timestamp: i64) -> f64 {
+    timestamp as f64 / 1_000.0
+}
+
+fn sort_workloads(workloads: &mut [crate::monitor::WorkloadSnapshot], sort_mode: SortMode) {
+    workloads.sort_by(|left, right| match sort_mode {
+        SortMode::Energy => compare_desc(right.energy.total(), left.energy.total())
+            .then_with(|| compare_names(left, right)),
+        SortMode::Power => compare_desc(right.power_watts, left.power_watts)
+            .then_with(|| compare_names(left, right)),
+        SortMode::Name => compare_names(left, right),
+    });
+}
+
+fn compare_desc(left: f64, right: f64) -> Ordering {
+    left.total_cmp(&right)
+}
+
+fn compare_names(
+    left: &crate::monitor::WorkloadSnapshot,
+    right: &crate::monitor::WorkloadSnapshot,
+) -> Ordering {
+    left.name
+        .cmp(&right.name)
+        .then_with(|| left.group_id.cmp(&right.group_id))
+        .then_with(|| left.root_pid.cmp(&right.root_pid))
+}
+
 #[derive(Debug, Clone)]
 struct EnergySample {
     at_secs: f64,
@@ -255,6 +442,7 @@ struct PowerSample {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::monitor::WorkloadSnapshot;
 
     fn energy(cpu: f64, dram: f64, gpu: f64) -> DeviceEnergy {
         DeviceEnergy {
@@ -272,6 +460,65 @@ mod tests {
         }
     }
 
+    fn workload(group_id: &str, name: &str, energy: DeviceEnergy) -> WorkloadSnapshot {
+        WorkloadSnapshot {
+            root_pid: 123,
+            group_id: group_id.to_string(),
+            name: name.to_string(),
+            user: "user".to_string(),
+            energy,
+            power_watts: 0.0,
+            percentage_of_system: 0.0,
+        }
+    }
+
+    #[test]
+    fn app_state_cycles_sort_modes_in_expected_order() {
+        let mut state = AppState::default();
+
+        assert_eq!(state.sort_mode, SortMode::Energy);
+        state.cycle_sort_mode();
+        assert_eq!(state.sort_mode, SortMode::Power);
+        state.cycle_sort_mode();
+        assert_eq!(state.sort_mode, SortMode::Name);
+        state.cycle_sort_mode();
+        assert_eq!(state.sort_mode, SortMode::Energy);
+    }
+
+    #[test]
+    fn tui_sink_sorts_workloads_by_selected_mode() {
+        let mut sink = TuiSink::default();
+        let mut snapshot = snapshot(1_000, energy(8.0, 0.0, 0.0));
+        snapshot.workloads = vec![
+            WorkloadSnapshot {
+                power_watts: 4.0,
+                ..workload("group-b", "beta", energy(2.0, 0.0, 0.0))
+            },
+            WorkloadSnapshot {
+                power_watts: 1.0,
+                ..workload("group-a", "alpha", energy(5.0, 0.0, 0.0))
+            },
+            WorkloadSnapshot {
+                power_watts: 9.0,
+                ..workload("group-c", "gamma", energy(1.0, 0.0, 0.0))
+            },
+        ];
+        sink.update(&snapshot);
+
+        assert_eq!(
+            workload_names(&sink.display_snapshot(SortMode::Energy)),
+            vec!["alpha", "beta", "gamma"]
+        );
+        assert_eq!(
+            workload_names(&sink.display_snapshot(SortMode::Power)),
+            vec!["gamma", "beta", "alpha"]
+        );
+        assert_eq!(
+            workload_names(&sink.display_snapshot(SortMode::Name)),
+            vec!["alpha", "beta", "gamma"]
+        );
+    }
+
     #[test]
     fn tui_sink_stores_latest_snapshot_and_power_history() {
         let mut sink = TuiSink::default();
@@ -282,6 +529,89 @@ mod tests {
         assert_eq!(sink.snapshot().system_total.cpu_joules, 11.0);
         assert_eq!(sink.power_history().cpu, vec![5.0]);
         assert_eq!(sink.power_history().dram, vec![2.0]);
+    }
+
+    #[test]
+    fn reset_zeroes_display_counters_and_preserves_workload_groups() {
+        let mut sink = TuiSink::default();
+        let mut before_reset = snapshot(2_000, energy(15.0, 6.0, 1.0));
+        before_reset.workloads = vec![
+            WorkloadSnapshot {
+                root_pid: 101,
+                power_watts: 5.0,
+                percentage_of_system: 60.0,
+                ..workload("pid:101", "compile", energy(10.0, 2.0, 1.0))
+            },
+            WorkloadSnapshot {
+                root_pid: 202,
+                power_watts: 3.0,
+                percentage_of_system: 40.0,
+                ..workload("pid:202", "test", energy(5.0, 4.0, 0.0))
+            },
+        ];
+        sink.update(&snapshot(1_000, energy(10.0, 3.0, 0.0)));
+        sink.update(&before_reset);
+
+        assert!(sink.power_history().has_samples());
+        sink.reset();
+
+        let display = sink.display_snapshot(SortMode::Energy);
+        assert_eq!(display.workloads.len(), 2);
+        assert_eq!(
+            display
+                .workloads
+                .iter()
+                .map(|workload| workload.group_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["pid:101", "pid:202"]
+        );
+        assert_eq!(display.system_total.total(), 0.0);
+        assert!(display.workloads.iter().all(|workload| {
+            workload.energy.total() == 0.0
+                && workload.power_watts == 0.0
+                && workload.percentage_of_system == 0.0
+        }));
+        assert!(!sink.power_history().has_samples());
+
+        let mut after_reset = snapshot(4_000, energy(20.0, 7.0, 2.0));
+        after_reset.workloads = vec![
+            WorkloadSnapshot {
+                root_pid: 101,
+                power_watts: 6.0,
+                ..workload("pid:101", "compile", energy(12.0, 4.0, 2.0))
+            },
+            WorkloadSnapshot {
+                root_pid: 202,
+                power_watts: 4.0,
+                ..workload("pid:202", "test", energy(8.0, 3.0, 0.0))
+            },
+        ];
+        sink.update(&after_reset);
+
+        let display = sink.display_snapshot(SortMode::Name);
+        assert_energy(&display.workloads[0].energy, &energy(2.0, 2.0, 1.0));
+        assert_eq!(display.workloads[0].power_watts, 2.5);
+        assert_energy(&display.workloads[1].energy, &energy(3.0, 0.0, 0.0));
+        assert_eq!(display.workloads[1].power_watts, 1.5);
+        assert_energy(&display.system_total, &energy(5.0, 1.0, 1.0));
+        assert_eq!(sink.power_history().cpu, vec![2.5]);
+    }
+
+    #[test]
+    fn reset_before_first_timestamp_does_not_use_epoch_sized_display_window() {
+        let mut sink = TuiSink::default();
+
+        sink.reset();
+        sink.update(&snapshot(1_700_000_000_000, energy(10.0, 0.0, 0.0)));
+
+        assert_eq!(sink.display_elapsed_secs(2.0), 2.0);
+        assert_eq!(
+            sink.display_snapshot(SortMode::Energy)
+                .system_total
+                .cpu_joules,
+            10.0
+        );
+        assert!(sink.power_history().cpu.is_empty());
     }
 
     #[test]
@@ -342,5 +672,19 @@ mod tests {
         history.record(0.5, &energy(10.0, 0.0, 0.0));
 
         assert!(history.snapshot().cpu.is_empty());
+    }
+
+    fn workload_names(snapshot: &MetricsSnapshot) -> Vec<&str> {
+        snapshot
+            .workloads
+            .iter()
+            .map(|workload| workload.name.as_str())
+            .collect()
+    }
+
+    fn assert_energy(actual: &DeviceEnergy, expected: &DeviceEnergy) {
+        assert_eq!(actual.cpu_joules, expected.cpu_joules);
+        assert_eq!(actual.dram_joules, expected.dram_joules);
+        assert_eq!(actual.gpu_joules, expected.gpu_joules);
     }
 }

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -4,6 +4,8 @@ use std::time::Duration;
 pub enum AppEvent {
     Tick,
     Quit,
+    CycleSortMode,
+    ResetDisplay,
 }
 
 pub fn poll(timeout: Duration) -> Option<AppEvent> {
@@ -18,6 +20,8 @@ pub fn poll(timeout: Duration) -> Option<AppEvent> {
 fn handle_key(key: KeyEvent) -> AppEvent {
     match key.code {
         KeyCode::Char('q') => AppEvent::Quit,
+        KeyCode::Char('s') => AppEvent::CycleSortMode,
+        KeyCode::Char('r') => AppEvent::ResetDisplay,
         KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => AppEvent::Quit,
         _ => AppEvent::Tick,
     }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,6 +1,6 @@
 use crate::monitor::MetricsSnapshot;
 use crate::tui::App;
-use crate::tui::app::PowerHistorySnapshot;
+use crate::tui::app::{PowerHistorySnapshot, SortMode};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -10,16 +10,27 @@ use ratatui::widgets::{Block, Borders, Paragraph, Row, Sparkline, Table};
 pub fn render(frame: &mut Frame, app: &App) {
     let snapshot = app.snapshot();
     let uptime = app.uptime_secs();
+    let display_elapsed = app.display_elapsed_secs();
     let power_history = app.power_history();
+    let sort_mode = app.sort_mode();
 
-    render_snapshot(frame, &snapshot, uptime, &power_history);
+    render_snapshot(
+        frame,
+        &snapshot,
+        uptime,
+        display_elapsed,
+        &power_history,
+        sort_mode,
+    );
 }
 
 fn render_snapshot(
     frame: &mut Frame,
     snapshot: &MetricsSnapshot,
     uptime: f64,
+    display_elapsed: f64,
     power_history: &PowerHistorySnapshot,
+    sort_mode: SortMode,
 ) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -30,9 +41,16 @@ fn render_snapshot(
         ])
         .split(frame.area());
 
-    render_header(frame, chunks[0], snapshot, uptime, power_history);
+    render_header(
+        frame,
+        chunks[0],
+        snapshot,
+        uptime,
+        display_elapsed,
+        power_history,
+    );
     render_body(frame, chunks[1], snapshot);
-    render_footer(frame, chunks[2]);
+    render_footer(frame, chunks[2], sort_mode);
 }
 
 fn render_header(
@@ -40,11 +58,12 @@ fn render_header(
     area: Rect,
     snapshot: &MetricsSnapshot,
     uptime: f64,
+    display_elapsed: f64,
     power_history: &PowerHistorySnapshot,
 ) {
     let total_energy = snapshot.system_total.total();
-    let power = if uptime > 0.0 {
-        total_energy / uptime
+    let power = if display_elapsed > 0.0 {
+        total_energy / display_elapsed
     } else {
         0.0
     };
@@ -275,10 +294,15 @@ fn render_body(frame: &mut Frame, area: Rect, snapshot: &MetricsSnapshot) {
     frame.render_widget(table, area);
 }
 
-fn render_footer(frame: &mut Frame, area: Rect) {
+fn render_footer(frame: &mut Frame, area: Rect, sort_mode: SortMode) {
     let footer = Paragraph::new(Line::from(vec![
         Span::styled(" q", Style::default().fg(Color::Red)),
         Span::raw(" quit"),
+        Span::styled("  s", Style::default().fg(Color::Cyan)),
+        Span::raw(" sort "),
+        Span::styled(sort_mode.label(), Style::default().fg(Color::Yellow)),
+        Span::styled("  r", Style::default().fg(Color::Cyan)),
+        Span::raw(" reset"),
     ]));
     frame.render_widget(footer, area);
 }
@@ -341,7 +365,16 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(120, 14)).unwrap();
 
         terminal
-            .draw(|frame| render_snapshot(frame, &snapshot, 60.0, &power_history))
+            .draw(|frame| {
+                render_snapshot(
+                    frame,
+                    &snapshot,
+                    60.0,
+                    60.0,
+                    &power_history,
+                    SortMode::Energy,
+                )
+            })
             .unwrap();
 
         let screen = terminal.backend().to_string();
@@ -354,6 +387,8 @@ mod tests {
         assert!(screen.contains("2.50"));
         assert!(screen.contains("python workload.py"));
         assert!(screen.contains("Tracked PIDs: 2"));
+        assert!(screen.contains("sort energy"));
+        assert!(screen.contains("reset"));
     }
 
     #[test]
@@ -382,7 +417,16 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(120, 14)).unwrap();
 
         terminal
-            .draw(|frame| render_snapshot(frame, &snapshot, 60.0, &power_history))
+            .draw(|frame| {
+                render_snapshot(
+                    frame,
+                    &snapshot,
+                    60.0,
+                    60.0,
+                    &power_history,
+                    SortMode::Energy,
+                )
+            })
             .unwrap();
 
         let screen = terminal.backend().to_string();


### PR DESCRIPTION
## Summary
- add `s` and `r` TUI controls for sort cycling and display-only reset
- sort workloads by energy, power, or name with deterministic tie breakers
- reset display totals by baselining from a fresh monitor snapshot while leaving collectors running
- clear interval sparklines on reset and keep the raw `TuiSink::snapshot()` accessor for compatibility
- show active sort mode and reset affordance in the footer

## Validation
- `cargo fmt --all`
- `cargo test tui::app --lib --quiet`
- `cargo test tui::ui --lib --bin emt --quiet`
- `cargo test --quiet`
- `git diff --check`
- independent review plus second pass: no remaining blockers

## Rebase
Rebased on `main` after ENE-28 / PR #64 merged, preserving the GPU availability TUI behavior. Rebased validation: `cargo fmt --all`, focused TUI tests, `cargo test --quiet`, and `git diff --check`.

Linear: ENE-27