### PR TITLE
ENE-29: Retain dead workload groups in TUI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -126,6 +126,7 @@ mod tests {
                 name: "work".to_string(),
                 user: "user".to_string(),
                 processes: Vec::new(),
+                is_live: true,
                 energy: DeviceEnergy {
                     cpu_joules: 2_700.0,
                     dram_joules: 900.0,

--- a/src/metrics_sink.rs
+++ b/src/metrics_sink.rs
@@ -631,6 +631,7 @@ mod tests {
             name: name.to_string(),
             user: "user".to_string(),
             processes: Vec::new(),
+            is_live: true,
             energy,
             power_watts: 0.0,
             percentage_of_system: 0.0,

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -7,7 +7,7 @@ use crate::process::{
 use crate::process_aggregation::{aggregate_energy_records, percentage_of_system};
 use crate::utils::errors::MonitoringError;
 use crate::utils::psutils::{ProcessRoot, walk_child_pids};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
@@ -57,6 +57,7 @@ pub struct WorkloadSnapshot {
     pub name: String,
     pub user: String,
     pub processes: Vec<ProcessEnergySnapshot>,
+    pub is_live: bool,
     pub energy: DeviceEnergy,
     pub power_watts: f64,
     pub percentage_of_system: f64,
@@ -108,6 +109,7 @@ fn workload_snapshot(
     group: &ProcessGroup,
     energy: DeviceEnergy,
     processes: Vec<ProcessEnergySnapshot>,
+    is_live: bool,
     elapsed_s: f64,
 ) -> WorkloadSnapshot {
     let power_watts = if elapsed_s > 0.0 {
@@ -122,10 +124,54 @@ fn workload_snapshot(
         name: group.name.clone(),
         user: group.user.clone(),
         processes,
+        is_live,
         energy,
         power_watts,
         percentage_of_system: 0.0,
     }
+}
+
+fn workload_snapshots_for_known_groups<F>(
+    known_groups: &HashMap<String, ProcessGroup>,
+    cumulative_by_group: &HashMap<String, DeviceEnergy>,
+    cumulative_by_pid: &HashMap<u32, DeviceEnergy>,
+    pid_to_group: &HashMap<u32, String>,
+    process_names: &HashMap<u32, String>,
+    elapsed_s: f64,
+    mut is_live_for_group: F,
+) -> Vec<WorkloadSnapshot>
+where
+    F: FnMut(&ProcessGroup) -> bool,
+{
+    let mut workloads: Vec<WorkloadSnapshot> = known_groups
+        .values()
+        .filter_map(|group| {
+            let energy = cumulative_by_group
+                .get(&group.id)
+                .cloned()
+                .unwrap_or_default();
+            if energy.total() <= 0.0 {
+                return None;
+            }
+
+            let processes = process_snapshots_for_group(
+                group,
+                &pid_energy_for_group(&group.id, &group.pids, cumulative_by_pid, pid_to_group),
+                process_names,
+                elapsed_s,
+            );
+
+            Some(workload_snapshot(
+                group,
+                energy,
+                processes,
+                is_live_for_group(group),
+                elapsed_s,
+            ))
+        })
+        .collect();
+    workloads.sort_by(|left, right| left.group_id.cmp(&right.group_id));
+    workloads
 }
 
 fn process_energy_snapshot(
@@ -590,6 +636,11 @@ impl Monitor {
         };
 
         let mut snap = self.snapshot.write().unwrap();
+        let existing_live_status: HashMap<String, bool> = snap
+            .workloads
+            .iter()
+            .map(|workload| (workload.group_id.clone(), workload.is_live))
+            .collect();
         let mut cumulative_by_group: HashMap<String, DeviceEnergy> = snap
             .workloads
             .iter()
@@ -626,32 +677,21 @@ impl Monitor {
         }
         add_device_energy(&mut snap.unattributed, &tick.unattributed);
 
-        let mut workloads: Vec<WorkloadSnapshot> = known_groups_snapshot
-            .values()
-            .filter_map(|group| {
-                let energy = cumulative_by_group
+        let mut workloads = workload_snapshots_for_known_groups(
+            &known_groups_snapshot,
+            &cumulative_by_group,
+            &cumulative_by_pid,
+            &pid_to_group,
+            &process_names,
+            elapsed_s,
+            |group| {
+                let is_live = existing_live_status
                     .get(&group.id)
-                    .cloned()
-                    .unwrap_or_default();
-                if energy.total() <= 0.0 {
-                    return None;
-                }
-
-                let processes = process_snapshots_for_group(
-                    group,
-                    &pid_energy_for_group(
-                        &group.id,
-                        &group.pids,
-                        &cumulative_by_pid,
-                        &pid_to_group,
-                    ),
-                    &process_names,
-                    elapsed_s,
-                );
-                Some(workload_snapshot(group, energy, processes, elapsed_s))
-            })
-            .collect();
-        workloads.sort_by(|left, right| left.group_id.cmp(&right.group_id));
+                    .copied()
+                    .unwrap_or(!group.pids.is_empty());
+                is_live
+            },
+        );
 
         let system_total = system_total_from_workloads(&workloads, &snap.unattributed);
         apply_workload_percentages(&mut workloads, &system_total);
@@ -732,7 +772,8 @@ impl Monitor {
                 let elapsed_s = (current_timestamp - tick_state.start_timestamp) as f64 / 1000.0;
 
                 let known_groups_snapshot = known_groups.read().unwrap().clone();
-                let mut workloads: Vec<WorkloadSnapshot> = Vec::new();
+                let live_group_ids: HashSet<String> =
+                    groups.iter().map(|group| group.id.clone()).collect();
                 resolve_missing_process_names(&expanded_pids, &mut tick_state.process_names);
                 for (pid, tick_energy) in &tick.pid_energy {
                     let entry = tick_state.pid_energy.entry(*pid).or_default();
@@ -740,43 +781,23 @@ impl Monitor {
                 }
                 tick_state.pid_to_group =
                     merge_pid_group_maps(&current_pid_to_group, &tick_state.pid_to_group);
-
-                for group in known_groups_snapshot.values() {
-                    let tick_energy = tick
-                        .group_energy
-                        .get(&group.id)
-                        .cloned()
-                        .unwrap_or_default();
-                    let mut cumulative_energy = tick_state
+                for (group_id, tick_energy) in &tick.group_energy {
+                    let entry = tick_state
                         .workload_energy
-                        .get(&group.id)
-                        .cloned()
-                        .unwrap_or_default();
-                    add_device_energy(&mut cumulative_energy, &tick_energy);
-
-                    if cumulative_energy.total() <= 0.0 {
-                        continue;
-                    }
-
-                    let processes = process_snapshots_for_group(
-                        group,
-                        &pid_energy_for_group(
-                            &group.id,
-                            &group.pids,
-                            &tick_state.pid_energy,
-                            &tick_state.pid_to_group,
-                        ),
-                        &tick_state.process_names,
-                        elapsed_s,
-                    );
-                    workloads.push(workload_snapshot(
-                        group,
-                        cumulative_energy,
-                        processes,
-                        elapsed_s,
-                    ));
+                        .entry(group_id.clone())
+                        .or_default();
+                    add_device_energy(entry, tick_energy);
                 }
-                workloads.sort_by(|left, right| left.group_id.cmp(&right.group_id));
+
+                let mut workloads = workload_snapshots_for_known_groups(
+                    &known_groups_snapshot,
+                    &tick_state.workload_energy,
+                    &tick_state.pid_energy,
+                    &tick_state.pid_to_group,
+                    &tick_state.process_names,
+                    elapsed_s,
+                    |group| live_group_ids.contains(&group.id),
+                );
 
                 let prev_unattributed = { snapshot.read().unwrap().unattributed.clone() };
                 let mut cumulative_unattributed = prev_unattributed;
@@ -1013,6 +1034,90 @@ mod tests {
     }
 
     #[test]
+    fn workload_snapshots_mark_known_groups_missing_from_current_scan_as_dead() {
+        let known_groups = HashMap::from([
+            (
+                "pid:100".to_string(),
+                ProcessGroup {
+                    id: "pid:100".to_string(),
+                    name: "live workload".to_string(),
+                    user: "alice".to_string(),
+                    pids: vec![100],
+                    representative_pid: 100,
+                },
+            ),
+            (
+                "pid:200".to_string(),
+                ProcessGroup {
+                    id: "pid:200".to_string(),
+                    name: "finished workload".to_string(),
+                    user: "alice".to_string(),
+                    pids: vec![200],
+                    representative_pid: 200,
+                },
+            ),
+        ]);
+        let cumulative_by_group = HashMap::from([
+            (
+                "pid:100".to_string(),
+                DeviceEnergy {
+                    cpu_joules: 3.0,
+                    dram_joules: 0.0,
+                    gpu_joules: 0.0,
+                },
+            ),
+            (
+                "pid:200".to_string(),
+                DeviceEnergy {
+                    cpu_joules: 5.0,
+                    dram_joules: 0.0,
+                    gpu_joules: 0.0,
+                },
+            ),
+        ]);
+        let cumulative_by_pid = HashMap::from([
+            (
+                100,
+                DeviceEnergy {
+                    cpu_joules: 3.0,
+                    dram_joules: 0.0,
+                    gpu_joules: 0.0,
+                },
+            ),
+            (
+                200,
+                DeviceEnergy {
+                    cpu_joules: 5.0,
+                    dram_joules: 0.0,
+                    gpu_joules: 0.0,
+                },
+            ),
+        ]);
+        let pid_to_group =
+            HashMap::from([(100, "pid:100".to_string()), (200, "pid:200".to_string())]);
+        let process_names = HashMap::from([(200, "short-lived".to_string())]);
+        let live_group_ids = HashSet::from(["pid:100".to_string()]);
+
+        let workloads = workload_snapshots_for_known_groups(
+            &known_groups,
+            &cumulative_by_group,
+            &cumulative_by_pid,
+            &pid_to_group,
+            &process_names,
+            2.0,
+            |group| live_group_ids.contains(&group.id),
+        );
+
+        assert_eq!(workloads.len(), 2);
+        assert!(workloads[0].is_live);
+        assert!(!workloads[1].is_live);
+        assert_eq!(workloads[1].group_id, "pid:200");
+        assert_eq!(workloads[1].energy.total(), 5.0);
+        assert_eq!(workloads[1].power_watts, 2.5);
+        assert_eq!(workloads[1].processes[0].name, "short-lived");
+    }
+
+    #[test]
     fn retained_pid_to_group_map_preserves_existing_process_rows() {
         let workloads = vec![WorkloadSnapshot {
             root_pid: 123,
@@ -1025,6 +1130,7 @@ mod tests {
                 energy: DeviceEnergy::default(),
                 power_watts: 0.0,
             }],
+            is_live: true,
             energy: DeviceEnergy::default(),
             power_watts: 0.0,
             percentage_of_system: 0.0,

--- a/src/process.rs
+++ b/src/process.rs
@@ -68,6 +68,10 @@ impl GroupingStrategy for ParentLineageGrouping {
         let mut groups: BTreeMap<u32, Vec<&ProcessInfo>> = BTreeMap::new();
 
         for process in processes {
+            if process.pid == 1 || process.pid == 2 {
+                continue;
+            }
+
             let root_pid = lineage_representative(process.pid, &by_pid);
             groups.entry(root_pid).or_default().push(process);
         }
@@ -589,6 +593,8 @@ mod tests {
             group.id == "lineage:1" && group.pids.iter().any(|pid| *pid == 100 || *pid == 101)
         }));
         assert!(groups.iter().any(|group| group.id == "lineage:200"));
+        assert!(!groups.iter().any(|group| group.id == "lineage:1"));
+        assert!(!groups.iter().any(|group| group.id == "lineage:2"));
     }
 
     #[test]
@@ -604,6 +610,25 @@ mod tests {
 
         assert_eq!(ids, vec!["lineage:100", "lineage:200"]);
         assert_eq!(groups[0].pids, vec![100, 101]);
+        assert_eq!(groups[1].pids, vec![200]);
+    }
+
+    #[test]
+    fn group_processes_falls_back_from_single_low_signal_user_slice() {
+        let processes = vec![
+            process(1, None, "systemd", "root", "/"),
+            process(100, Some(1), "python api.py", "alice", "/user.slice"),
+            process(101, Some(100), "worker", "alice", "/user.slice"),
+            process(200, Some(1), "node server.js", "alice", "/user.slice"),
+        ];
+
+        let groups = group_processes(&processes);
+        let ids: Vec<&str> = groups.iter().map(|group| group.id.as_str()).collect();
+
+        assert_eq!(ids, vec!["lineage:100", "lineage:200"]);
+        assert_eq!(groups[0].name, "python");
+        assert_eq!(groups[0].pids, vec![100, 101]);
+        assert_eq!(groups[1].name, "node");
         assert_eq!(groups[1].pids, vec![200]);
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -96,8 +96,11 @@ impl App {
     }
 
     pub fn expand_selected(&mut self) {
-        if let Some(group_id) = self.selected_group_id() {
-            self.state.expand_group(group_id);
+        let snapshot = self.sink.display_snapshot(self.state.sort_mode);
+        if let Some(workload) = snapshot.workloads.get(self.state.selected_group_index) {
+            if workload.is_live {
+                self.state.expand_group(workload.group_id.clone());
+            }
         }
     }
 
@@ -148,7 +151,7 @@ impl App {
         let Some(workload) = snapshot.workloads.get(self.state.selected_group_index) else {
             return false;
         };
-        if !self.state.expanded_group_ids.contains(&workload.group_id) {
+        if !workload.is_live || !self.state.expanded_group_ids.contains(&workload.group_id) {
             return false;
         }
 
@@ -157,14 +160,15 @@ impl App {
     }
 
     fn scroll_selected_children_previous(&mut self) -> bool {
-        let Some(group_id) = self.selected_group_id() else {
+        let snapshot = self.sink.display_snapshot(self.state.sort_mode);
+        let Some(workload) = snapshot.workloads.get(self.state.selected_group_index) else {
             return false;
         };
-        if !self.state.expanded_group_ids.contains(&group_id) {
+        if !workload.is_live || !self.state.expanded_group_ids.contains(&workload.group_id) {
             return false;
         }
 
-        self.state.scroll_children_previous(&group_id)
+        self.state.scroll_children_previous(&workload.group_id)
     }
 }
 
@@ -289,6 +293,7 @@ impl SortMode {
 pub struct TuiSink {
     snapshot: MetricsSnapshot,
     baseline: Option<ResetBaseline>,
+    hidden_dead_group_ids: HashSet<String>,
     power_history: RollingPowerHistory,
 }
 
@@ -308,6 +313,14 @@ impl TuiSink {
     }
 
     pub fn reset(&mut self) {
+        self.hidden_dead_group_ids = self
+            .snapshot
+            .workloads
+            .iter()
+            .filter(|workload| !workload.is_live)
+            .map(|workload| workload.group_id.clone())
+            .collect();
+
         if self.snapshot.timestamp > 0 {
             self.power_history.reset(Some((
                 timestamp_to_secs(self.snapshot.timestamp),
@@ -330,6 +343,7 @@ impl TuiSink {
     fn baseline_adjusted_snapshot(&self) -> MetricsSnapshot {
         let mut snapshot = self.snapshot.clone();
         let Some(baseline) = &self.baseline else {
+            self.hide_reset_dead_workloads(&mut snapshot);
             return snapshot;
         };
 
@@ -367,7 +381,52 @@ impl TuiSink {
             }
         }
 
+        self.hide_reset_dead_workloads(&mut snapshot);
+
         snapshot
+    }
+
+    fn hide_reset_dead_workloads(&self, snapshot: &mut MetricsSnapshot) {
+        if self.hidden_dead_group_ids.is_empty() {
+            return;
+        }
+
+        let original_len = snapshot.workloads.len();
+        snapshot.workloads.retain(|workload| {
+            workload.is_live || !self.hidden_dead_group_ids.contains(&workload.group_id)
+        });
+        if snapshot.workloads.len() == original_len {
+            return;
+        }
+
+        snapshot.system_total = system_total_from_display_workloads(snapshot);
+        for workload in &mut snapshot.workloads {
+            workload.percentage_of_system =
+                percentage_of_system(&workload.energy, &snapshot.system_total);
+        }
+    }
+}
+
+fn system_total_from_display_workloads(snapshot: &MetricsSnapshot) -> DeviceEnergy {
+    DeviceEnergy {
+        cpu_joules: snapshot
+            .workloads
+            .iter()
+            .map(|workload| workload.energy.cpu_joules)
+            .sum::<f64>()
+            + snapshot.unattributed.cpu_joules,
+        dram_joules: snapshot
+            .workloads
+            .iter()
+            .map(|workload| workload.energy.dram_joules)
+            .sum::<f64>()
+            + snapshot.unattributed.dram_joules,
+        gpu_joules: snapshot
+            .workloads
+            .iter()
+            .map(|workload| workload.energy.gpu_joules)
+            .sum::<f64>()
+            + snapshot.unattributed.gpu_joules,
     }
 }
 
@@ -674,6 +733,7 @@ mod tests {
             name: name.to_string(),
             user: "user".to_string(),
             processes: Vec::new(),
+            is_live: true,
             energy,
             power_watts: 0.0,
             percentage_of_system: 0.0,
@@ -894,6 +954,43 @@ mod tests {
         assert_eq!(display.workloads[1].processes[0].power_watts, 1.5);
         assert_energy(&display.system_total, &energy(5.0, 1.0, 1.0));
         assert_eq!(sink.power_history().cpu, vec![2.5]);
+    }
+
+    #[test]
+    fn reset_clears_dead_groups_from_display() {
+        let mut sink = TuiSink::default();
+        let mut before_reset = snapshot(2_000, energy(15.0, 0.0, 0.0));
+        before_reset.workloads = vec![
+            workload("pid:101", "live", energy(10.0, 0.0, 0.0)),
+            WorkloadSnapshot {
+                is_live: false,
+                ..workload("pid:202", "dead", energy(5.0, 0.0, 0.0))
+            },
+        ];
+        sink.update(&before_reset);
+
+        assert_eq!(
+            workload_names(&sink.display_snapshot(SortMode::Name)),
+            vec!["dead", "live"]
+        );
+
+        sink.reset();
+        let mut after_reset = snapshot(3_000, energy(22.0, 0.0, 0.0));
+        after_reset.workloads = vec![
+            workload("pid:101", "live", energy(15.0, 0.0, 0.0)),
+            WorkloadSnapshot {
+                is_live: false,
+                ..workload("pid:202", "dead", energy(7.0, 0.0, 0.0))
+            },
+        ];
+        sink.update(&after_reset);
+
+        let display = sink.display_snapshot(SortMode::Name);
+
+        assert_eq!(workload_names(&display), vec!["live"]);
+        assert_eq!(display.workloads[0].energy.total(), 5.0);
+        assert_eq!(display.system_total.total(), 5.0);
+        assert_eq!(display.workloads[0].percentage_of_system, 100.0);
     }
 
     #[test]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -356,7 +356,9 @@ fn workload_table_rows(
 
     for (group_index, workload) in snapshot.workloads.iter().enumerate() {
         let is_expanded = expanded_group_ids.contains(&workload.group_id);
-        let disclosure = if workload.processes.is_empty() {
+        let disclosure = if !workload.is_live {
+            "x "
+        } else if workload.processes.is_empty() {
             "  "
         } else if is_expanded {
             "v "
@@ -365,6 +367,8 @@ fn workload_table_rows(
         };
         let style = if group_index == selected_group_index {
             Style::default().add_modifier(Modifier::REVERSED)
+        } else if !workload.is_live {
+            Style::default().fg(Color::DarkGray)
         } else {
             Style::default()
         };
@@ -381,7 +385,7 @@ fn workload_table_rows(
             group_index: Some(group_index),
         });
 
-        if is_expanded {
+        if workload.is_live && is_expanded {
             let offset = child_scroll_offsets
                 .get(&workload.group_id)
                 .copied()
@@ -473,6 +477,7 @@ mod tests {
                 name: "python workload.py".to_string(),
                 user: "alice".to_string(),
                 processes: Vec::new(),
+                is_live: true,
                 energy: DeviceEnergy {
                     cpu_joules: 120.0,
                     dram_joules: 30.0,
@@ -600,6 +605,7 @@ mod tests {
                     },
                     power_watts: 7.5,
                 }],
+                is_live: true,
                 energy: DeviceEnergy {
                     cpu_joules: 20.0,
                     dram_joules: 4.0,
@@ -664,6 +670,7 @@ mod tests {
                     },
                     power_watts: 4.0,
                 }],
+                is_live: true,
                 energy: DeviceEnergy {
                     cpu_joules: 8.0,
                     dram_joules: 0.0,
@@ -681,6 +688,69 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].cells[0], "> python");
         assert!(rows[0].style.add_modifier.contains(Modifier::REVERSED));
+    }
+
+    #[test]
+    fn workload_table_rows_mark_dead_groups() {
+        let snapshot = MetricsSnapshot {
+            timestamp: 1_000,
+            gpu_available: false,
+            system_total: DeviceEnergy {
+                cpu_joules: 8.0,
+                dram_joules: 0.0,
+                gpu_joules: 0.0,
+            },
+            workloads: vec![
+                WorkloadSnapshot {
+                    root_pid: 100,
+                    group_id: "pid:100".to_string(),
+                    name: "live".to_string(),
+                    user: "alice".to_string(),
+                    processes: Vec::new(),
+                    is_live: true,
+                    energy: DeviceEnergy {
+                        cpu_joules: 3.0,
+                        dram_joules: 0.0,
+                        gpu_joules: 0.0,
+                    },
+                    power_watts: 3.0,
+                    percentage_of_system: 37.5,
+                },
+                WorkloadSnapshot {
+                    root_pid: 200,
+                    group_id: "pid:200".to_string(),
+                    name: "finished".to_string(),
+                    user: "alice".to_string(),
+                    processes: vec![crate::monitor::ProcessEnergySnapshot {
+                        pid: 201,
+                        name: "stale-child".to_string(),
+                        energy: DeviceEnergy {
+                            cpu_joules: 2.0,
+                            dram_joules: 0.0,
+                            gpu_joules: 0.0,
+                        },
+                        power_watts: 0.0,
+                    }],
+                    is_live: false,
+                    energy: DeviceEnergy {
+                        cpu_joules: 5.0,
+                        dram_joules: 0.0,
+                        gpu_joules: 0.0,
+                    },
+                    power_watts: 0.0,
+                    percentage_of_system: 62.5,
+                },
+            ],
+            unattributed: DeviceEnergy::default(),
+            tracked_pids: vec![100],
+        };
+        let expanded = HashSet::from(["pid:200".to_string()]);
+
+        let rows = workload_table_rows(&snapshot, 0, &expanded, &HashMap::new());
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[1].cells[0], "x finished");
+        assert_eq!(rows[1].style.fg, Some(Color::DarkGray));
     }
 
     #[test]
@@ -710,6 +780,7 @@ mod tests {
                         power_watts: 1.0,
                     })
                     .collect(),
+                is_live: true,
                 energy: DeviceEnergy {
                     cpu_joules: 3.0,
                     dram_joules: 0.0,


### PR DESCRIPTION
## Summary
- retain known workload groups after they disappear from the current process scan and mark them as dead in snapshots
- render dead workload rows distinctly in the TUI, hide them after display reset, and keep reset display totals consistent when late final energy arrives
- harden parent-lineage fallback for low-signal single cgroup scans by skipping root-only PID 1/2 groups

## Verification
- cargo fmt --all -- --check
- cargo test --quiet
- git diff --check
- independent review pass completed; follow-up findings resolved and final follow-up was clean

Linear: ENE-29