### PR TITLE
ENE-26 Add TUI expand/collapse navigation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,7 @@ mod tests {
                 group_id: "pid:123".to_string(),
                 name: "work".to_string(),
                 user: "user".to_string(),
+                processes: Vec::new(),
                 energy: DeviceEnergy {
                     cpu_joules: 2_700.0,
                     dram_joules: 900.0,
@@ -417,6 +418,10 @@ async fn run_tui(config: EmtConfig, pid: Option<u32>) {
                 tui::event::AppEvent::Quit => app.quit(),
                 tui::event::AppEvent::CycleSortMode => app.cycle_sort_mode(),
                 tui::event::AppEvent::ResetDisplay => app.reset_display(),
+                tui::event::AppEvent::SelectPrevious => app.select_previous(),
+                tui::event::AppEvent::SelectNext => app.select_next(),
+                tui::event::AppEvent::ExpandSelected => app.expand_selected(),
+                tui::event::AppEvent::CollapseSelected => app.collapse_selected(),
                 tui::event::AppEvent::Tick => {}
             }
         }

--- a/src/metrics_sink.rs
+++ b/src/metrics_sink.rs
@@ -630,6 +630,7 @@ mod tests {
             group_id: group_id.to_string(),
             name: name.to_string(),
             user: "user".to_string(),
+            processes: Vec::new(),
             energy,
             power_watts: 0.0,
             percentage_of_system: 0.0,

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -40,6 +40,15 @@ impl DeviceEnergy {
     }
 }
 
+/// Per-process energy and power snapshot nested under a workload group.
+#[derive(Debug, Clone)]
+pub struct ProcessEnergySnapshot {
+    pub pid: u32,
+    pub name: String,
+    pub energy: DeviceEnergy,
+    pub power_watts: f64,
+}
+
 /// Per-workload (root process) energy and power snapshot.
 #[derive(Debug, Clone)]
 pub struct WorkloadSnapshot {
@@ -47,6 +56,7 @@ pub struct WorkloadSnapshot {
     pub group_id: String,
     pub name: String,
     pub user: String,
+    pub processes: Vec<ProcessEnergySnapshot>,
     pub energy: DeviceEnergy,
     pub power_watts: f64,
     pub percentage_of_system: f64,
@@ -97,6 +107,7 @@ fn system_total_from_workloads(
 fn workload_snapshot(
     group: &ProcessGroup,
     energy: DeviceEnergy,
+    processes: Vec<ProcessEnergySnapshot>,
     elapsed_s: f64,
 ) -> WorkloadSnapshot {
     let power_watts = if elapsed_s > 0.0 {
@@ -110,10 +121,54 @@ fn workload_snapshot(
         group_id: group.id.clone(),
         name: group.name.clone(),
         user: group.user.clone(),
+        processes,
         energy,
         power_watts,
         percentage_of_system: 0.0,
     }
+}
+
+fn process_energy_snapshot(
+    pid: u32,
+    name: String,
+    energy: DeviceEnergy,
+    elapsed_s: f64,
+) -> ProcessEnergySnapshot {
+    let power_watts = if elapsed_s > 0.0 {
+        energy.total() / elapsed_s
+    } else {
+        0.0
+    };
+
+    ProcessEnergySnapshot {
+        pid,
+        name,
+        energy,
+        power_watts,
+    }
+}
+
+fn process_snapshots_for_group(
+    group: &ProcessGroup,
+    cumulative_by_pid: &HashMap<u32, DeviceEnergy>,
+    process_names: &HashMap<u32, String>,
+    elapsed_s: f64,
+) -> Vec<ProcessEnergySnapshot> {
+    let mut pids = group.pids.clone();
+    pids.extend(cumulative_by_pid.keys().copied());
+    pids.sort_unstable();
+    pids.dedup();
+
+    pids.into_iter()
+        .map(|pid| {
+            let energy = cumulative_by_pid.get(&pid).cloned().unwrap_or_default();
+            let name = process_names
+                .get(&pid)
+                .cloned()
+                .unwrap_or_else(|| format!("pid {pid}"));
+            process_energy_snapshot(pid, name, energy, elapsed_s)
+        })
+        .collect()
 }
 
 fn apply_workload_percentages(workloads: &mut [WorkloadSnapshot], system_total: &DeviceEnergy) {
@@ -236,6 +291,18 @@ fn merge_pid_group_maps(
     merged
 }
 
+fn retained_pid_to_group_map(workloads: &[WorkloadSnapshot]) -> HashMap<u32, String> {
+    workloads
+        .iter()
+        .flat_map(|workload| {
+            workload
+                .processes
+                .iter()
+                .map(|process| (process.pid, workload.group_id.clone()))
+        })
+        .collect()
+}
+
 // ─── MonitorHandle ──────────────────────────────────────────────────────────
 
 /// A cloneable handle providing read-only access to the latest monitor state.
@@ -275,6 +342,9 @@ impl MonitorHandle {
 struct TickState {
     start_timestamp: i64,
     workload_energy: HashMap<String, DeviceEnergy>,
+    pid_energy: HashMap<u32, DeviceEnergy>,
+    pid_to_group: HashMap<u32, String>,
+    process_names: HashMap<u32, String>,
 }
 
 impl Default for TickState {
@@ -282,6 +352,9 @@ impl Default for TickState {
         Self {
             start_timestamp: 0,
             workload_energy: HashMap::new(),
+            pid_energy: HashMap::new(),
+            pid_to_group: HashMap::new(),
+            process_names: HashMap::new(),
         }
     }
 }
@@ -466,7 +539,12 @@ impl Monitor {
             return;
         }
 
-        let pid_to_group = self.last_pid_to_group.read().unwrap().clone();
+        let retained_pid_to_group = {
+            let snap = self.snapshot.read().unwrap();
+            retained_pid_to_group_map(&snap.workloads)
+        };
+        let current_pid_to_group = self.last_pid_to_group.read().unwrap().clone();
+        let pid_to_group = merge_pid_group_maps(&current_pid_to_group, &retained_pid_to_group);
         let tick = aggregate_energy_records(final_records, &pid_to_group);
         if tick.system_total.total() <= 0.0 && tick.group_energy.is_empty() {
             return;
@@ -517,9 +595,33 @@ impl Monitor {
             .iter()
             .map(|workload| (workload.group_id.clone(), workload.energy.clone()))
             .collect();
+        let mut cumulative_by_pid: HashMap<u32, DeviceEnergy> = snap
+            .workloads
+            .iter()
+            .flat_map(|workload| {
+                workload
+                    .processes
+                    .iter()
+                    .map(|process| (process.pid, process.energy.clone()))
+            })
+            .collect();
+        let process_names: HashMap<u32, String> = snap
+            .workloads
+            .iter()
+            .flat_map(|workload| {
+                workload
+                    .processes
+                    .iter()
+                    .map(|process| (process.pid, process.name.clone()))
+            })
+            .collect();
 
         for (group_id, tick_energy) in &tick.group_energy {
             let entry = cumulative_by_group.entry(group_id.clone()).or_default();
+            add_device_energy(entry, tick_energy);
+        }
+        for (pid, tick_energy) in &tick.pid_energy {
+            let entry = cumulative_by_pid.entry(*pid).or_default();
             add_device_energy(entry, tick_energy);
         }
         add_device_energy(&mut snap.unattributed, &tick.unattributed);
@@ -535,7 +637,18 @@ impl Monitor {
                     return None;
                 }
 
-                Some(workload_snapshot(group, energy, elapsed_s))
+                let processes = process_snapshots_for_group(
+                    group,
+                    &pid_energy_for_group(
+                        &group.id,
+                        &group.pids,
+                        &cumulative_by_pid,
+                        &pid_to_group,
+                    ),
+                    &process_names,
+                    elapsed_s,
+                );
+                Some(workload_snapshot(group, energy, processes, elapsed_s))
             })
             .collect();
         workloads.sort_by(|left, right| left.group_id.cmp(&right.group_id));
@@ -620,6 +733,13 @@ impl Monitor {
 
                 let known_groups_snapshot = known_groups.read().unwrap().clone();
                 let mut workloads: Vec<WorkloadSnapshot> = Vec::new();
+                resolve_missing_process_names(&expanded_pids, &mut tick_state.process_names);
+                for (pid, tick_energy) in &tick.pid_energy {
+                    let entry = tick_state.pid_energy.entry(*pid).or_default();
+                    add_device_energy(entry, tick_energy);
+                }
+                tick_state.pid_to_group =
+                    merge_pid_group_maps(&current_pid_to_group, &tick_state.pid_to_group);
 
                 for group in known_groups_snapshot.values() {
                     let tick_energy = tick
@@ -638,7 +758,23 @@ impl Monitor {
                         continue;
                     }
 
-                    workloads.push(workload_snapshot(group, cumulative_energy, elapsed_s));
+                    let processes = process_snapshots_for_group(
+                        group,
+                        &pid_energy_for_group(
+                            &group.id,
+                            &group.pids,
+                            &tick_state.pid_energy,
+                            &tick_state.pid_to_group,
+                        ),
+                        &tick_state.process_names,
+                        elapsed_s,
+                    );
+                    workloads.push(workload_snapshot(
+                        group,
+                        cumulative_energy,
+                        processes,
+                        elapsed_s,
+                    ));
                 }
                 workloads.sort_by(|left, right| left.group_id.cmp(&right.group_id));
 
@@ -687,6 +823,60 @@ impl Monitor {
                 tokio::time::sleep(interval).await;
             }
         }));
+    }
+}
+
+fn pid_energy_for_group(
+    group_id: &str,
+    live_pids: &[u32],
+    cumulative_by_pid: &HashMap<u32, DeviceEnergy>,
+    pid_to_group: &HashMap<u32, String>,
+) -> HashMap<u32, DeviceEnergy> {
+    let mut result = HashMap::new();
+
+    for pid in live_pids {
+        if let Some(energy) = cumulative_by_pid.get(pid) {
+            result.insert(*pid, energy.clone());
+        }
+    }
+
+    for (pid, mapped_group_id) in pid_to_group {
+        if mapped_group_id == group_id {
+            if let Some(energy) = cumulative_by_pid.get(pid) {
+                result.insert(*pid, energy.clone());
+            }
+        }
+    }
+
+    result
+}
+
+fn resolve_missing_process_names(pids: &[u32], process_names: &mut HashMap<u32, String>) {
+    let missing_pids: Vec<u32> = pids
+        .iter()
+        .copied()
+        .filter(|pid| !process_names.contains_key(pid))
+        .collect();
+    if missing_pids.is_empty() {
+        return;
+    }
+
+    use sysinfo::System;
+
+    let system = System::new_all();
+    for pid in missing_pids {
+        let name = system
+            .process(sysinfo::Pid::from_u32(pid))
+            .map(|process| {
+                let name = process.name().to_string_lossy().to_string();
+                if name.is_empty() {
+                    format!("pid {pid}")
+                } else {
+                    name
+                }
+            })
+            .unwrap_or_else(|| format!("pid {pid}"));
+        process_names.insert(pid, name);
     }
 }
 
@@ -756,6 +946,93 @@ mod tests {
         assert_eq!(refreshed[0].name, "cached-root");
         assert_eq!(refreshed[0].user, "cached-user");
         assert!(refreshed[0].pids.contains(&pid));
+    }
+
+    #[test]
+    fn process_snapshots_for_group_include_pid_energy_power_and_names() {
+        let group = ProcessGroup {
+            id: "pid:123".to_string(),
+            name: "workload".to_string(),
+            user: "user".to_string(),
+            pids: vec![123, 456],
+            representative_pid: 123,
+        };
+        let cumulative_by_pid = HashMap::from([(
+            123,
+            DeviceEnergy {
+                cpu_joules: 3.0,
+                dram_joules: 1.0,
+                gpu_joules: 0.0,
+            },
+        )]);
+        let process_names = HashMap::from([(123, "python".to_string())]);
+
+        let processes =
+            process_snapshots_for_group(&group, &cumulative_by_pid, &process_names, 2.0);
+
+        assert_eq!(processes.len(), 2);
+        assert_eq!(processes[0].pid, 123);
+        assert_eq!(processes[0].name, "python");
+        assert_eq!(processes[0].energy.total(), 4.0);
+        assert_eq!(processes[0].power_watts, 2.0);
+        assert_eq!(processes[1].pid, 456);
+        assert_eq!(processes[1].name, "pid 456");
+        assert_eq!(processes[1].energy.total(), 0.0);
+        assert_eq!(processes[1].power_watts, 0.0);
+    }
+
+    #[test]
+    fn pid_energy_for_group_keeps_previously_mapped_exited_pids() {
+        let cumulative_by_pid = HashMap::from([
+            (
+                123,
+                DeviceEnergy {
+                    cpu_joules: 2.0,
+                    dram_joules: 0.0,
+                    gpu_joules: 0.0,
+                },
+            ),
+            (
+                456,
+                DeviceEnergy {
+                    cpu_joules: 3.0,
+                    dram_joules: 0.0,
+                    gpu_joules: 0.0,
+                },
+            ),
+        ]);
+        let pid_to_group =
+            HashMap::from([(123, "pid:123".to_string()), (456, "pid:123".to_string())]);
+
+        let group_energy =
+            pid_energy_for_group("pid:123", &[123], &cumulative_by_pid, &pid_to_group);
+
+        assert_eq!(group_energy.len(), 2);
+        assert_eq!(group_energy.get(&123).unwrap().total(), 2.0);
+        assert_eq!(group_energy.get(&456).unwrap().total(), 3.0);
+    }
+
+    #[test]
+    fn retained_pid_to_group_map_preserves_existing_process_rows() {
+        let workloads = vec![WorkloadSnapshot {
+            root_pid: 123,
+            group_id: "pid:123".to_string(),
+            name: "workload".to_string(),
+            user: "user".to_string(),
+            processes: vec![ProcessEnergySnapshot {
+                pid: 456,
+                name: "child".to_string(),
+                energy: DeviceEnergy::default(),
+                power_watts: 0.0,
+            }],
+            energy: DeviceEnergy::default(),
+            power_watts: 0.0,
+            percentage_of_system: 0.0,
+        }];
+
+        let retained = retained_pid_to_group_map(&workloads);
+
+        assert_eq!(retained.get(&456), Some(&"pid:123".to_string()));
     }
 
     #[test]

--- a/src/process_aggregation.rs
+++ b/src/process_aggregation.rs
@@ -13,6 +13,7 @@ pub enum AggregatedDeviceClass {
 pub struct GroupedEnergyTick {
     pub system_total: DeviceEnergy,
     pub group_energy: HashMap<String, DeviceEnergy>,
+    pub pid_energy: HashMap<u32, DeviceEnergy>,
     pub unattributed: DeviceEnergy,
 }
 
@@ -32,6 +33,7 @@ pub fn aggregate_energy_records(
 ) -> GroupedEnergyTick {
     let mut system_total = DeviceEnergy::default();
     let mut group_energy: HashMap<String, DeviceEnergy> = HashMap::new();
+    let mut pid_energy: HashMap<u32, DeviceEnergy> = HashMap::new();
     let mut groups_sum = DeviceEnergy::default();
 
     for record in records {
@@ -41,6 +43,8 @@ pub fn aggregate_energy_records(
         if let Some(group_id) = pid_to_group.get(&record.pid) {
             let entry = group_energy.entry(group_id.clone()).or_default();
             accumulate_device_energy(entry, device_class, record.energy);
+            let pid_entry = pid_energy.entry(record.pid).or_default();
+            accumulate_device_energy(pid_entry, device_class, record.energy);
             accumulate_device_energy(&mut groups_sum, device_class, record.energy);
         }
     }
@@ -50,6 +54,7 @@ pub fn aggregate_energy_records(
     GroupedEnergyTick {
         system_total,
         group_energy,
+        pid_energy,
         unattributed,
     }
 }
@@ -131,6 +136,9 @@ mod tests {
         assert_close(group.cpu_joules, 2.0);
         assert_close(group.dram_joules, 0.5);
         assert_close(group.gpu_joules, 3.0);
+        assert_close(tick.pid_energy.get(&101).unwrap().cpu_joules, 2.0);
+        assert_close(tick.pid_energy.get(&102).unwrap().dram_joules, 0.5);
+        assert_close(tick.pid_energy.get(&102).unwrap().gpu_joules, 3.0);
         assert_close(tick.system_total.total(), 5.5);
         assert_close(tick.unattributed.total(), 0.0);
     }
@@ -153,6 +161,7 @@ mod tests {
         assert_close(tick.unattributed.dram_joules, 0.75);
         assert_close(tick.unattributed.gpu_joules, 1.25);
         assert!(!tick.group_energy.contains_key("999"));
+        assert!(!tick.pid_energy.contains_key(&999));
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,9 +1,8 @@
 use crate::metrics_sink::MetricsSink;
-use crate::monitor::{DeviceEnergy, MetricsSnapshot, MonitorHandle};
+use crate::monitor::{DeviceEnergy, MetricsSnapshot, MonitorHandle, WorkloadSnapshot};
 use crate::process_aggregation::percentage_of_system;
 use std::cmp::Ordering;
-use std::collections::HashMap;
-use std::collections::VecDeque;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::Instant;
 
 const POWER_HISTORY_WINDOW_SECS: f64 = 60.0;
@@ -29,8 +28,10 @@ impl App {
     }
 
     pub fn refresh(&mut self) {
+        let selected_group_id = self.selected_group_id();
         let snapshot = self.handle.snapshot();
         self.sink.update(&snapshot);
+        self.restore_selection(selected_group_id);
     }
 
     pub fn snapshot(&self) -> MetricsSnapshot {
@@ -54,28 +55,207 @@ impl App {
     }
 
     pub fn cycle_sort_mode(&mut self) {
+        let selected_group_id = self.selected_group_id();
         self.state.cycle_sort_mode();
+        self.restore_selection(selected_group_id);
     }
 
     pub fn reset_display(&mut self) {
+        let selected_group_id = self.selected_group_id();
         let snapshot = self.handle.snapshot();
         self.sink.update(&snapshot);
         self.sink.reset();
+        self.restore_selection(selected_group_id);
+    }
+
+    pub fn selected_group_index(&self) -> usize {
+        self.state.selected_group_index
+    }
+
+    pub fn expanded_group_ids(&self) -> &HashSet<String> {
+        &self.state.expanded_group_ids
+    }
+
+    pub fn child_scroll_offsets(&self) -> &HashMap<String, usize> {
+        &self.state.child_scroll_offsets
+    }
+
+    pub fn select_previous(&mut self) {
+        if self.scroll_selected_children_previous() {
+            return;
+        }
+        self.state.select_previous();
+    }
+
+    pub fn select_next(&mut self) {
+        if self.scroll_selected_children_next() {
+            return;
+        }
+        let workload_count = self.current_workload_count();
+        self.state.select_next(workload_count);
+    }
+
+    pub fn expand_selected(&mut self) {
+        if let Some(group_id) = self.selected_group_id() {
+            self.state.expand_group(group_id);
+        }
+    }
+
+    pub fn collapse_selected(&mut self) {
+        if let Some(group_id) = self.selected_group_id() {
+            self.state.collapse_group(&group_id);
+        }
     }
 
     pub fn quit(&mut self) {
         self.should_quit = true;
+    }
+
+    fn selected_group_id(&self) -> Option<String> {
+        self.sink
+            .display_snapshot(self.state.sort_mode)
+            .workloads
+            .get(self.state.selected_group_index)
+            .map(|workload| workload.group_id.clone())
+    }
+
+    fn restore_selection(&mut self, selected_group_id: Option<String>) {
+        let snapshot = self.sink.display_snapshot(self.state.sort_mode);
+        if let Some(group_id) = selected_group_id {
+            if let Some(index) = snapshot
+                .workloads
+                .iter()
+                .position(|workload| workload.group_id == group_id)
+            {
+                self.state.selected_group_index = index;
+                self.state.clamp_child_scroll_offsets(&snapshot.workloads);
+                return;
+            }
+        }
+        self.state.clamp_selection(snapshot.workloads.len());
+        self.state.clamp_child_scroll_offsets(&snapshot.workloads);
+    }
+
+    fn current_workload_count(&self) -> usize {
+        self.sink
+            .display_snapshot(self.state.sort_mode)
+            .workloads
+            .len()
+    }
+
+    fn scroll_selected_children_next(&mut self) -> bool {
+        let snapshot = self.sink.display_snapshot(self.state.sort_mode);
+        let Some(workload) = snapshot.workloads.get(self.state.selected_group_index) else {
+            return false;
+        };
+        if !self.state.expanded_group_ids.contains(&workload.group_id) {
+            return false;
+        }
+
+        self.state
+            .scroll_children_next(&workload.group_id, workload.processes.len())
+    }
+
+    fn scroll_selected_children_previous(&mut self) -> bool {
+        let Some(group_id) = self.selected_group_id() else {
+            return false;
+        };
+        if !self.state.expanded_group_ids.contains(&group_id) {
+            return false;
+        }
+
+        self.state.scroll_children_previous(&group_id)
     }
 }
 
 #[derive(Debug, Clone, Default)]
 struct AppState {
     sort_mode: SortMode,
+    selected_group_index: usize,
+    expanded_group_ids: HashSet<String>,
+    child_scroll_offsets: HashMap<String, usize>,
 }
 
 impl AppState {
     fn cycle_sort_mode(&mut self) {
         self.sort_mode = self.sort_mode.next();
+    }
+
+    fn select_previous(&mut self) {
+        self.selected_group_index = self.selected_group_index.saturating_sub(1);
+    }
+
+    fn select_next(&mut self, workload_count: usize) {
+        if workload_count == 0 {
+            self.selected_group_index = 0;
+            return;
+        }
+
+        let last_index = workload_count - 1;
+        self.selected_group_index = (self.selected_group_index + 1).min(last_index);
+    }
+
+    fn clamp_selection(&mut self, workload_count: usize) {
+        if workload_count == 0 {
+            self.selected_group_index = 0;
+        } else {
+            self.selected_group_index = self.selected_group_index.min(workload_count - 1);
+        }
+    }
+
+    fn expand_group(&mut self, group_id: String) {
+        self.expanded_group_ids.insert(group_id);
+    }
+
+    fn collapse_group(&mut self, group_id: &str) {
+        self.expanded_group_ids.remove(group_id);
+    }
+
+    fn scroll_children_next(&mut self, group_id: &str, child_count: usize) -> bool {
+        if child_count <= 1 {
+            return false;
+        }
+
+        let offset = self
+            .child_scroll_offsets
+            .entry(group_id.to_string())
+            .or_default();
+        if *offset + 1 >= child_count {
+            return false;
+        }
+
+        *offset += 1;
+        true
+    }
+
+    fn scroll_children_previous(&mut self, group_id: &str) -> bool {
+        if let Some(offset) = self.child_scroll_offsets.get_mut(group_id) {
+            if *offset == 0 {
+                return false;
+            }
+            *offset = offset.saturating_sub(1);
+            return true;
+        }
+
+        false
+    }
+
+    fn clamp_child_scroll_offsets(&mut self, workloads: &[WorkloadSnapshot]) {
+        let child_counts: HashMap<&str, usize> = workloads
+            .iter()
+            .map(|workload| (workload.group_id.as_str(), workload.processes.len()))
+            .collect();
+
+        self.child_scroll_offsets
+            .retain(|group_id, _| child_counts.contains_key(group_id.as_str()));
+        for (group_id, offset) in &mut self.child_scroll_offsets {
+            let max_offset = child_counts
+                .get(group_id.as_str())
+                .copied()
+                .unwrap_or_default()
+                .saturating_sub(1);
+            *offset = (*offset).min(max_offset);
+        }
     }
 }
 
@@ -171,6 +351,20 @@ impl TuiSink {
             };
             workload.percentage_of_system =
                 percentage_of_system(&workload.energy, &snapshot.system_total);
+
+            for process in &mut workload.processes {
+                let baseline_energy = baseline
+                    .processes
+                    .get(&(workload.group_id.clone(), process.pid))
+                    .cloned()
+                    .unwrap_or_default();
+                process.energy = process.energy.saturating_sub(&baseline_energy);
+                process.power_watts = if elapsed_secs > f64::EPSILON {
+                    process.energy.total() / elapsed_secs
+                } else {
+                    0.0
+                };
+            }
         }
 
         snapshot
@@ -193,6 +387,7 @@ struct ResetBaseline {
     system_total: DeviceEnergy,
     unattributed: DeviceEnergy,
     workloads: HashMap<String, DeviceEnergy>,
+    processes: HashMap<(String, u32), DeviceEnergy>,
 }
 
 impl ResetBaseline {
@@ -216,6 +411,18 @@ impl From<&MetricsSnapshot> for ResetBaseline {
                 .workloads
                 .iter()
                 .map(|workload| (workload.group_id.clone(), workload.energy.clone()))
+                .collect(),
+            processes: snapshot
+                .workloads
+                .iter()
+                .flat_map(|workload| {
+                    workload.processes.iter().map(|process| {
+                        (
+                            (workload.group_id.clone(), process.pid),
+                            process.energy.clone(),
+                        )
+                    })
+                })
                 .collect(),
         }
     }
@@ -442,7 +649,7 @@ struct PowerSample {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::monitor::WorkloadSnapshot;
+    use crate::monitor::{ProcessEnergySnapshot, WorkloadSnapshot};
 
     fn energy(cpu: f64, dram: f64, gpu: f64) -> DeviceEnergy {
         DeviceEnergy {
@@ -466,9 +673,19 @@ mod tests {
             group_id: group_id.to_string(),
             name: name.to_string(),
             user: "user".to_string(),
+            processes: Vec::new(),
             energy,
             power_watts: 0.0,
             percentage_of_system: 0.0,
+        }
+    }
+
+    fn process(pid: u32, name: &str, energy: DeviceEnergy) -> ProcessEnergySnapshot {
+        ProcessEnergySnapshot {
+            pid,
+            name: name.to_string(),
+            energy,
+            power_watts: 0.0,
         }
     }
 
@@ -483,6 +700,74 @@ mod tests {
         assert_eq!(state.sort_mode, SortMode::Name);
         state.cycle_sort_mode();
         assert_eq!(state.sort_mode, SortMode::Energy);
+    }
+
+    #[test]
+    fn app_state_navigation_clamps_to_group_boundaries() {
+        let mut state = AppState::default();
+
+        state.select_previous();
+        assert_eq!(state.selected_group_index, 0);
+
+        state.select_next(3);
+        state.select_next(3);
+        state.select_next(3);
+        state.select_next(3);
+        assert_eq!(state.selected_group_index, 2);
+
+        state.clamp_selection(1);
+        assert_eq!(state.selected_group_index, 0);
+        state.select_next(0);
+        assert_eq!(state.selected_group_index, 0);
+    }
+
+    #[test]
+    fn app_state_tracks_expanded_group_ids_until_collapse() {
+        let mut state = AppState::default();
+
+        state.expand_group("pid:123".to_string());
+        state.clamp_selection(1);
+        assert!(state.expanded_group_ids.contains("pid:123"));
+
+        state.collapse_group("pid:123");
+        assert!(!state.expanded_group_ids.contains("pid:123"));
+    }
+
+    #[test]
+    fn app_state_scrolls_expanded_children_before_leaving_group() {
+        let mut state = AppState::default();
+        state.expand_group("pid:123".to_string());
+
+        assert!(state.scroll_children_next("pid:123", 3));
+        assert!(state.scroll_children_next("pid:123", 3));
+        assert!(!state.scroll_children_next("pid:123", 3));
+        assert_eq!(state.child_scroll_offsets.get("pid:123"), Some(&2));
+
+        assert!(state.scroll_children_previous("pid:123"));
+        assert!(state.scroll_children_previous("pid:123"));
+        assert!(!state.scroll_children_previous("pid:123"));
+        assert_eq!(state.child_scroll_offsets.get("pid:123"), Some(&0));
+    }
+
+    #[test]
+    fn app_state_clamps_stale_child_scroll_offsets_to_current_process_count() {
+        let mut state = AppState::default();
+        state.child_scroll_offsets.insert("pid:123".to_string(), 5);
+        state
+            .child_scroll_offsets
+            .insert("pid:missing".to_string(), 2);
+        let workload = WorkloadSnapshot {
+            processes: vec![
+                process(123, "child-a", DeviceEnergy::default()),
+                process(124, "child-b", DeviceEnergy::default()),
+            ],
+            ..workload("pid:123", "parent", DeviceEnergy::default())
+        };
+
+        state.clamp_child_scroll_offsets(&[workload]);
+
+        assert_eq!(state.child_scroll_offsets.get("pid:123"), Some(&1));
+        assert!(!state.child_scroll_offsets.contains_key("pid:missing"));
     }
 
     #[test]
@@ -540,12 +825,14 @@ mod tests {
                 root_pid: 101,
                 power_watts: 5.0,
                 percentage_of_system: 60.0,
+                processes: vec![process(101, "rustc", energy(10.0, 2.0, 1.0))],
                 ..workload("pid:101", "compile", energy(10.0, 2.0, 1.0))
             },
             WorkloadSnapshot {
                 root_pid: 202,
                 power_watts: 3.0,
                 percentage_of_system: 40.0,
+                processes: vec![process(202, "cargo", energy(5.0, 4.0, 0.0))],
                 ..workload("pid:202", "test", energy(5.0, 4.0, 0.0))
             },
         ];
@@ -578,11 +865,13 @@ mod tests {
             WorkloadSnapshot {
                 root_pid: 101,
                 power_watts: 6.0,
+                processes: vec![process(101, "rustc", energy(12.0, 4.0, 2.0))],
                 ..workload("pid:101", "compile", energy(12.0, 4.0, 2.0))
             },
             WorkloadSnapshot {
                 root_pid: 202,
                 power_watts: 4.0,
+                processes: vec![process(202, "cargo", energy(8.0, 3.0, 0.0))],
                 ..workload("pid:202", "test", energy(8.0, 3.0, 0.0))
             },
         ];
@@ -591,8 +880,18 @@ mod tests {
         let display = sink.display_snapshot(SortMode::Name);
         assert_energy(&display.workloads[0].energy, &energy(2.0, 2.0, 1.0));
         assert_eq!(display.workloads[0].power_watts, 2.5);
+        assert_energy(
+            &display.workloads[0].processes[0].energy,
+            &energy(2.0, 2.0, 1.0),
+        );
+        assert_eq!(display.workloads[0].processes[0].power_watts, 2.5);
         assert_energy(&display.workloads[1].energy, &energy(3.0, 0.0, 0.0));
         assert_eq!(display.workloads[1].power_watts, 1.5);
+        assert_energy(
+            &display.workloads[1].processes[0].energy,
+            &energy(3.0, 0.0, 0.0),
+        );
+        assert_eq!(display.workloads[1].processes[0].power_watts, 1.5);
         assert_energy(&display.system_total, &energy(5.0, 1.0, 1.0));
         assert_eq!(sink.power_history().cpu, vec![2.5]);
     }

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -6,6 +6,10 @@ pub enum AppEvent {
     Quit,
     CycleSortMode,
     ResetDisplay,
+    SelectPrevious,
+    SelectNext,
+    ExpandSelected,
+    CollapseSelected,
 }
 
 pub fn poll(timeout: Duration) -> Option<AppEvent> {
@@ -22,7 +26,48 @@ fn handle_key(key: KeyEvent) -> AppEvent {
         KeyCode::Char('q') => AppEvent::Quit,
         KeyCode::Char('s') => AppEvent::CycleSortMode,
         KeyCode::Char('r') => AppEvent::ResetDisplay,
+        KeyCode::Up => AppEvent::SelectPrevious,
+        KeyCode::Down => AppEvent::SelectNext,
+        KeyCode::Enter | KeyCode::Right => AppEvent::ExpandSelected,
+        KeyCode::Esc | KeyCode::Left => AppEvent::CollapseSelected,
         KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => AppEvent::Quit,
         _ => AppEvent::Tick,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn maps_navigation_keys_to_app_events() {
+        assert!(matches!(
+            handle_key(key(KeyCode::Up)),
+            AppEvent::SelectPrevious
+        ));
+        assert!(matches!(
+            handle_key(key(KeyCode::Down)),
+            AppEvent::SelectNext
+        ));
+        assert!(matches!(
+            handle_key(key(KeyCode::Enter)),
+            AppEvent::ExpandSelected
+        ));
+        assert!(matches!(
+            handle_key(key(KeyCode::Right)),
+            AppEvent::ExpandSelected
+        ));
+        assert!(matches!(
+            handle_key(key(KeyCode::Esc)),
+            AppEvent::CollapseSelected
+        ));
+        assert!(matches!(
+            handle_key(key(KeyCode::Left)),
+            AppEvent::CollapseSelected
+        ));
     }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -6,6 +6,7 @@ use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Row, Sparkline, Table};
+use std::collections::{HashMap, HashSet};
 
 pub fn render(frame: &mut Frame, app: &App) {
     let snapshot = app.snapshot();
@@ -13,6 +14,9 @@ pub fn render(frame: &mut Frame, app: &App) {
     let display_elapsed = app.display_elapsed_secs();
     let power_history = app.power_history();
     let sort_mode = app.sort_mode();
+    let selected_group_index = app.selected_group_index();
+    let expanded_group_ids = app.expanded_group_ids();
+    let child_scroll_offsets = app.child_scroll_offsets();
 
     render_snapshot(
         frame,
@@ -21,6 +25,9 @@ pub fn render(frame: &mut Frame, app: &App) {
         display_elapsed,
         &power_history,
         sort_mode,
+        selected_group_index,
+        expanded_group_ids,
+        child_scroll_offsets,
     );
 }
 
@@ -31,6 +38,9 @@ fn render_snapshot(
     display_elapsed: f64,
     power_history: &PowerHistorySnapshot,
     sort_mode: SortMode,
+    selected_group_index: usize,
+    expanded_group_ids: &HashSet<String>,
+    child_scroll_offsets: &HashMap<String, usize>,
 ) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -49,7 +59,14 @@ fn render_snapshot(
         display_elapsed,
         power_history,
     );
-    render_body(frame, chunks[1], snapshot);
+    render_body(
+        frame,
+        chunks[1],
+        snapshot,
+        selected_group_index,
+        expanded_group_ids,
+        child_scroll_offsets,
+    );
     render_footer(frame, chunks[2], sort_mode);
 }
 
@@ -247,7 +264,14 @@ fn power_to_sparkline_value(watts: f64) -> u64 {
     }
 }
 
-fn render_body(frame: &mut Frame, area: Rect, snapshot: &MetricsSnapshot) {
+fn render_body(
+    frame: &mut Frame,
+    area: Rect,
+    snapshot: &MetricsSnapshot,
+    selected_group_index: usize,
+    expanded_group_ids: &HashSet<String>,
+    child_scroll_offsets: &HashMap<String, usize>,
+) {
     if snapshot.workloads.is_empty() {
         let block = Block::default().borders(Borders::ALL).title(" Workloads ");
         let paragraph = Paragraph::new("  No process data yet...").block(block);
@@ -264,19 +288,16 @@ fn render_body(frame: &mut Frame, area: Rect, snapshot: &MetricsSnapshot) {
     ])
     .style(Style::default().add_modifier(Modifier::BOLD));
 
-    let rows: Vec<Row> = snapshot
-        .workloads
-        .iter()
-        .map(|wl| {
-            Row::new(vec![
-                wl.name.clone(),
-                wl.user.clone(),
-                format!("{:.4}", wl.energy.total()),
-                format!("{:.2}", wl.power_watts),
-                format!("{:.1}%", wl.percentage_of_system),
-            ])
-        })
-        .collect();
+    let rows = workload_table_rows(
+        snapshot,
+        selected_group_index,
+        expanded_group_ids,
+        child_scroll_offsets,
+    );
+    let rows = visible_table_rows(rows, selected_group_index, table_body_capacity(area))
+        .into_iter()
+        .map(WorkloadTableRow::into_row)
+        .collect::<Vec<_>>();
 
     let table = Table::new(
         rows,
@@ -298,6 +319,12 @@ fn render_footer(frame: &mut Frame, area: Rect, sort_mode: SortMode) {
     let footer = Paragraph::new(Line::from(vec![
         Span::styled(" q", Style::default().fg(Color::Red)),
         Span::raw(" quit"),
+        Span::styled("  up/down", Style::default().fg(Color::Cyan)),
+        Span::raw(" move"),
+        Span::styled("  enter", Style::default().fg(Color::Cyan)),
+        Span::raw(" expand"),
+        Span::styled("  esc", Style::default().fg(Color::Cyan)),
+        Span::raw(" collapse"),
         Span::styled("  s", Style::default().fg(Color::Cyan)),
         Span::raw(" sort "),
         Span::styled(sort_mode.label(), Style::default().fg(Color::Yellow)),
@@ -305,6 +332,109 @@ fn render_footer(frame: &mut Frame, area: Rect, sort_mode: SortMode) {
         Span::raw(" reset"),
     ]));
     frame.render_widget(footer, area);
+}
+
+struct WorkloadTableRow {
+    cells: Vec<String>,
+    style: Style,
+    group_index: Option<usize>,
+}
+
+impl WorkloadTableRow {
+    fn into_row(self) -> Row<'static> {
+        Row::new(self.cells).style(self.style)
+    }
+}
+
+fn workload_table_rows(
+    snapshot: &MetricsSnapshot,
+    selected_group_index: usize,
+    expanded_group_ids: &HashSet<String>,
+    child_scroll_offsets: &HashMap<String, usize>,
+) -> Vec<WorkloadTableRow> {
+    let mut rows = Vec::new();
+
+    for (group_index, workload) in snapshot.workloads.iter().enumerate() {
+        let is_expanded = expanded_group_ids.contains(&workload.group_id);
+        let disclosure = if workload.processes.is_empty() {
+            "  "
+        } else if is_expanded {
+            "v "
+        } else {
+            "> "
+        };
+        let style = if group_index == selected_group_index {
+            Style::default().add_modifier(Modifier::REVERSED)
+        } else {
+            Style::default()
+        };
+
+        rows.push(WorkloadTableRow {
+            cells: vec![
+                format!("{disclosure}{}", workload.name),
+                workload.user.clone(),
+                format!("{:.4}", workload.energy.total()),
+                format!("{:.2}", workload.power_watts),
+                format!("{:.1}%", workload.percentage_of_system),
+            ],
+            style,
+            group_index: Some(group_index),
+        });
+
+        if is_expanded {
+            let offset = child_scroll_offsets
+                .get(&workload.group_id)
+                .copied()
+                .unwrap_or_default()
+                .min(workload.processes.len().saturating_sub(1));
+            for process in workload.processes.iter().skip(offset) {
+                rows.push(WorkloadTableRow {
+                    cells: vec![
+                        format!("  pid {} {}", process.pid, process.name),
+                        String::new(),
+                        format!("{:.4}", process.energy.total()),
+                        format!("{:.2}", process.power_watts),
+                        String::new(),
+                    ],
+                    style: Style::default().fg(Color::DarkGray),
+                    group_index: None,
+                });
+            }
+        }
+    }
+
+    rows
+}
+
+fn visible_table_rows(
+    rows: Vec<WorkloadTableRow>,
+    selected_group_index: usize,
+    capacity: usize,
+) -> Vec<WorkloadTableRow> {
+    if rows.len() <= capacity {
+        return rows;
+    }
+
+    let selected_row_index = rows
+        .iter()
+        .position(|row| row.group_index == Some(selected_group_index))
+        .unwrap_or_default();
+    let selected_group_has_children = rows
+        .get(selected_row_index + 1)
+        .is_some_and(|row| row.group_index.is_none());
+    let start = if selected_group_has_children {
+        selected_row_index.min(rows.len().saturating_sub(capacity))
+    } else {
+        selected_row_index
+            .saturating_add(1)
+            .saturating_sub(capacity)
+    };
+
+    rows.into_iter().skip(start).take(capacity).collect()
+}
+
+fn table_body_capacity(area: Rect) -> usize {
+    usize::from(area.height.saturating_sub(3)).max(1)
 }
 
 #[cfg(test)]
@@ -342,6 +472,7 @@ mod tests {
                 group_id: "pid:123".to_string(),
                 name: "python workload.py".to_string(),
                 user: "alice".to_string(),
+                processes: Vec::new(),
                 energy: DeviceEnergy {
                     cpu_joules: 120.0,
                     dram_joules: 30.0,
@@ -362,6 +493,8 @@ mod tests {
             dram: vec![1.5],
             gpu: vec![],
         };
+        let expanded = HashSet::new();
+        let child_scroll_offsets = HashMap::new();
         let mut terminal = Terminal::new(TestBackend::new(120, 14)).unwrap();
 
         terminal
@@ -373,6 +506,9 @@ mod tests {
                     60.0,
                     &power_history,
                     SortMode::Energy,
+                    0,
+                    &expanded,
+                    &child_scroll_offsets,
                 )
             })
             .unwrap();
@@ -414,6 +550,8 @@ mod tests {
             dram: vec![1.5],
             gpu: vec![3.0],
         };
+        let expanded = HashSet::new();
+        let child_scroll_offsets = HashMap::new();
         let mut terminal = Terminal::new(TestBackend::new(120, 14)).unwrap();
 
         terminal
@@ -425,6 +563,9 @@ mod tests {
                     60.0,
                     &power_history,
                     SortMode::Energy,
+                    0,
+                    &expanded,
+                    &child_scroll_offsets,
                 )
             })
             .unwrap();
@@ -432,5 +573,178 @@ mod tests {
         let screen = terminal.backend().to_string();
         assert!(screen.contains("GPU: 30.0000 J"));
         assert!(screen.contains("Interval GPU: 3.00 W"));
+    }
+
+    #[test]
+    fn render_snapshot_shows_expanded_pid_rows_and_selected_group() {
+        let snapshot = MetricsSnapshot {
+            timestamp: 1_000,
+            gpu_available: false,
+            system_total: DeviceEnergy {
+                cpu_joules: 20.0,
+                dram_joules: 4.0,
+                gpu_joules: 0.0,
+            },
+            workloads: vec![WorkloadSnapshot {
+                root_pid: 123,
+                group_id: "pid:123".to_string(),
+                name: "cargo test".to_string(),
+                user: "alice".to_string(),
+                processes: vec![crate::monitor::ProcessEnergySnapshot {
+                    pid: 123,
+                    name: "cargo".to_string(),
+                    energy: DeviceEnergy {
+                        cpu_joules: 12.0,
+                        dram_joules: 3.0,
+                        gpu_joules: 0.0,
+                    },
+                    power_watts: 7.5,
+                }],
+                energy: DeviceEnergy {
+                    cpu_joules: 20.0,
+                    dram_joules: 4.0,
+                    gpu_joules: 0.0,
+                },
+                power_watts: 12.0,
+                percentage_of_system: 100.0,
+            }],
+            unattributed: DeviceEnergy::default(),
+            tracked_pids: vec![123],
+        };
+        let power_history = PowerHistorySnapshot::default();
+        let expanded = HashSet::from(["pid:123".to_string()]);
+        let child_scroll_offsets = HashMap::new();
+        let mut terminal = Terminal::new(TestBackend::new(120, 14)).unwrap();
+
+        terminal
+            .draw(|frame| {
+                render_snapshot(
+                    frame,
+                    &snapshot,
+                    2.0,
+                    2.0,
+                    &power_history,
+                    SortMode::Energy,
+                    0,
+                    &expanded,
+                    &child_scroll_offsets,
+                )
+            })
+            .unwrap();
+
+        let screen = terminal.backend().to_string();
+        assert!(screen.contains("v cargo test"));
+        assert!(screen.contains("pid 123 cargo"));
+        assert!(screen.contains("15.0000"));
+        assert!(screen.contains("7.50"));
+    }
+
+    #[test]
+    fn workload_table_rows_mark_selected_group_and_hide_collapsed_children() {
+        let snapshot = MetricsSnapshot {
+            timestamp: 1_000,
+            gpu_available: false,
+            system_total: DeviceEnergy {
+                cpu_joules: 8.0,
+                dram_joules: 0.0,
+                gpu_joules: 0.0,
+            },
+            workloads: vec![WorkloadSnapshot {
+                root_pid: 123,
+                group_id: "pid:123".to_string(),
+                name: "python".to_string(),
+                user: "alice".to_string(),
+                processes: vec![crate::monitor::ProcessEnergySnapshot {
+                    pid: 123,
+                    name: "python".to_string(),
+                    energy: DeviceEnergy {
+                        cpu_joules: 8.0,
+                        dram_joules: 0.0,
+                        gpu_joules: 0.0,
+                    },
+                    power_watts: 4.0,
+                }],
+                energy: DeviceEnergy {
+                    cpu_joules: 8.0,
+                    dram_joules: 0.0,
+                    gpu_joules: 0.0,
+                },
+                power_watts: 4.0,
+                percentage_of_system: 100.0,
+            }],
+            unattributed: DeviceEnergy::default(),
+            tracked_pids: vec![123],
+        };
+
+        let rows = workload_table_rows(&snapshot, 0, &HashSet::new(), &HashMap::new());
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].cells[0], "> python");
+        assert!(rows[0].style.add_modifier.contains(Modifier::REVERSED));
+    }
+
+    #[test]
+    fn workload_table_rows_apply_child_scroll_offset_to_expanded_group() {
+        let snapshot = MetricsSnapshot {
+            timestamp: 1_000,
+            gpu_available: false,
+            system_total: DeviceEnergy {
+                cpu_joules: 3.0,
+                dram_joules: 0.0,
+                gpu_joules: 0.0,
+            },
+            workloads: vec![WorkloadSnapshot {
+                root_pid: 1,
+                group_id: "pid:1".to_string(),
+                name: "python".to_string(),
+                user: "alice".to_string(),
+                processes: (1..=3)
+                    .map(|pid| crate::monitor::ProcessEnergySnapshot {
+                        pid,
+                        name: format!("child-{pid}"),
+                        energy: DeviceEnergy {
+                            cpu_joules: 1.0,
+                            dram_joules: 0.0,
+                            gpu_joules: 0.0,
+                        },
+                        power_watts: 1.0,
+                    })
+                    .collect(),
+                energy: DeviceEnergy {
+                    cpu_joules: 3.0,
+                    dram_joules: 0.0,
+                    gpu_joules: 0.0,
+                },
+                power_watts: 3.0,
+                percentage_of_system: 100.0,
+            }],
+            unattributed: DeviceEnergy::default(),
+            tracked_pids: vec![1, 2, 3],
+        };
+        let expanded = HashSet::from(["pid:1".to_string()]);
+        let child_scroll_offsets = HashMap::from([("pid:1".to_string(), 1)]);
+
+        let rows = workload_table_rows(&snapshot, 0, &expanded, &child_scroll_offsets);
+
+        assert_eq!(rows[0].cells[0], "v python");
+        assert_eq!(rows[1].cells[0], "  pid 2 child-2");
+        assert_eq!(rows[2].cells[0], "  pid 3 child-3");
+    }
+
+    #[test]
+    fn visible_table_rows_keep_selected_group_visible() {
+        let rows = (0..8)
+            .map(|index| WorkloadTableRow {
+                cells: vec![format!("row {index}")],
+                style: Style::default(),
+                group_index: Some(index),
+            })
+            .collect::<Vec<_>>();
+
+        let visible = visible_table_rows(rows, 7, 3);
+
+        assert_eq!(visible.len(), 3);
+        assert_eq!(visible[0].cells[0], "row 5");
+        assert_eq!(visible[2].cells[0], "row 7");
     }
 }


### PR DESCRIPTION
## Summary
- add per-PID energy snapshots under each workload group
- preserve cumulative per-PID energy through live ticks and shutdown drains
- add TUI selection state, expand/collapse state, and child-row scrolling
- map up/down/enter/right/esc/left keys to navigation actions
- render selected group rows, expanded PID detail rows, and viewport windowing

## Validation
- `cargo fmt --all -- --check`
- `cargo test monitor::tests::retained_pid_to_group_map_preserves_existing_process_rows --lib --quiet`
- `cargo test tui::app --lib --quiet`
- `cargo test tui::ui --lib --bin emt --quiet`
- `cargo test --quiet`
- `git diff --check`
- independent review plus follow-up passes: no remaining acceptance blockers

## Residual Risks
- `WorkloadSnapshot` has a new public Rust field, so external Rust struct-literal construction needs updating. The stable Python API is unchanged.
- Long-running sessions still identify child rows by numeric PID, so future work may need stronger process identity if PID reuse becomes visible.

Linear: ENE-26