### PR TITLE
[codex] ENE-43/ENE-44 low-overhead TUI attribution

### DIFF
--- a/scripts/benchmark_burst_attribution.py
+++ b/scripts/benchmark_burst_attribution.py
@@ -1,0 +1,892 @@
+#!/usr/bin/env python3
+"""
+Investigate bursty and short-lived attribution behavior for ENE-44.
+
+This harness runs controlled process patterns while release EMT monitors all
+processes with configurable low-overhead cadences. It records process ground
+truth from the workload, independent /proc CPU-time samples, and compact EMT
+group evidence so short-lived failures can be separated into discovery,
+grouping, and exit-accounting gaps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from collections import Counter, defaultdict
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_BINARY = PROJECT_ROOT / "target" / "release" / "emt"
+DEFAULT_OUTPUT = PROJECT_ROOT / ".artifacts" / "burst_attribution_results.json"
+WORKLOAD_SCRIPT = PROJECT_ROOT / "scripts" / "burst_attribution_workload.py"
+DEFAULT_SWEEP_RUNTIMES = [2.0, 10.0, 20.0, 35.0, 52.0]
+DEFAULT_SWEEP_START_OFFSETS = [0.0, 10.0, 20.0]
+TOP_GROUP_EVIDENCE_LIMIT = 25
+
+
+@dataclass
+class ExpectedProcess:
+    pid: int
+    role: str
+    expected_runtime_seconds: float | None
+    sweep_repetition: int | None
+    sweep_start_offset_seconds: float | None
+    self_reported_cpu_ticks_delta: int | None
+
+
+@dataclass
+class ProcCpuSample:
+    timestamp: float
+    pid: int
+    cpu_ticks: int
+
+
+@dataclass
+class ProcCpuEvidence:
+    pid: int
+    sample_count: int
+    first_cpu_ticks: int | None
+    last_cpu_ticks: int | None
+    observed_cpu_ticks: int
+    externally_observed: bool
+
+
+@dataclass
+class ProcessFinding:
+    pid: int
+    role: str
+    expected_runtime_seconds: float | None
+    sweep_repetition: int | None
+    sweep_start_offset_seconds: float | None
+    discovered: bool
+    attributed: bool
+    energy_joules: float
+    group_id: str | None
+    group_energy_joules: float
+    proc_cpu_ticks_observed: int
+    proc_cpu_sample_count: int
+    self_reported_cpu_ticks_delta: int | None
+    failure_mode: str
+
+
+@dataclass
+class GroupProcessEnergy:
+    pid: int
+    energy_joules: float
+
+
+@dataclass
+class GroupEvidence:
+    group_id: str | None
+    root_pid: int | None
+    energy_joules: float
+    process_pids: list[int]
+    process_energy_joules: list[GroupProcessEnergy]
+    evidence_reason: str
+
+
+@dataclass
+class PatternResult:
+    pattern: str
+    monitor_duration_seconds: float
+    workload_duration_seconds: float
+    collection_rate_hz: float
+    scan_interval_secs: float
+    attribution_refresh_secs: float
+    expected_processes: list[ExpectedProcess]
+    findings: list[ProcessFinding]
+    proc_cpu_evidence: list[ProcCpuEvidence]
+    group_evidence: list[GroupEvidence]
+    snapshot_group_count: int
+    snapshot_group_energy_joules: float
+    workload_events: list[dict[str, Any]]
+    unattributed_joules: float
+    system_total_joules: float
+    recommendation: str
+
+
+def parse_event_line(line: str) -> dict[str, Any] | None:
+    line = line.strip()
+    if not line:
+        return None
+    try:
+        event = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    return event if isinstance(event, dict) else None
+
+
+def parse_workload_events(stdout: str) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for line in stdout.splitlines():
+        event = parse_event_line(line)
+        if event is not None:
+            events.append(event)
+    return events
+
+
+def expected_processes(events: list[dict[str, Any]]) -> list[ExpectedProcess]:
+    runtimes: dict[int, float | None] = {}
+    roles: dict[int, str] = {}
+    repetitions: dict[int, int | None] = {}
+    start_offsets: dict[int, float | None] = {}
+    self_ticks: dict[int, int | None] = {}
+    for event in events:
+        pid = event.get("pid")
+        if not isinstance(pid, int):
+            continue
+        roles[pid] = str(event.get("role", "unknown"))
+        if event.get("event") == "child_spawned":
+            runtimes[pid] = float(event.get("expected_runtime_seconds", 0.0))
+            repetition = event.get("sweep_repetition")
+            repetitions[pid] = repetition if isinstance(repetition, int) else None
+            offset = event.get("sweep_start_offset_seconds")
+            start_offsets[pid] = (
+                float(offset) if isinstance(offset, (int, float)) else None
+            )
+        elif event.get("event") == "process_end":
+            if "runtime_seconds" in event:
+                runtimes[pid] = float(event["runtime_seconds"])
+            ticks_delta = event.get("self_cpu_ticks_delta")
+            self_ticks[pid] = ticks_delta if isinstance(ticks_delta, int) else None
+        else:
+            runtimes.setdefault(pid, None)
+    return [
+        ExpectedProcess(
+            pid=pid,
+            role=roles.get(pid, "unknown"),
+            expected_runtime_seconds=runtimes.get(pid),
+            sweep_repetition=repetitions.get(pid),
+            sweep_start_offset_seconds=start_offsets.get(pid),
+            self_reported_cpu_ticks_delta=self_ticks.get(pid),
+        )
+        for pid in sorted(roles)
+    ]
+
+
+def load_snapshot(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def device_energy_total(energy: dict[str, Any]) -> float:
+    return sum(
+        float(energy.get(key, 0.0))
+        for key in ("cpu_joules", "dram_joules", "gpu_joules")
+    )
+
+
+def read_proc_cpu_ticks(pid: int) -> int | None:
+    try:
+        stat = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return None
+    fields = stat[stat.rfind(")") + 2 :].split()
+    if len(fields) < 13:
+        return None
+    try:
+        return int(fields[11]) + int(fields[12])
+    except ValueError:
+        return None
+
+
+def read_workload_stdout(
+    proc: subprocess.Popen[str],
+    events: list[dict[str, Any]],
+    known_pids: set[int],
+    lock: threading.Lock,
+) -> None:
+    if proc.stdout is None:
+        return
+    for line in proc.stdout:
+        event = parse_event_line(line)
+        if event is None:
+            continue
+        with lock:
+            events.append(event)
+            pid = event.get("pid")
+            if isinstance(pid, int):
+                known_pids.add(pid)
+
+
+def sample_known_pids(
+    known_pids: set[int], lock: threading.Lock, samples: list[ProcCpuSample]
+) -> None:
+    with lock:
+        pids = sorted(known_pids)
+    timestamp = time.time()
+    for pid in pids:
+        ticks = read_proc_cpu_ticks(pid)
+        if ticks is not None:
+            samples.append(ProcCpuSample(timestamp, pid, ticks))
+
+
+def run_workload_collecting_proc_evidence(
+    cmd: list[str], timeout: float, sample_interval: float
+) -> tuple[list[dict[str, Any]], list[ProcCpuSample], int, str]:
+    events: list[dict[str, Any]] = []
+    samples: list[ProcCpuSample] = []
+    known_pids: set[int] = set()
+    lock = threading.Lock()
+    proc = subprocess.Popen(
+        cmd,
+        cwd=PROJECT_ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+        start_new_session=True,
+    )
+    with lock:
+        known_pids.add(proc.pid)
+    reader = threading.Thread(
+        target=read_workload_stdout,
+        args=(proc, events, known_pids, lock),
+        daemon=True,
+    )
+    reader.start()
+
+    deadline = time.time() + timeout
+    while proc.poll() is None:
+        if time.time() > deadline:
+            proc.kill()
+            proc.wait(timeout=5)
+            raise RuntimeError(f"workload timed out after {timeout:.1f}s")
+        sample_known_pids(known_pids, lock, samples)
+        time.sleep(sample_interval)
+    sample_known_pids(known_pids, lock, samples)
+    reader.join(timeout=2)
+    stderr = proc.stderr.read() if proc.stderr is not None else ""
+    with lock:
+        final_events = list(events)
+    return final_events, samples, int(proc.returncode or 0), stderr
+
+
+def cpu_evidence_by_pid(
+    samples: list[ProcCpuSample], expected: list[ExpectedProcess]
+) -> dict[int, ProcCpuEvidence]:
+    samples_by_pid: dict[int, list[ProcCpuSample]] = defaultdict(list)
+    for sample in samples:
+        samples_by_pid[sample.pid].append(sample)
+
+    evidence: dict[int, ProcCpuEvidence] = {}
+    for process in expected:
+        pid_samples = sorted(
+            samples_by_pid.get(process.pid, []), key=lambda sample: sample.timestamp
+        )
+        if pid_samples:
+            first = pid_samples[0].cpu_ticks
+            last = pid_samples[-1].cpu_ticks
+            observed = max(0, last - first)
+            evidence[process.pid] = ProcCpuEvidence(
+                pid=process.pid,
+                sample_count=len(pid_samples),
+                first_cpu_ticks=first,
+                last_cpu_ticks=last,
+                observed_cpu_ticks=observed,
+                externally_observed=True,
+            )
+        else:
+            evidence[process.pid] = ProcCpuEvidence(
+                pid=process.pid,
+                sample_count=0,
+                first_cpu_ticks=None,
+                last_cpu_ticks=None,
+                observed_cpu_ticks=0,
+                externally_observed=False,
+            )
+    return evidence
+
+
+def find_process(
+    snapshot: dict[str, Any], pid: int
+) -> tuple[bool, float, str | None, float]:
+    for workload in snapshot.get("workloads", []):
+        group_energy = device_energy_total(workload.get("energy", {}))
+        if workload.get("root_pid") == pid:
+            return True, group_energy, workload.get("group_id"), group_energy
+        for process in workload.get("processes", []):
+            if process.get("pid") == pid:
+                return (
+                    True,
+                    device_energy_total(process.get("energy", {})),
+                    workload.get("group_id"),
+                    group_energy,
+                )
+    return False, 0.0, None, 0.0
+
+
+def process_has_cpu_evidence(
+    proc_ticks_observed: int,
+    proc_sample_count: int,
+    self_reported_ticks: int | None,
+) -> bool:
+    return (
+        proc_ticks_observed > 0
+        or proc_sample_count > 0
+        or (self_reported_ticks is not None and self_reported_ticks > 0)
+    )
+
+
+def classify_failure_mode(
+    discovered: bool,
+    attributed: bool,
+    proc_ticks_observed: int,
+    proc_sample_count: int,
+    self_reported_ticks: int | None,
+) -> str:
+    if attributed:
+        return "attributed"
+    if not process_has_cpu_evidence(
+        proc_ticks_observed, proc_sample_count, self_reported_ticks
+    ):
+        return "no_cpu_time_evidence"
+    if not discovered:
+        return "not_discovered_before_exit_or_grouped_elsewhere"
+    return "discovered_without_energy_exit_accounting_or_sample_gap"
+
+
+def build_findings(
+    snapshot: dict[str, Any],
+    expected: list[ExpectedProcess],
+    cpu_evidence: dict[int, ProcCpuEvidence] | None = None,
+) -> list[ProcessFinding]:
+    findings = []
+    cpu_evidence = cpu_evidence or {}
+    for process in expected:
+        discovered, energy, group_id, group_energy = find_process(snapshot, process.pid)
+        proc_evidence = cpu_evidence.get(
+            process.pid,
+            ProcCpuEvidence(
+                pid=process.pid,
+                sample_count=0,
+                first_cpu_ticks=None,
+                last_cpu_ticks=None,
+                observed_cpu_ticks=0,
+                externally_observed=False,
+            ),
+        )
+        failure_mode = classify_failure_mode(
+            discovered,
+            energy > 0.0,
+            proc_evidence.observed_cpu_ticks,
+            proc_evidence.sample_count,
+            process.self_reported_cpu_ticks_delta,
+        )
+        findings.append(
+            ProcessFinding(
+                pid=process.pid,
+                role=process.role,
+                expected_runtime_seconds=process.expected_runtime_seconds,
+                sweep_repetition=process.sweep_repetition,
+                sweep_start_offset_seconds=process.sweep_start_offset_seconds,
+                discovered=discovered,
+                attributed=energy > 0.0,
+                energy_joules=energy,
+                group_id=group_id,
+                group_energy_joules=group_energy,
+                proc_cpu_ticks_observed=proc_evidence.observed_cpu_ticks,
+                proc_cpu_sample_count=proc_evidence.sample_count,
+                self_reported_cpu_ticks_delta=process.self_reported_cpu_ticks_delta,
+                failure_mode=failure_mode,
+            )
+        )
+    return findings
+
+
+def group_evidence_from_workload(
+    workload: dict[str, Any], reason: str
+) -> GroupEvidence:
+    process_pids = []
+    process_energies = []
+    root_pid = workload.get("root_pid")
+    if isinstance(root_pid, int):
+        process_pids.append(root_pid)
+    for process in workload.get("processes", []):
+        pid = process.get("pid")
+        if not isinstance(pid, int):
+            continue
+        process_pids.append(pid)
+        process_energies.append(
+            GroupProcessEnergy(
+                pid=pid,
+                energy_joules=device_energy_total(process.get("energy", {})),
+            )
+        )
+    return GroupEvidence(
+        group_id=workload.get("group_id"),
+        root_pid=root_pid if isinstance(root_pid, int) else None,
+        energy_joules=device_energy_total(workload.get("energy", {})),
+        process_pids=sorted(set(process_pids)),
+        process_energy_joules=process_energies,
+        evidence_reason=reason,
+    )
+
+
+def compact_group_evidence(
+    snapshot: dict[str, Any],
+    expected_pids: set[int],
+    top_limit: int = TOP_GROUP_EVIDENCE_LIMIT,
+) -> list[GroupEvidence]:
+    evidence_by_group_id: dict[str, GroupEvidence] = {}
+    for workload in snapshot.get("workloads", []):
+        evidence = group_evidence_from_workload(workload, "expected_pid_intersection")
+        if expected_pids.intersection(evidence.process_pids):
+            evidence_by_group_id[str(evidence.group_id)] = evidence
+
+    top_groups = sorted(
+        snapshot.get("workloads", []),
+        key=lambda workload: device_energy_total(workload.get("energy", {})),
+        reverse=True,
+    )[:top_limit]
+    for workload in top_groups:
+        evidence = group_evidence_from_workload(workload, "top_energy_group")
+        group_key = str(evidence.group_id)
+        if group_key in evidence_by_group_id:
+            evidence_by_group_id[group_key].evidence_reason = (
+                "expected_pid_intersection,top_energy_group"
+            )
+        else:
+            evidence_by_group_id[group_key] = evidence
+
+    return sorted(
+        evidence_by_group_id.values(),
+        key=lambda evidence: evidence.energy_joules,
+        reverse=True,
+    )
+
+
+def recommendation_for(
+    pattern: str, findings: list[ProcessFinding], refresh_secs: float
+) -> str:
+    non_root = [finding for finding in findings if finding.role != "root"]
+    targets = non_root or findings
+    if not targets:
+        return "No expected processes were emitted by the workload."
+    if all(finding.discovered and finding.attributed for finding in targets):
+        return "Observed processes were discovered and attributed under this cadence."
+    failure_modes = Counter(finding.failure_mode for finding in targets)
+    if pattern in {"child_under_interval", "many_short"}:
+        return (
+            "Sub-interval processes were missed or partially attributed; this is a "
+            f"cadence/discovery limit at {refresh_secs:.2f}s refresh. Prefer "
+            "event-based child discovery or retained exit accounting; only lower "
+            "the cadence if ENE-43 overhead is re-benchmarked and still passes. "
+            f"failure_modes={dict(failure_modes)}"
+        )
+    return (
+        "Expected processes were not fully attributed; investigate event-based "
+        "child discovery, retained PID maps, and exit accounting before reducing "
+        f"cadence. failure_modes={dict(failure_modes)}"
+    )
+
+
+def run_pattern(
+    pattern: str,
+    binary: Path,
+    monitor_duration: float,
+    workload_duration: float,
+    rate: float,
+    scan_interval: float,
+    sweep_runtimes: list[float],
+    sweep_repetitions: int,
+    sweep_start_offsets: list[float],
+    proc_sample_interval: float,
+) -> PatternResult:
+    refresh_secs = 1.0 / rate
+    minimum_reliable_runtime = scan_interval + (2.0 * refresh_secs)
+    child_over_runtime = minimum_reliable_runtime + 2.0
+    child_under_runtime = max(0.05, min(refresh_secs, scan_interval) / 2.0)
+    (PROJECT_ROOT / ".artifacts").mkdir(exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=PROJECT_ROOT / ".artifacts") as tmp:
+        tmp_path = Path(tmp)
+        snapshot_path = tmp_path / "snapshot.json"
+        cli_output_path = tmp_path / "emt.json"
+        emt = subprocess.Popen(
+            [
+                str(binary),
+                "--json-out",
+                str(cli_output_path),
+                "--duration",
+                str(round(monitor_duration)),
+                "--rate",
+                str(rate),
+                "--scan-interval",
+                str(scan_interval),
+                "--snapshot-out",
+                str(snapshot_path),
+            ],
+            cwd=PROJECT_ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
+        try:
+            time.sleep(1.0)
+            workload_cmd = [
+                sys.executable,
+                str(WORKLOAD_SCRIPT),
+                pattern,
+                "--duration",
+                str(workload_duration),
+            ]
+            if pattern == "child_over_interval":
+                workload_cmd.extend(["--child-runtime", str(child_over_runtime)])
+            elif pattern in {"child_under_interval", "many_short"}:
+                workload_cmd.extend(
+                    [
+                        "--child-runtime",
+                        str(child_under_runtime),
+                        "--spawn-interval",
+                        str(max(child_under_runtime, 0.1)),
+                    ]
+                )
+            elif pattern == "lifetime_sweep":
+                workload_cmd.extend(
+                    [
+                        "--child-runtimes",
+                        ",".join(str(runtime) for runtime in sweep_runtimes),
+                        "--sweep-repetitions",
+                        str(sweep_repetitions),
+                        "--sweep-start-offsets",
+                        ",".join(str(offset) for offset in sweep_start_offsets),
+                    ]
+                )
+            events, proc_samples, workload_returncode, workload_stderr = (
+                run_workload_collecting_proc_evidence(
+                    workload_cmd,
+                    timeout=monitor_duration + 5,
+                    sample_interval=proc_sample_interval,
+                )
+            )
+            stdout, stderr = emt.communicate(timeout=monitor_duration + 10)
+        finally:
+            if emt.poll() is None:
+                emt.terminate()
+                try:
+                    emt.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    emt.kill()
+                    emt.wait(timeout=5)
+
+        if emt.returncode != 0:
+            raise RuntimeError(f"emt failed with {emt.returncode}: {stderr or stdout}")
+        if workload_returncode != 0:
+            raise RuntimeError(
+                f"workload failed with {workload_returncode}: {workload_stderr}"
+            )
+        snapshot = load_snapshot(snapshot_path)
+
+    expected = expected_processes(events)
+    evidence_by_pid = cpu_evidence_by_pid(proc_samples, expected)
+    findings = build_findings(snapshot, expected, evidence_by_pid)
+    group_evidence = compact_group_evidence(
+        snapshot, {process.pid for process in expected}
+    )
+    snapshot_workloads = snapshot.get("workloads", [])
+    unattributed = device_energy_total(snapshot.get("unattributed", {}))
+    system_total = device_energy_total(snapshot.get("system_total", {}))
+    return PatternResult(
+        pattern=pattern,
+        monitor_duration_seconds=monitor_duration,
+        workload_duration_seconds=workload_duration,
+        collection_rate_hz=rate,
+        scan_interval_secs=scan_interval,
+        attribution_refresh_secs=refresh_secs,
+        expected_processes=expected,
+        findings=findings,
+        proc_cpu_evidence=list(evidence_by_pid.values()),
+        group_evidence=group_evidence,
+        snapshot_group_count=len(snapshot_workloads),
+        snapshot_group_energy_joules=sum(
+            device_energy_total(workload.get("energy", {}))
+            for workload in snapshot_workloads
+        ),
+        workload_events=events,
+        unattributed_joules=unattributed,
+        system_total_joules=system_total,
+        recommendation=recommendation_for(pattern, findings, refresh_secs),
+    )
+
+
+def has_cpu_evidence(finding: ProcessFinding) -> bool:
+    return process_has_cpu_evidence(
+        finding.proc_cpu_ticks_observed,
+        finding.proc_cpu_sample_count,
+        finding.self_reported_cpu_ticks_delta,
+    )
+
+
+def lifetime_sweep_summary(results: list[PatternResult]) -> list[dict[str, Any]]:
+    grouped: dict[float, list[ProcessFinding]] = defaultdict(list)
+    for result in results:
+        if result.pattern != "lifetime_sweep":
+            continue
+        for finding in result.findings:
+            if finding.role == "root" or finding.expected_runtime_seconds is None:
+                continue
+            grouped[finding.expected_runtime_seconds].append(finding)
+
+    summary = []
+    for runtime, findings in sorted(grouped.items()):
+        expected = len(findings)
+        discovered = sum(1 for finding in findings if finding.discovered)
+        attributed = sum(1 for finding in findings if finding.attributed)
+        cpu_evidence = sum(1 for finding in findings if has_cpu_evidence(finding))
+        start_offsets = sorted(
+            {
+                finding.sweep_start_offset_seconds
+                for finding in findings
+                if finding.sweep_start_offset_seconds is not None
+            }
+        )
+        summary.append(
+            {
+                "runtime_seconds": runtime,
+                "start_offsets_seconds": start_offsets,
+                "expected": expected,
+                "discovered": discovered,
+                "attributed": attributed,
+                "cpu_evidence_processes": cpu_evidence,
+                "reliable": (
+                    expected > 0
+                    and discovered == expected
+                    and attributed == expected
+                    and cpu_evidence == expected
+                ),
+                "failure_modes": dict(
+                    Counter(finding.failure_mode for finding in findings)
+                ),
+            }
+        )
+    return summary
+
+
+def exit_accounting_assessment(results: list[PatternResult]) -> str:
+    if not results:
+        return "No benchmark results were collected."
+    target_runtime = results[0].scan_interval_secs + (
+        2.0 * results[0].attribution_refresh_secs
+    )
+    findings_with_cpu = [
+        finding
+        for result in results
+        for finding in result.findings
+        if finding.role != "root" and has_cpu_evidence(finding)
+    ]
+    long_failures = [
+        finding
+        for finding in findings_with_cpu
+        if finding.expected_runtime_seconds is not None
+        and finding.expected_runtime_seconds >= target_runtime
+        and not finding.attributed
+    ]
+    if long_failures:
+        return (
+            f"Exit accounting/discovery is insufficient: {len(long_failures)} "
+            f"processes at or above the {target_runtime:.1f}s scan+sample target "
+            "had CPU-time evidence but no process-level attribution."
+        )
+    short_failures = [
+        finding for finding in findings_with_cpu if not finding.attributed
+    ]
+    if short_failures:
+        return (
+            "Long-lived processes at the scan+sample target were attributed, but "
+            f"{len(short_failures)} shorter CPU-active processes were missed or "
+            "partially attributed. Event-based child discovery or retained exit "
+            "accounting is needed if those lifetimes must be reported."
+        )
+    return (
+        "All CPU-active non-root processes observed in this run were discovered and "
+        "attributed under the tested cadence."
+    )
+
+
+def summarize(results: list[PatternResult]) -> dict[str, Any]:
+    minimum_observed_attributed_lifetime = None
+    for result in results:
+        attributed_lifetimes = [
+            finding.expected_runtime_seconds
+            for finding in result.findings
+            if finding.role != "root"
+            and finding.expected_runtime_seconds is not None
+            and finding.discovered
+            and finding.attributed
+        ]
+        if attributed_lifetimes:
+            candidate = min(attributed_lifetimes)
+            minimum_observed_attributed_lifetime = (
+                candidate
+                if minimum_observed_attributed_lifetime is None
+                else min(minimum_observed_attributed_lifetime, candidate)
+            )
+
+    sweep_summary = lifetime_sweep_summary(results)
+    reliable_runtimes = [
+        row["runtime_seconds"] for row in sweep_summary if row["reliable"]
+    ]
+
+    by_pattern = {}
+    for result in results:
+        failure_modes = Counter(finding.failure_mode for finding in result.findings)
+        non_root_findings = [
+            finding for finding in result.findings if finding.role != "root"
+        ]
+        non_root_failure_modes = Counter(
+            finding.failure_mode for finding in non_root_findings
+        )
+        by_pattern[result.pattern] = {
+            "expected": len(result.findings),
+            "discovered": sum(1 for finding in result.findings if finding.discovered),
+            "attributed": sum(1 for finding in result.findings if finding.attributed),
+            "cpu_evidence_processes": sum(
+                1 for finding in result.findings if has_cpu_evidence(finding)
+            ),
+            "non_root_expected": len(non_root_findings),
+            "non_root_discovered": sum(
+                1 for finding in non_root_findings if finding.discovered
+            ),
+            "non_root_attributed": sum(
+                1 for finding in non_root_findings if finding.attributed
+            ),
+            "non_root_cpu_evidence_processes": sum(
+                1 for finding in non_root_findings if has_cpu_evidence(finding)
+            ),
+            "group_evidence_groups": len(result.group_evidence),
+            "snapshot_group_count": result.snapshot_group_count,
+            "snapshot_group_energy_joules": result.snapshot_group_energy_joules,
+            "unattributed_joules": result.unattributed_joules,
+            "system_total_joules": result.system_total_joules,
+            "failure_modes": dict(failure_modes),
+            "non_root_failure_modes": dict(non_root_failure_modes),
+            "recommendation": result.recommendation,
+        }
+    return {
+        "minimum_observed_attributed_lifetime_seconds": (
+            minimum_observed_attributed_lifetime
+        ),
+        "minimum_reliable_lifetime_seconds": (
+            min(reliable_runtimes) if reliable_runtimes else None
+        ),
+        "lifetime_sweep": sweep_summary,
+        "exit_accounting_assessment": exit_accounting_assessment(results),
+        "patterns": by_pattern,
+    }
+
+
+def parse_sweep_runtimes(value: str) -> list[float]:
+    runtimes = [float(item) for item in value.split(",") if item.strip()]
+    if not runtimes:
+        raise argparse.ArgumentTypeError("at least one sweep runtime is required")
+    if any(runtime <= 0 for runtime in runtimes):
+        raise argparse.ArgumentTypeError("sweep runtimes must be positive")
+    return runtimes
+
+
+def parse_sweep_offsets(value: str) -> list[float]:
+    offsets = [float(item) for item in value.split(",") if item.strip()]
+    if not offsets:
+        raise argparse.ArgumentTypeError("at least one sweep offset is required")
+    if any(offset < 0 for offset in offsets):
+        raise argparse.ArgumentTypeError("sweep offsets must be non-negative")
+    return offsets
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--emt-binary", type=Path, default=DEFAULT_BINARY)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--monitor-duration", type=float, default=90.0)
+    parser.add_argument("--workload-duration", type=float, default=60.0)
+    parser.add_argument("--rate", type=float, default=0.1)
+    parser.add_argument("--scan-interval", type=float, default=30.0)
+    parser.add_argument(
+        "--pattern",
+        action="append",
+        choices=[
+            "long_lived_bursts",
+            "child_over_interval",
+            "child_under_interval",
+            "lifetime_sweep",
+            "many_short",
+        ],
+    )
+    parser.add_argument(
+        "--sweep-runtimes",
+        type=parse_sweep_runtimes,
+        default=DEFAULT_SWEEP_RUNTIMES,
+    )
+    parser.add_argument("--sweep-repetitions", type=int, default=3)
+    parser.add_argument(
+        "--sweep-start-offsets",
+        type=parse_sweep_offsets,
+        default=DEFAULT_SWEEP_START_OFFSETS,
+    )
+    parser.add_argument("--proc-sample-interval", type=float, default=0.25)
+    parser.add_argument("--no-build", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.no_build:
+        subprocess.run(["cargo", "build", "--release"], cwd=PROJECT_ROOT, check=True)
+    if not args.emt_binary.exists():
+        raise SystemExit(f"missing release binary: {args.emt_binary}")
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    (PROJECT_ROOT / ".artifacts").mkdir(exist_ok=True)
+    patterns = args.pattern or [
+        "long_lived_bursts",
+        "child_over_interval",
+        "child_under_interval",
+        "lifetime_sweep",
+        "many_short",
+    ]
+    results = []
+    for pattern in patterns:
+        print(f"pattern={pattern}", flush=True)
+        results.append(
+            run_pattern(
+                pattern,
+                args.emt_binary,
+                args.monitor_duration,
+                args.workload_duration,
+                args.rate,
+                args.scan_interval,
+                args.sweep_runtimes,
+                args.sweep_repetitions,
+                args.sweep_start_offsets,
+                args.proc_sample_interval,
+            )
+        )
+    payload = {
+        "metadata": {
+            "monitor_duration_seconds": args.monitor_duration,
+            "workload_duration_seconds": args.workload_duration,
+            "rate_hz": args.rate,
+            "scan_interval_secs": args.scan_interval,
+            "sweep_runtimes": args.sweep_runtimes,
+            "sweep_repetitions": args.sweep_repetitions,
+            "sweep_start_offsets": args.sweep_start_offsets,
+            "proc_sample_interval_seconds": args.proc_sample_interval,
+            "top_group_evidence_limit": TOP_GROUP_EVIDENCE_LIMIT,
+        },
+        "summary": summarize(results),
+        "results": [asdict(result) for result in results],
+    }
+    args.output.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_emt_overhead.py
+++ b/scripts/benchmark_emt_overhead.py
@@ -1,0 +1,770 @@
+#!/usr/bin/env python3
+"""
+Benchmark release EMT self-overhead for ENE-43.
+
+The primary signal is external: raw host package+DRAM RAPL energy over a fixed
+window, plus EMT process-tree CPU time sampled from /proc. The TUI snapshot is
+captured only as a diagnostic cross-check for attribution/grouping behavior.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import pty
+import statistics
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+WORKLOAD_SCRIPT = PROJECT_ROOT / "scripts" / "verification_workload.py"
+DEFAULT_BINARY = PROJECT_ROOT / "target" / "release" / "emt"
+DEFAULT_OUTPUT = PROJECT_ROOT / ".artifacts" / "emt_overhead_benchmark.json"
+RAPL_ROOT = Path("/sys/class/powercap")
+CLOCK_TICKS = os.sysconf(os.sysconf_names.get("SC_CLK_TCK", "SC_CLK_TCK"))
+PAGE_SIZE = os.sysconf(os.sysconf_names.get("SC_PAGE_SIZE", "SC_PAGE_SIZE"))
+DEFAULT_COMPARISON_RATE_HZ = 0.1
+DEFAULT_COMPARISON_SCAN_INTERVAL_SECS = 30.0
+DISPLAY_EXTERNAL_AGREEMENT_PERCENT = 1.0
+VISIBLE_TUI_MAX_PERCENT = 1.0
+REQUIRED_NON_IDLE_RUNS = 3
+
+
+@dataclass
+class ProcSample:
+    timestamp: float
+    pids: list[int]
+    cpu_ticks: int
+    rss_bytes: int
+    system_active_ticks: int
+
+
+@dataclass
+class RunResult:
+    mode: str
+    workload: str
+    iteration: int
+    duration_seconds: float
+    emt_pid: int
+    workload_pids: list[int]
+    raw_package_dram_joules: float
+    emt_cpu_seconds: float
+    system_active_cpu_seconds: float
+    emt_cpu_share: float
+    external_estimated_emt_joules: float
+    external_overhead_percent: float
+    peak_rss_bytes: int
+    rss_samples_bytes: list[int]
+    process_sample_count: int
+    min_process_count: int
+    max_process_count: int
+    pids_seen: list[int]
+    tracked_pid_count: int | None
+    collection_tick_count: int | None
+    process_scan_count: int | None
+    snapshot_process_group_count: int | None
+    snapshot_emt_group_found: bool
+    snapshot_emt_group_ids: list[str]
+    snapshot_emt_percentage: float | None
+    snapshot_emt_energy_joules: float | None
+    snapshot_workload_groups_found: int
+    snapshot_workload_group_ids: list[str]
+    snapshot_groups_distinct: bool | None
+    displayed_vs_external_delta_percent: float | None
+    displayed_external_agree: bool | None
+    displayed_attribution_diagnostic: str
+    collection_rate_hz: float
+    scan_interval_secs: float
+    render_interval_millis: int | None
+    rapl_zones: list[dict[str, Any]]
+
+
+def readable_rapl_zones(root: Path = RAPL_ROOT) -> list[Path]:
+    zones: list[Path] = []
+    for entry in sorted(root.iterdir() if root.exists() else []):
+        if not entry.name.startswith(("intel-rapl", "amd-rapl")):
+            continue
+        if (entry / "energy_uj").exists() and (entry / "name").exists():
+            zones.append(entry)
+    return zones
+
+
+def zone_is_package_or_dram(zone: Path) -> bool:
+    try:
+        name = (zone / "name").read_text(encoding="utf-8").strip().lower()
+    except OSError:
+        return False
+    return name.startswith("package") or "dram" in name
+
+
+def read_rapl_snapshot(root: Path = RAPL_ROOT) -> dict[str, dict[str, Any]]:
+    snapshot: dict[str, dict[str, Any]] = {}
+    for zone in readable_rapl_zones(root):
+        if not zone_is_package_or_dram(zone):
+            continue
+        try:
+            energy_uj = int((zone / "energy_uj").read_text(encoding="utf-8").strip())
+            name = (zone / "name").read_text(encoding="utf-8").strip()
+        except (OSError, ValueError):
+            continue
+        max_path = zone / "max_energy_range_uj"
+        try:
+            max_energy_uj = int(max_path.read_text(encoding="utf-8").strip())
+        except (OSError, ValueError):
+            max_energy_uj = None
+        snapshot[str(zone)] = {
+            "name": name,
+            "energy_uj": energy_uj,
+            "max_energy_uj": max_energy_uj,
+        }
+    return snapshot
+
+
+def rapl_delta_joules(
+    before: dict[str, dict[str, Any]], after: dict[str, dict[str, Any]]
+) -> tuple[float, list[dict[str, Any]]]:
+    total_uj = 0
+    zones: list[dict[str, Any]] = []
+    for path, start in before.items():
+        end = after.get(path)
+        if end is None:
+            continue
+        start_uj = int(start["energy_uj"])
+        end_uj = int(end["energy_uj"])
+        max_energy_uj = start.get("max_energy_uj")
+        if end_uj >= start_uj:
+            delta_uj = end_uj - start_uj
+        elif max_energy_uj:
+            delta_uj = end_uj + int(max_energy_uj) - start_uj
+        else:
+            delta_uj = 0
+        total_uj += delta_uj
+        zones.append(
+            {
+                "path": path,
+                "name": start["name"],
+                "delta_joules": delta_uj / 1_000_000.0,
+            }
+        )
+    return total_uj / 1_000_000.0, zones
+
+
+def process_tree(root_pid: int) -> list[int]:
+    children_by_parent: dict[int, list[int]] = {}
+    live: set[int] = set()
+    for proc_dir in Path("/proc").iterdir():
+        if not proc_dir.name.isdigit():
+            continue
+        pid = int(proc_dir.name)
+        try:
+            stat = (proc_dir / "stat").read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        fields = stat[stat.rfind(")") + 2 :].split()
+        if len(fields) < 2:
+            continue
+        try:
+            ppid = int(fields[1])
+        except ValueError:
+            continue
+        live.add(pid)
+        children_by_parent.setdefault(ppid, []).append(pid)
+
+    found: list[int] = []
+    stack = [root_pid]
+    seen: set[int] = set()
+    while stack:
+        pid = stack.pop()
+        if pid in seen:
+            continue
+        seen.add(pid)
+        if pid in live:
+            found.append(pid)
+        stack.extend(children_by_parent.get(pid, []))
+    return sorted(found)
+
+
+def read_proc_cpu_ticks(pid: int) -> int:
+    try:
+        stat = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return 0
+    fields = stat[stat.rfind(")") + 2 :].split()
+    if len(fields) < 13:
+        return 0
+    try:
+        return int(fields[11]) + int(fields[12])
+    except ValueError:
+        return 0
+
+
+def read_proc_rss_bytes(pid: int) -> int:
+    try:
+        fields = Path(f"/proc/{pid}/statm").read_text(encoding="utf-8").split()
+        return int(fields[1]) * PAGE_SIZE
+    except (OSError, ValueError, IndexError):
+        return 0
+
+
+def read_system_active_ticks() -> int:
+    try:
+        line = Path("/proc/stat").read_text(encoding="utf-8").splitlines()[0]
+    except (OSError, IndexError):
+        return 0
+    fields = [int(value) for value in line.split()[1:] if value.isdigit()]
+    if len(fields) < 4:
+        return 0
+    idle = fields[3] + (fields[4] if len(fields) > 4 else 0)
+    return sum(fields) - idle
+
+
+def sample_process_tree(root_pid: int) -> ProcSample:
+    pids = process_tree(root_pid)
+    return ProcSample(
+        timestamp=time.time(),
+        pids=pids,
+        cpu_ticks=sum(read_proc_cpu_ticks(pid) for pid in pids),
+        rss_bytes=sum(read_proc_rss_bytes(pid) for pid in pids),
+        system_active_ticks=read_system_active_ticks(),
+    )
+
+
+def start_workload(case: str, duration: float) -> list[subprocess.Popen[str]]:
+    if case == "idle":
+        return []
+    count = 1
+    if case == "multi_cpu":
+        count = max(2, (os.cpu_count() or 2) // 2)
+    return [
+        subprocess.Popen(
+            [sys.executable, str(WORKLOAD_SCRIPT), str(duration)],
+            cwd=PROJECT_ROOT,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            start_new_session=True,
+        )
+        for _ in range(count)
+    ]
+
+
+def free_port() -> int:
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def command_for_mode(
+    mode: str,
+    binary: Path,
+    duration: float,
+    snapshot_path: Path,
+    cli_output_path: Path,
+    rate: float | None,
+    scan_interval: float | None,
+) -> list[str]:
+    cmd = [str(binary), "--snapshot-out", str(snapshot_path)]
+    if rate is not None:
+        cmd.extend(["--rate", str(rate)])
+    if scan_interval is not None:
+        cmd.extend(["--scan-interval", str(scan_interval)])
+    if mode == "tui":
+        cmd.append("--tui")
+    elif mode == "headless":
+        cmd.extend(
+            [
+                "--headless",
+                "--export",
+                "prometheus",
+                "--bind",
+                "127.0.0.1",
+                "--port",
+                str(free_port()),
+            ]
+        )
+    elif mode == "json":
+        cmd.extend(
+            ["--json-out", str(cli_output_path), "--duration", str(math.ceil(duration))]
+        )
+    else:
+        raise ValueError(f"unsupported mode: {mode}")
+    return cmd
+
+
+def drain_fd(fd: int, sink: list[bytes], stop: threading.Event) -> None:
+    while not stop.is_set():
+        try:
+            chunk = os.read(fd, 4096)
+        except OSError:
+            break
+        if not chunk:
+            break
+        sink.append(chunk)
+
+
+def start_emt(
+    cmd: list[str], mode: str
+) -> tuple[subprocess.Popen[Any], int | None, threading.Event, list[bytes]]:
+    if mode != "tui":
+        proc = subprocess.Popen(
+            cmd,
+            cwd=PROJECT_ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        return proc, None, threading.Event(), []
+
+    master_fd, slave_fd = pty.openpty()
+    env = os.environ.copy()
+    env.setdefault("TERM", "xterm")
+    proc = subprocess.Popen(
+        cmd,
+        cwd=PROJECT_ROOT,
+        stdin=slave_fd,
+        stdout=slave_fd,
+        stderr=slave_fd,
+        env=env,
+        start_new_session=True,
+    )
+    os.close(slave_fd)
+    stop = threading.Event()
+    output: list[bytes] = []
+    thread = threading.Thread(
+        target=drain_fd, args=(master_fd, output, stop), daemon=True
+    )
+    thread.start()
+    return proc, master_fd, stop, output
+
+
+def stop_emt(
+    proc: subprocess.Popen[Any], mode: str, tty_fd: int | None, stop: threading.Event
+) -> None:
+    if proc.poll() is not None:
+        stop.set()
+        if tty_fd is not None:
+            try:
+                os.close(tty_fd)
+            except OSError:
+                pass
+        return
+    if mode == "tui" and tty_fd is not None:
+        try:
+            os.write(tty_fd, b"q")
+        except OSError:
+            pass
+    else:
+        proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+    stop.set()
+    if tty_fd is not None:
+        try:
+            os.close(tty_fd)
+        except OSError:
+            pass
+
+
+def load_snapshot(path: Path) -> dict[str, Any] | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def group_contains_pid(group: dict[str, Any], pid: int) -> bool:
+    if group.get("root_pid") == pid:
+        return True
+    return any(process.get("pid") == pid for process in group.get("processes", []))
+
+
+def snapshot_diagnostics(
+    snapshot: dict[str, Any] | None, emt_pids: set[int], workload_pids: list[int]
+) -> dict[str, Any]:
+    if snapshot is None:
+        return {
+            "emt_group_found": False,
+            "emt_group_ids": [],
+            "emt_percentage": None,
+            "emt_energy_joules": None,
+            "workload_group_ids": [],
+            "workload_groups_found": 0,
+            "groups_distinct": None,
+            "tracked_pid_count": None,
+            "collection_tick_count": None,
+            "process_scan_count": None,
+            "process_group_count": None,
+        }
+    workloads = snapshot.get("workloads", [])
+    emt_groups = []
+    for group in workloads:
+        if any(group_contains_pid(group, pid) for pid in emt_pids):
+            emt_groups.append(group)
+    workload_groups = {
+        group.get("group_id")
+        for group in workloads
+        if any(group_contains_pid(group, pid) for pid in workload_pids)
+    }
+    workload_groups = {group_id for group_id in workload_groups if group_id is not None}
+    emt_group_ids = {
+        group.get("group_id")
+        for group in emt_groups
+        if group.get("group_id") is not None
+    }
+    energy = None
+    percentage = None
+    if emt_groups:
+        energy = 0.0
+        percentage = 0.0
+        for group in emt_groups:
+            device_energy = group.get("energy", {})
+            energy += sum(
+                float(device_energy.get(key, 0.0))
+                for key in ("cpu_joules", "dram_joules", "gpu_joules")
+            )
+            percentage += float(group.get("percentage_of_system", 0.0))
+    groups_distinct = None
+    if workload_pids:
+        groups_distinct = (
+            bool(emt_group_ids)
+            and bool(workload_groups)
+            and emt_group_ids.isdisjoint(workload_groups)
+        )
+    diagnostics = snapshot.get("diagnostics", {})
+    return {
+        "emt_group_found": bool(emt_groups),
+        "emt_group_ids": sorted(emt_group_ids),
+        "emt_percentage": percentage,
+        "emt_energy_joules": energy,
+        "workload_group_ids": sorted(workload_groups),
+        "workload_groups_found": len(workload_groups),
+        "groups_distinct": groups_distinct,
+        "tracked_pid_count": len(snapshot.get("tracked_pids", [])),
+        "collection_tick_count": diagnostics.get("collection_ticks"),
+        "process_scan_count": diagnostics.get("process_scans"),
+        "process_group_count": diagnostics.get("process_groups"),
+    }
+
+
+def displayed_attribution_diagnostic(
+    displayed_percent: float | None,
+    external_percent: float,
+    groups_distinct: bool | None,
+) -> tuple[float | None, bool | None, str]:
+    if displayed_percent is None:
+        return None, None, "snapshot_missing_emt_group"
+    delta = abs(displayed_percent - external_percent)
+    agree = delta <= DISPLAY_EXTERNAL_AGREEMENT_PERCENT
+    if groups_distinct is False:
+        return delta, agree, "grouping_not_distinct"
+    if agree:
+        return delta, True, "display_agrees_with_external_estimate"
+    return delta, False, "display_appears_to_include_attribution_artifact"
+
+
+def run_once(
+    mode: str,
+    workload: str,
+    iteration: int,
+    duration: float,
+    binary: Path,
+    rate: float | None,
+    scan_interval: float | None,
+) -> RunResult:
+    (PROJECT_ROOT / ".artifacts").mkdir(exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=PROJECT_ROOT / ".artifacts") as tmp:
+        tmp_path = Path(tmp)
+        snapshot_path = tmp_path / "snapshot.json"
+        cli_output_path = tmp_path / "cli-output.json"
+        cmd = command_for_mode(
+            mode, binary, duration, snapshot_path, cli_output_path, rate, scan_interval
+        )
+
+        proc, tty_fd, stop, _output = start_emt(cmd, mode)
+        try:
+            time.sleep(1.0)
+            before_rapl = read_rapl_snapshot()
+            start_sample = sample_process_tree(proc.pid)
+            workloads = start_workload(workload, duration)
+            workload_pids = [process.pid for process in workloads]
+            samples = [start_sample]
+            deadline = time.time() + duration
+            while time.time() < deadline and proc.poll() is None:
+                time.sleep(min(1.0, max(0.1, deadline - time.time())))
+                samples.append(sample_process_tree(proc.pid))
+            for workload_proc in workloads:
+                try:
+                    workload_proc.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    workload_proc.terminate()
+            samples.append(sample_process_tree(proc.pid))
+            after_rapl = read_rapl_snapshot()
+        finally:
+            stop_emt(proc, mode, tty_fd, stop)
+
+        snapshot = load_snapshot(snapshot_path)
+
+    first = samples[0]
+    live_samples = [sample for sample in samples if sample.pids]
+    last = live_samples[-1] if live_samples else samples[-1]
+    emt_cpu_ticks = max(0, last.cpu_ticks - first.cpu_ticks)
+    system_active_ticks = max(0, last.system_active_ticks - first.system_active_ticks)
+    emt_cpu_share = emt_cpu_ticks / system_active_ticks if system_active_ticks else 0.0
+    raw_energy, zones = rapl_delta_joules(before_rapl, after_rapl)
+    estimated_energy = raw_energy * emt_cpu_share
+    overhead_percent = (
+        (estimated_energy / raw_energy * 100.0) if raw_energy > 0 else 0.0
+    )
+    pids_seen = sorted({pid for sample in samples for pid in sample.pids})
+    diagnostics = snapshot_diagnostics(
+        snapshot,
+        set(pids_seen),
+        workload_pids,
+    )
+    displayed_delta, displayed_agree, displayed_diagnostic = (
+        displayed_attribution_diagnostic(
+            diagnostics["emt_percentage"],
+            overhead_percent,
+            diagnostics["groups_distinct"],
+        )
+    )
+
+    effective_rate = rate if rate is not None else DEFAULT_COMPARISON_RATE_HZ
+    effective_scan = (
+        scan_interval
+        if scan_interval is not None
+        else DEFAULT_COMPARISON_SCAN_INTERVAL_SECS
+    )
+    process_counts = [len(sample.pids) for sample in samples]
+    return RunResult(
+        mode=mode,
+        workload=workload,
+        iteration=iteration,
+        duration_seconds=duration,
+        emt_pid=proc.pid,
+        workload_pids=workload_pids,
+        raw_package_dram_joules=raw_energy,
+        emt_cpu_seconds=emt_cpu_ticks / CLOCK_TICKS,
+        system_active_cpu_seconds=system_active_ticks / CLOCK_TICKS,
+        emt_cpu_share=emt_cpu_share,
+        external_estimated_emt_joules=estimated_energy,
+        external_overhead_percent=overhead_percent,
+        peak_rss_bytes=max(sample.rss_bytes for sample in samples),
+        rss_samples_bytes=[sample.rss_bytes for sample in samples],
+        process_sample_count=len(samples),
+        min_process_count=min(process_counts) if process_counts else 0,
+        max_process_count=max(process_counts) if process_counts else 0,
+        pids_seen=pids_seen,
+        tracked_pid_count=diagnostics["tracked_pid_count"],
+        collection_tick_count=diagnostics["collection_tick_count"],
+        process_scan_count=diagnostics["process_scan_count"],
+        snapshot_process_group_count=diagnostics["process_group_count"],
+        snapshot_emt_group_found=diagnostics["emt_group_found"],
+        snapshot_emt_group_ids=diagnostics["emt_group_ids"],
+        snapshot_emt_percentage=diagnostics["emt_percentage"],
+        snapshot_emt_energy_joules=diagnostics["emt_energy_joules"],
+        snapshot_workload_groups_found=diagnostics["workload_groups_found"],
+        snapshot_workload_group_ids=diagnostics["workload_group_ids"],
+        snapshot_groups_distinct=diagnostics["groups_distinct"],
+        displayed_vs_external_delta_percent=displayed_delta,
+        displayed_external_agree=displayed_agree,
+        displayed_attribution_diagnostic=displayed_diagnostic,
+        collection_rate_hz=effective_rate,
+        scan_interval_secs=effective_scan,
+        render_interval_millis=2000 if mode == "tui" else None,
+        rapl_zones=zones,
+    )
+
+
+def summarize(results: list[RunResult]) -> dict[str, Any]:
+    summary: dict[str, Any] = {}
+    for mode in sorted({result.mode for result in results}):
+        summary[mode] = {}
+        for workload in sorted(
+            {result.workload for result in results if result.mode == mode}
+        ):
+            subset = [r for r in results if r.mode == mode and r.workload == workload]
+            overheads = [r.external_overhead_percent for r in subset]
+            displayed_diagnostics = [r.displayed_attribution_diagnostic for r in subset]
+            distinct_runs = [
+                r.snapshot_groups_distinct
+                for r in subset
+                if r.snapshot_groups_distinct is not None
+            ]
+            visible_percentages = [
+                r.snapshot_emt_percentage
+                for r in subset
+                if r.snapshot_emt_percentage is not None
+            ]
+            display_agreements = [
+                r.displayed_external_agree
+                for r in subset
+                if r.displayed_external_agree is not None
+            ]
+            summary[mode][workload] = {
+                "runs": len(subset),
+                "median_external_overhead_percent": (
+                    statistics.median(overheads) if overheads else None
+                ),
+                "max_external_overhead_percent": max(overheads) if overheads else None,
+                "emt_group_found_runs": sum(
+                    1 for result in subset if result.snapshot_emt_group_found
+                ),
+                "distinct_group_runs": sum(1 for distinct in distinct_runs if distinct),
+                "grouping_distinct": (all(distinct_runs) if distinct_runs else None),
+                "max_visible_emt_percent": (
+                    max(visible_percentages) if visible_percentages else None
+                ),
+                "visible_emt_percent_under_1_runs": sum(
+                    1
+                    for visible_percent in visible_percentages
+                    if visible_percent <= VISIBLE_TUI_MAX_PERCENT
+                ),
+                "display_agrees_with_external_runs": sum(
+                    1 for agrees in display_agreements if agrees
+                ),
+                "display_agrees_with_external": (
+                    all(display_agreements) if display_agreements else None
+                ),
+                "displayed_attribution_diagnostics": sorted(set(displayed_diagnostics)),
+                "median_displayed_vs_external_delta_percent": (
+                    statistics.median(
+                        [
+                            r.displayed_vs_external_delta_percent
+                            for r in subset
+                            if r.displayed_vs_external_delta_percent is not None
+                        ]
+                    )
+                    if any(
+                        r.displayed_vs_external_delta_percent is not None
+                        for r in subset
+                    )
+                    else None
+                ),
+            }
+
+    tui = summary.get("tui", {})
+    passing = True
+    for workload in ("single_cpu", "multi_cpu"):
+        stats = tui.get(workload)
+        if not stats:
+            passing = False
+            continue
+        median = stats["median_external_overhead_percent"]
+        maximum = stats["max_external_overhead_percent"]
+        visible_max = stats["max_visible_emt_percent"]
+        enough_runs = stats["runs"] >= REQUIRED_NON_IDLE_RUNS
+        grouping_ok = stats["grouping_distinct"] is True
+        visible_ok = visible_max is not None and visible_max <= VISIBLE_TUI_MAX_PERCENT
+        display_agrees = stats["display_agrees_with_external"] is True
+        passing = (
+            passing
+            and enough_runs
+            and grouping_ok
+            and visible_ok
+            and display_agrees
+            and median is not None
+            and maximum is not None
+            and median <= 0.5
+            and maximum <= 1.0
+        )
+    summary["acceptance"] = {
+        "tui_non_idle_overhead_passed": passing,
+        "thresholds": {
+            "median_percent": 0.5,
+            "max_percent": 1.0,
+            "required_non_idle_runs": REQUIRED_NON_IDLE_RUNS,
+            "visible_tui_max_percent": VISIBLE_TUI_MAX_PERCENT,
+        },
+    }
+    return summary
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--duration", type=float, default=60.0)
+    parser.add_argument("--iterations", type=int, default=3)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--emt-binary", type=Path, default=DEFAULT_BINARY)
+    parser.add_argument("--mode", action="append", choices=["tui", "headless", "json"])
+    parser.add_argument(
+        "--workload", action="append", choices=["idle", "single_cpu", "multi_cpu"]
+    )
+    parser.add_argument("--rate", type=float, default=DEFAULT_COMPARISON_RATE_HZ)
+    parser.add_argument(
+        "--scan-interval", type=float, default=DEFAULT_COMPARISON_SCAN_INTERVAL_SECS
+    )
+    parser.add_argument("--no-build", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.no_build:
+        subprocess.run(["cargo", "build", "--release"], cwd=PROJECT_ROOT, check=True)
+    if not args.emt_binary.exists():
+        raise SystemExit(f"missing release binary: {args.emt_binary}")
+    if not read_rapl_snapshot():
+        raise SystemExit(
+            "no readable package/DRAM RAPL zones found under /sys/class/powercap"
+        )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    modes = args.mode or ["tui", "headless", "json"]
+    workloads = args.workload or ["idle", "single_cpu", "multi_cpu"]
+    results: list[RunResult] = []
+    for iteration in range(1, args.iterations + 1):
+        for mode in modes:
+            for workload in workloads:
+                print(f"[{iteration}] mode={mode} workload={workload}", flush=True)
+                result = run_once(
+                    mode,
+                    workload,
+                    iteration,
+                    args.duration,
+                    args.emt_binary,
+                    args.rate,
+                    args.scan_interval,
+                )
+                print(
+                    f"  overhead={result.external_overhead_percent:.3f}% "
+                    f"raw={result.raw_package_dram_joules:.3f}J "
+                    f"emt_cpu={result.emt_cpu_seconds:.3f}s",
+                    flush=True,
+                )
+                results.append(result)
+
+    payload = {
+        "metadata": {
+            "duration_seconds": args.duration,
+            "iterations": args.iterations,
+            "modes": modes,
+            "workloads": workloads,
+            "emt_binary": str(args.emt_binary),
+            "rate_hz": args.rate,
+            "scan_interval_secs": args.scan_interval,
+            "comparison_cadence": "same_rate_and_scan_interval_for_all_modes",
+        },
+        "summary": summarize(results),
+        "results": [asdict(result) for result in results],
+    }
+    args.output.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote {args.output}")
+    return 0 if payload["summary"]["acceptance"]["tui_non_idle_overhead_passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/burst_attribution_workload.py
+++ b/scripts/burst_attribution_workload.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""
+Controlled bursty and short-lived process workload for ENE-44.
+
+The script prints JSON lines describing every expected process. The benchmark
+harness uses those events as ground truth when checking EMT's final snapshot.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import multiprocessing as mp
+import os
+import time
+from typing import Any
+
+
+def emit(event: dict[str, Any]) -> None:
+    print(json.dumps(event, sort_keys=True), flush=True)
+
+
+def read_own_cpu_ticks() -> int | None:
+    try:
+        stat = open(
+            f"/proc/{os.getpid()}/stat", encoding="utf-8", errors="ignore"
+        ).read()
+    except OSError:
+        return None
+    fields = stat[stat.rfind(")") + 2 :].split()
+    if len(fields) < 13:
+        return None
+    try:
+        return int(fields[11]) + int(fields[12])
+    except ValueError:
+        return None
+
+
+def busy_for(seconds: float) -> None:
+    deadline = time.perf_counter() + seconds
+    value = 0.0
+    while time.perf_counter() < deadline:
+        for index in range(2_000):
+            value += (index * 31 % 17) / 19.0
+    if value < 0:
+        print(value)
+
+
+def child_worker(seconds: float, role: str) -> None:
+    start_cpu_ticks = read_own_cpu_ticks()
+    emit(
+        {
+            "event": "process_start",
+            "role": role,
+            "pid": os.getpid(),
+            "timestamp": time.time(),
+            "self_cpu_ticks": start_cpu_ticks,
+        }
+    )
+    busy_for(seconds)
+    end_cpu_ticks = read_own_cpu_ticks()
+    emit(
+        {
+            "event": "process_end",
+            "role": role,
+            "pid": os.getpid(),
+            "timestamp": time.time(),
+            "runtime_seconds": seconds,
+            "self_cpu_ticks": end_cpu_ticks,
+            "self_cpu_ticks_delta": (
+                None
+                if start_cpu_ticks is None or end_cpu_ticks is None
+                else max(0, end_cpu_ticks - start_cpu_ticks)
+            ),
+        }
+    )
+
+
+def long_lived_bursts(
+    duration: float, burst_seconds: float, idle_seconds: float
+) -> None:
+    start_cpu_ticks = read_own_cpu_ticks()
+    emit(
+        {
+            "event": "process_start",
+            "role": "root",
+            "pid": os.getpid(),
+            "timestamp": time.time(),
+            "self_cpu_ticks": start_cpu_ticks,
+        }
+    )
+    deadline = time.perf_counter() + duration
+    bursts = 0
+    while time.perf_counter() < deadline:
+        busy_for(min(burst_seconds, max(0.0, deadline - time.perf_counter())))
+        bursts += 1
+        time.sleep(min(idle_seconds, max(0.0, deadline - time.perf_counter())))
+    end_cpu_ticks = read_own_cpu_ticks()
+    emit(
+        {
+            "event": "process_end",
+            "role": "root",
+            "pid": os.getpid(),
+            "timestamp": time.time(),
+            "runtime_seconds": duration,
+            "bursts": bursts,
+            "self_cpu_ticks": end_cpu_ticks,
+            "self_cpu_ticks_delta": (
+                None
+                if start_cpu_ticks is None or end_cpu_ticks is None
+                else max(0, end_cpu_ticks - start_cpu_ticks)
+            ),
+        }
+    )
+
+
+def one_child(duration: float, child_runtime: float, role: str) -> None:
+    start_cpu_ticks = read_own_cpu_ticks()
+    emit(
+        {
+            "event": "process_start",
+            "role": "root",
+            "pid": os.getpid(),
+            "timestamp": time.time(),
+            "self_cpu_ticks": start_cpu_ticks,
+        }
+    )
+    process = mp.Process(target=child_worker, args=(child_runtime, role))
+    process.start()
+    emit(
+        {
+            "event": "child_spawned",
+            "role": role,
+            "pid": process.pid,
+            "timestamp": time.time(),
+            "expected_runtime_seconds": child_runtime,
+        }
+    )
+    process.join()
+    time.sleep(max(0.0, duration - child_runtime))
+    end_cpu_ticks = read_own_cpu_ticks()
+    emit(
+        {
+            "event": "process_end",
+            "role": "root",
+            "pid": os.getpid(),
+            "timestamp": time.time(),
+            "runtime_seconds": duration,
+            "self_cpu_ticks": end_cpu_ticks,
+            "self_cpu_ticks_delta": (
+                None
+                if start_cpu_ticks is None or end_cpu_ticks is None
+                else max(0, end_cpu_ticks - start_cpu_ticks)
+            ),
+        }
+    )
+
+
+def many_short_children(
+    duration: float, child_runtime: float, spawn_interval: float
+) -> None:
+    start_cpu_ticks = read_own_cpu_ticks()
+    emit(
+        {
+            "event": "process_start",
+            "role": "root",
+            "pid": os.getpid(),
+            "timestamp": time.time(),
+            "self_cpu_ticks": start_cpu_ticks,
+        }
+    )
+    deadline = time.perf_counter() + duration
+    processes: list[mp.Process] = []
+    spawned = 0
+    while time.perf_counter() < deadline:
+        process = mp.Process(target=child_worker, args=(child_runtime, "short_child"))
+        process.start()
+        spawned += 1
+        processes.append(process)
+        emit(
+            {
+                "event": "child_spawned",
+                "role": "short_child",
+                "pid": process.pid,
+                "timestamp": time.time(),
+                "expected_runtime_seconds": child_runtime,
+            }
+        )
+        time.sleep(min(spawn_interval, max(0.0, deadline - time.perf_counter())))
+    for process in processes:
+        process.join()
+    end_cpu_ticks = read_own_cpu_ticks()
+    emit(
+        {
+            "event": "process_end",
+            "role": "root",
+            "pid": os.getpid(),
+            "timestamp": time.time(),
+            "runtime_seconds": duration,
+            "children_spawned": spawned,
+            "self_cpu_ticks": end_cpu_ticks,
+            "self_cpu_ticks_delta": (
+                None
+                if start_cpu_ticks is None or end_cpu_ticks is None
+                else max(0, end_cpu_ticks - start_cpu_ticks)
+            ),
+        }
+    )
+
+
+def lifetime_sweep(
+    duration: float,
+    child_runtimes: list[float],
+    repetitions: int,
+    start_offsets: list[float],
+) -> None:
+    start_cpu_ticks = read_own_cpu_ticks()
+    emit(
+        {
+            "event": "process_start",
+            "role": "root",
+            "pid": os.getpid(),
+            "timestamp": time.time(),
+            "self_cpu_ticks": start_cpu_ticks,
+        }
+    )
+    processes: list[mp.Process] = []
+    sweep_start = time.perf_counter()
+    for repetition in range(repetitions):
+        offset = start_offsets[repetition] if repetition < len(start_offsets) else 0.0
+        while time.perf_counter() - sweep_start < offset:
+            time.sleep(min(0.1, offset - (time.perf_counter() - sweep_start)))
+        for runtime in child_runtimes:
+            role = f"sweep_child_{runtime:.1f}s"
+            process = mp.Process(target=child_worker, args=(runtime, role))
+            process.start()
+            processes.append(process)
+            emit(
+                {
+                    "event": "child_spawned",
+                    "role": role,
+                    "pid": process.pid,
+                    "timestamp": time.time(),
+                    "expected_runtime_seconds": runtime,
+                    "sweep_repetition": repetition + 1,
+                    "sweep_start_offset_seconds": offset,
+                }
+            )
+    for process in processes:
+        process.join()
+    elapsed = time.perf_counter() - sweep_start
+    time.sleep(max(0.0, duration - elapsed))
+    actual_runtime = time.perf_counter() - sweep_start
+    end_cpu_ticks = read_own_cpu_ticks()
+    emit(
+        {
+            "event": "process_end",
+            "role": "root",
+            "pid": os.getpid(),
+            "timestamp": time.time(),
+            "runtime_seconds": actual_runtime,
+            "configured_duration_seconds": duration,
+            "sweep_children_spawned": len(processes),
+            "self_cpu_ticks": end_cpu_ticks,
+            "self_cpu_ticks_delta": (
+                None
+                if start_cpu_ticks is None or end_cpu_ticks is None
+                else max(0, end_cpu_ticks - start_cpu_ticks)
+            ),
+        }
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "pattern",
+        choices=[
+            "long_lived_bursts",
+            "child_over_interval",
+            "child_under_interval",
+            "lifetime_sweep",
+            "many_short",
+        ],
+    )
+    parser.add_argument("--duration", type=float, default=20.0)
+    parser.add_argument("--child-runtime", type=float, default=2.0)
+    parser.add_argument("--burst-seconds", type=float, default=0.2)
+    parser.add_argument("--idle-seconds", type=float, default=0.8)
+    parser.add_argument("--spawn-interval", type=float, default=1.0)
+    parser.add_argument("--child-runtimes", default="")
+    parser.add_argument("--sweep-repetitions", type=int, default=2)
+    parser.add_argument("--sweep-start-offsets", default="")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.pattern == "long_lived_bursts":
+        long_lived_bursts(args.duration, args.burst_seconds, args.idle_seconds)
+    elif args.pattern == "child_over_interval":
+        one_child(args.duration, args.child_runtime, "child_over_interval")
+    elif args.pattern == "child_under_interval":
+        one_child(args.duration, args.child_runtime, "child_under_interval")
+    elif args.pattern == "lifetime_sweep":
+        runtimes = [
+            float(value) for value in args.child_runtimes.split(",") if value.strip()
+        ]
+        offsets = [
+            float(value)
+            for value in args.sweep_start_offsets.split(",")
+            if value.strip()
+        ]
+        lifetime_sweep(args.duration, runtimes, args.sweep_repetitions, offsets)
+    elif args.pattern == "many_short":
+        many_short_children(args.duration, args.child_runtime, args.spawn_interval)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/collectors/rapl.rs
+++ b/src/collectors/rapl.rs
@@ -7,7 +7,8 @@ use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
-use sysinfo::{Pid, System};
+
+const LINUX_PAGE_SIZE_BYTES: u64 = 4096;
 
 /// DeltaReader tracks energy deltas from RAPL MSR registers
 /// It reads the energy_uj file and computes the delta from the previous reading
@@ -72,6 +73,7 @@ struct SocketReaders {
 }
 
 type UtilizationSeries = Vec<(u32, f64)>;
+const UNATTRIBUTED_PID: u32 = 0;
 
 /// Tracks CPU times for a process to calculate CPU percentage accurately
 /// Similar to how psutil tracks cpu_percent internally
@@ -164,8 +166,10 @@ pub struct Rapl {
     psys_reader: Option<DeltaReader>,
     /// Tracked process PIDs for per-process energy attribution
     tracked_pids: Arc<Mutex<Vec<u32>>>,
-    /// Persistent System instance for memory tracking
-    system: Mutex<System>,
+    /// Logical CPU count used to normalize process CPU percentages.
+    cpu_count: f64,
+    /// Host total memory, used to normalize process RSS.
+    total_memory_bytes: u64,
     /// Per-process CPU time trackers for accurate CPU percentage
     cpu_trackers: Mutex<std::collections::HashMap<u32, ProcessCpuTracker>>,
     /// System-wide CPU tracker
@@ -235,9 +239,6 @@ impl Rapl {
         let rapl_dir = rapl_path.unwrap_or_else(|| "/sys/class/powercap".to_string());
         let (socket_readers, dram_reader, psys_reader) = Self::scan_powercap_entries(&rapl_dir);
 
-        // Initialize System for memory tracking (CPU tracking now uses /proc/stat directly)
-        let system = System::new_all();
-
         // Initialize CPU trackers with a warmup call
         let mut system_cpu_tracker = SystemCpuTracker::default();
         system_cpu_tracker.update(); // First call establishes baseline
@@ -247,7 +248,8 @@ impl Rapl {
             dram_reader,
             psys_reader,
             tracked_pids: Arc::new(Mutex::new(Vec::new())),
-            system: Mutex::new(system),
+            cpu_count: logical_cpu_count(),
+            total_memory_bytes: read_total_memory_bytes(),
             cpu_trackers: Mutex::new(std::collections::HashMap::new()),
             system_cpu_tracker: Mutex::new(system_cpu_tracker),
         }
@@ -434,8 +436,6 @@ impl Rapl {
         &self,
         pids: &[u32],
     ) -> Result<(UtilizationSeries, UtilizationSeries), String> {
-        use sysinfo::{ProcessRefreshKind, ProcessesToUpdate};
-
         // Get system CPU using our custom tracker (reads from /proc/stat)
         let (system_cpu, sys_valid) = {
             let mut tracker = self
@@ -481,41 +481,22 @@ impl Rapl {
             pids.len()
         );
 
-        // Use sysinfo only for memory tracking
-        let mut system = self
-            .system
-            .lock()
-            .map_err(|e| format!("Failed to lock system: {}", e))?;
-
-        // Refresh memory info for tracked processes
-        let pids_to_update: Vec<Pid> = pids.iter().map(|&p| Pid::from(p as usize)).collect();
-        let refresh_kind = ProcessRefreshKind::nothing().with_memory();
-        system.refresh_processes_specifics(
-            ProcessesToUpdate::Some(&pids_to_update),
-            true,
-            refresh_kind,
-        );
-
-        let cpu_count = system.cpus().len().max(1) as f64;
-        let total_memory = system.total_memory();
+        let cpu_count = self.cpu_count.max(1.0);
+        let total_memory = self.total_memory_bytes;
 
         // Calculate per-process memory utilization
         let mut total_process_memory = 0.0;
         let mut process_memory: Vec<(u32, f64)> = Vec::new();
 
         for &pid in pids {
-            if let Some(process) = system.process(Pid::from(pid as usize)) {
-                let memory_bytes = process.memory();
-                let memory_percent = if total_memory > 0 {
-                    (memory_bytes as f64 / total_memory as f64) * 100.0
-                } else {
-                    0.0
-                };
-                total_process_memory += memory_percent;
-                process_memory.push((pid, memory_percent));
+            let memory_bytes = read_process_rss_bytes(pid);
+            let memory_percent = if total_memory > 0 {
+                (memory_bytes as f64 / total_memory as f64) * 100.0
             } else {
-                process_memory.push((pid, 0.0));
-            }
+                0.0
+            };
+            total_process_memory += memory_percent;
+            process_memory.push((pid, memory_percent));
         }
 
         // Normalize CPU utilization relative to system CPU
@@ -539,6 +520,7 @@ impl Rapl {
                 (pid, normalized)
             })
             .collect();
+        let normalized_cpus = normalize_fraction_budget(normalized_cpus);
 
         // Normalize memory utilization relative to total process memory
         let normalized_memory: Vec<(u32, f64)> = process_memory
@@ -552,9 +534,65 @@ impl Rapl {
                 (pid, normalized)
             })
             .collect();
+        let normalized_memory = normalize_fraction_budget(normalized_memory);
 
         Ok((normalized_cpus, normalized_memory))
     }
+}
+
+fn normalize_fraction_budget(series: UtilizationSeries) -> UtilizationSeries {
+    let total: f64 = series.iter().map(|(_, value)| *value).sum();
+    if total <= 1.0 || total <= f64::EPSILON {
+        return series;
+    }
+
+    series
+        .into_iter()
+        .map(|(pid, value)| (pid, value / total))
+        .collect()
+}
+
+fn logical_cpu_count() -> f64 {
+    std::thread::available_parallelism()
+        .map(|count| count.get().max(1) as f64)
+        .unwrap_or(1.0)
+}
+
+fn read_total_memory_bytes() -> u64 {
+    fs::read_to_string("/proc/meminfo")
+        .ok()
+        .and_then(|contents| parse_memtotal_bytes(&contents))
+        .unwrap_or(0)
+}
+
+fn parse_memtotal_bytes(contents: &str) -> Option<u64> {
+    contents.lines().find_map(|line| {
+        let mut fields = line.split_whitespace();
+        if fields.next()? != "MemTotal:" {
+            return None;
+        }
+        fields
+            .next()?
+            .parse::<u64>()
+            .ok()
+            .map(|kib| kib.saturating_mul(1024))
+    })
+}
+
+fn read_process_rss_bytes(pid: u32) -> u64 {
+    fs::read_to_string(format!("/proc/{pid}/statm"))
+        .ok()
+        .and_then(|contents| parse_statm_resident_bytes(&contents))
+        .unwrap_or(0)
+}
+
+fn parse_statm_resident_bytes(contents: &str) -> Option<u64> {
+    contents
+        .split_whitespace()
+        .nth(1)?
+        .parse::<u64>()
+        .ok()
+        .map(|resident_pages| resident_pages.saturating_mul(LINUX_PAGE_SIZE_BYTES))
 }
 
 impl Default for Rapl {
@@ -645,6 +683,7 @@ impl EnergyCollector for Rapl {
             // NOTE: Package energy is the total socket energy and already includes core energy.
             // We only attribute package energy to avoid double counting.
             // Core and uncore are recorded separately for detailed breakdown but not summed into total.
+            let mut attributed_package_energy = 0.0;
             for &pid in &pids {
                 let normalized_cpu = cpu_utilization_ratio
                     .iter()
@@ -656,6 +695,7 @@ impl EnergyCollector for Rapl {
                 // Package = Core + Uncore, so we only count package to avoid double counting
                 if socket.package_reader.is_some() {
                     let package_attribution = package_energy * normalized_cpu;
+                    attributed_package_energy += package_attribution;
                     log::trace!(
                         "PID {} socket {}: package_energy={:.4}J × normalized_cpu={:.4} = {:.4}J",
                         pid,
@@ -669,6 +709,19 @@ impl EnergyCollector for Rapl {
                         timestamp,
                         device: format!("rapl:socket:{}:package", socket_id),
                         energy: package_attribution,
+                    });
+                }
+            }
+
+            if socket.package_reader.is_some() {
+                let unattributed_package_energy =
+                    (package_energy - attributed_package_energy).max(0.0);
+                if unattributed_package_energy > 0.0 {
+                    records.push(EnergyRecord {
+                        pid: UNATTRIBUTED_PID,
+                        timestamp,
+                        device: format!("rapl:socket:{}:package", socket_id),
+                        energy: unattributed_package_energy,
                     });
                 }
             }
@@ -702,6 +755,8 @@ impl EnergyCollector for Rapl {
         };
 
         // Attribute system-level energy to tracked PIDs
+        let mut attributed_dram_energy = 0.0;
+        let mut attributed_psys_energy = 0.0;
         for &pid in &pids {
             let normalized_mem = memory_utilization_ratio
                 .iter()
@@ -712,6 +767,7 @@ impl EnergyCollector for Rapl {
             // DRAM energy attributed by memory usage
             if self.dram_reader.is_some() {
                 let dram_attribution = dram_energy * normalized_mem;
+                attributed_dram_energy += dram_attribution;
                 records.push(EnergyRecord {
                     pid,
                     timestamp,
@@ -723,11 +779,35 @@ impl EnergyCollector for Rapl {
             // PSYS energy distributed equally among processes
             if self.psys_reader.is_some() {
                 let psys_attribution = psys_energy / pids.len() as f64;
+                attributed_psys_energy += psys_attribution;
                 records.push(EnergyRecord {
                     pid,
                     timestamp,
                     device: "rapl:system:psys".to_string(),
                     energy: psys_attribution,
+                });
+            }
+        }
+
+        if self.dram_reader.is_some() {
+            let unattributed_dram_energy = (dram_energy - attributed_dram_energy).max(0.0);
+            if unattributed_dram_energy > 0.0 {
+                records.push(EnergyRecord {
+                    pid: UNATTRIBUTED_PID,
+                    timestamp,
+                    device: "rapl:system:dram".to_string(),
+                    energy: unattributed_dram_energy,
+                });
+            }
+        }
+        if self.psys_reader.is_some() {
+            let unattributed_psys_energy = (psys_energy - attributed_psys_energy).max(0.0);
+            if unattributed_psys_energy > 0.0 {
+                records.push(EnergyRecord {
+                    pid: UNATTRIBUTED_PID,
+                    timestamp,
+                    device: "rapl:system:psys".to_string(),
+                    energy: unattributed_psys_energy,
                 });
             }
         }
@@ -832,6 +912,23 @@ mod tests {
     }
 
     #[test]
+    fn normalize_fraction_budget_preserves_under_budget_values() {
+        let values = vec![(1, 0.25), (2, 0.5)];
+
+        assert_eq!(normalize_fraction_budget(values.clone()), values);
+    }
+
+    #[test]
+    fn normalize_fraction_budget_scales_over_budget_values() {
+        let values = normalize_fraction_budget(vec![(1, 0.75), (2, 0.75)]);
+        let total: f64 = values.iter().map(|(_, value)| *value).sum();
+
+        assert!((total - 1.0).abs() < 1e-10);
+        assert!((values[0].1 - 0.5).abs() < 1e-10);
+        assert!((values[1].1 - 0.5).abs() < 1e-10);
+    }
+
+    #[test]
     fn scan_powercap_entries_keeps_multi_socket_components_separate() {
         let rapl_dir = TempTestDir::new("multi-socket");
 
@@ -863,5 +960,22 @@ mod tests {
         assert!(socket1.package_reader.is_some());
         assert!(socket1.core_reader.is_some());
         assert!(socket1.uncore_reader.is_none());
+    }
+
+    #[test]
+    fn parse_memtotal_bytes_reads_kib_value() {
+        let contents = "MemFree: 1 kB\nMemTotal: 2048 kB\n";
+
+        assert_eq!(parse_memtotal_bytes(contents), Some(2_097_152));
+    }
+
+    #[test]
+    fn parse_statm_resident_bytes_reads_resident_pages() {
+        let contents = "100 3 0 0 0 0 0\n";
+
+        assert_eq!(
+            parse_statm_resident_bytes(contents),
+            Some(3 * LINUX_PAGE_SIZE_BYTES)
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,18 @@ pub struct CollectionConfig {
     pub trace_flush_interval_secs: f64,
 }
 
+/// Configuration for the interactive terminal UI.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct TuiConfig {
+    /// Lower collection rate used by default for monitor-all TUI mode.
+    pub monitor_all_rate_hz: f64,
+    /// Lower process scan cadence used by default for monitor-all TUI mode.
+    pub monitor_all_scan_interval_secs: f64,
+    /// TUI render/input polling interval in milliseconds.
+    pub render_interval_millis: u64,
+}
+
 /// Configuration for user-facing measurement units.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -44,6 +56,7 @@ pub struct MeasurementUnitsConfig {
 pub struct EmtConfig {
     pub discovery: DiscoveryConfig,
     pub collection: CollectionConfig,
+    pub tui: TuiConfig,
     pub measurement_units: MeasurementUnitsConfig,
 }
 
@@ -72,6 +85,16 @@ impl Default for CollectionConfig {
             rate_hz: 10.0,
             trace_retention_secs: 3600,
             trace_flush_interval_secs: 5.0,
+        }
+    }
+}
+
+impl Default for TuiConfig {
+    fn default() -> Self {
+        Self {
+            monitor_all_rate_hz: 0.1,
+            monitor_all_scan_interval_secs: 30.0,
+            render_interval_millis: 2000,
         }
     }
 }
@@ -175,6 +198,16 @@ impl EmtConfig {
             "collection.trace_flush_interval_secs",
             self.collection.trace_flush_interval_secs,
         )?;
+        validate_positive_finite("tui.monitor_all_rate_hz", self.tui.monitor_all_rate_hz)?;
+        validate_positive_finite(
+            "tui.monitor_all_scan_interval_secs",
+            self.tui.monitor_all_scan_interval_secs,
+        )?;
+        if self.tui.render_interval_millis == 0 {
+            return Err(ConfigError::Invalid(
+                "tui.render_interval_millis must be greater than 0".to_string(),
+            ));
+        }
         if self.collection.trace_retention_secs == 0 {
             return Err(ConfigError::Invalid(
                 "collection.trace_retention_secs must be greater than 0".to_string(),
@@ -239,6 +272,9 @@ mod tests {
         assert_eq!(config.collection.rate_hz, 10.0);
         assert_eq!(config.collection.trace_retention_secs, 3600);
         assert_eq!(config.collection.trace_flush_interval_secs, 5.0);
+        assert_eq!(config.tui.monitor_all_rate_hz, 0.1);
+        assert_eq!(config.tui.monitor_all_scan_interval_secs, 30.0);
+        assert_eq!(config.tui.render_interval_millis, 2000);
         assert_eq!(config.measurement_units.energy, "Joules");
         assert_eq!(config.measurement_units.power, "Watts");
     }
@@ -251,6 +287,7 @@ mod tests {
         assert_eq!(config.collection.trace_retention_secs, 3600);
         assert_eq!(config.collection.trace_flush_interval_secs, 5.0);
         assert_eq!(config.discovery.scan_interval_secs, 2.0);
+        assert_eq!(config.tui.monitor_all_rate_hz, 0.1);
         assert_eq!(config.measurement_units.energy, "Joules");
     }
 
@@ -262,6 +299,7 @@ mod tests {
         assert_eq!(config.collection.trace_retention_secs, 3600);
         assert_eq!(config.collection.trace_flush_interval_secs, 5.0);
         assert_eq!(config.discovery.scan_interval_secs, 2.0);
+        assert_eq!(config.tui.render_interval_millis, 2000);
     }
 
     #[test]
@@ -306,6 +344,10 @@ mod tests {
 
         let mut config = EmtConfig::default();
         config.collection.trace_retention_secs = 0;
+        assert!(matches!(config.validate(), Err(ConfigError::Invalid(_))));
+
+        let mut config = EmtConfig::default();
+        config.tui.render_interval_millis = 0;
         assert!(matches!(config.validate(), Err(ConfigError::Invalid(_))));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 
 const DEFAULT_BATCH_DURATION_SECS: u64 = 10;
 const DEFAULT_PROMETHEUS_PORT: u16 = 9101;
+const TUI_INPUT_POLL_INTERVAL: Duration = Duration::from_millis(500);
 
 #[derive(Parser, Debug)]
 #[command(name = "emt")]
@@ -28,6 +29,14 @@ struct Args {
     /// Collection rate in Hz (overrides config file)
     #[arg(short, long)]
     rate: Option<f64>,
+
+    /// Process scan interval in seconds (overrides config file)
+    #[arg(long = "scan-interval")]
+    scan_interval: Option<f64>,
+
+    /// Write the final raw metrics snapshot to PATH
+    #[arg(long = "snapshot-out", value_name = "PATH")]
+    snapshot_out: Option<String>,
 
     /// Launch interactive TUI (default mode)
     #[arg(long, conflicts_with_all = ["headless", "json_out"])]
@@ -101,6 +110,8 @@ mod tests {
             pid: Some(123),
             duration: Some(10),
             rate: None,
+            scan_interval: None,
+            snapshot_out: None,
             tui: false,
             headless: false,
             export: None,
@@ -137,6 +148,7 @@ mod tests {
             }],
             unattributed: DeviceEnergy::default(),
             tracked_pids: vec![123],
+            ..MetricsSnapshot::default()
         };
 
         let output = build_cli_output(&args, 10.0, &snapshot, &units);
@@ -162,6 +174,8 @@ mod tests {
             pid: None,
             duration: None,
             rate: Some(5.0),
+            scan_interval: None,
+            snapshot_out: None,
             tui: false,
             headless: false,
             export: None,
@@ -176,6 +190,52 @@ mod tests {
 
         assert_eq!(config.collection.rate_hz, 5.0);
         config.validate().unwrap();
+    }
+
+    #[test]
+    fn cli_scan_interval_override_wins_over_loaded_config() {
+        let args = Args::parse_from(["emt", "--scan-interval", "7.5"]);
+        let mut config = EmtConfig::default();
+
+        apply_cli_overrides(&mut config, &args);
+
+        assert_eq!(config.discovery.scan_interval_secs, 7.5);
+        config.validate().unwrap();
+    }
+
+    #[test]
+    fn tui_monitor_all_uses_low_overhead_defaults_without_cli_overrides() {
+        let args = Args::parse_from(["emt", "--tui"]);
+        let mut config = EmtConfig::default();
+
+        apply_mode_defaults(&mut config, &args);
+
+        assert_eq!(config.collection.rate_hz, 0.1);
+        assert_eq!(config.discovery.scan_interval_secs, 30.0);
+        assert_eq!(tui_render_interval(&config), Duration::from_millis(2000));
+    }
+
+    #[test]
+    fn tui_monitor_all_preserves_explicit_cli_rate_and_scan_interval() {
+        let args = Args::parse_from(["emt", "--tui", "--rate", "8", "--scan-interval", "1.5"]);
+        let mut config = EmtConfig::default();
+        apply_cli_overrides(&mut config, &args);
+
+        apply_mode_defaults(&mut config, &args);
+
+        assert_eq!(config.collection.rate_hz, 8.0);
+        assert_eq!(config.discovery.scan_interval_secs, 1.5);
+    }
+
+    #[test]
+    fn tui_pid_mode_preserves_default_collection_cadence() {
+        let args = Args::parse_from(["emt", "--tui", "--pid", "123"]);
+        let mut config = EmtConfig::default();
+
+        apply_mode_defaults(&mut config, &args);
+
+        assert_eq!(config.collection.rate_hz, 10.0);
+        assert_eq!(config.discovery.scan_interval_secs, 2.0);
     }
 
     #[test]
@@ -337,6 +397,32 @@ fn apply_cli_overrides(config: &mut EmtConfig, args: &Args) {
     if let Some(rate) = args.rate {
         config.collection.rate_hz = rate;
     }
+    if let Some(scan_interval) = args.scan_interval {
+        config.discovery.scan_interval_secs = scan_interval;
+    }
+}
+
+fn apply_mode_defaults(config: &mut EmtConfig, args: &Args) {
+    if selected_mode(args) != Mode::Tui || args.pid.is_some() {
+        return;
+    }
+
+    if args.rate.is_none() {
+        config.collection.rate_hz = config
+            .collection
+            .rate_hz
+            .min(config.tui.monitor_all_rate_hz);
+    }
+    if args.scan_interval.is_none() {
+        config.discovery.scan_interval_secs = config
+            .discovery
+            .scan_interval_secs
+            .max(config.tui.monitor_all_scan_interval_secs);
+    }
+}
+
+fn tui_render_interval(config: &EmtConfig) -> Duration {
+    Duration::from_millis(config.tui.render_interval_millis)
 }
 
 #[tokio::main]
@@ -350,26 +436,44 @@ async fn main() {
 
     let mut config = EmtConfig::load();
     apply_cli_overrides(&mut config, &args);
+    apply_mode_defaults(&mut config, &args);
     if let Err(e) = config.validate() {
         eprintln!("Invalid configuration: {e}");
         std::process::exit(2);
     }
 
     match mode {
-        Mode::Tui => run_tui(config, args.pid).await,
-        Mode::Headless => run_prometheus_export(config, args.pid, args.bind, args.port).await,
+        Mode::Tui => run_tui(config, args.pid, args.snapshot_out.as_deref()).await,
+        Mode::Headless => {
+            run_prometheus_export(
+                config,
+                args.pid,
+                args.bind,
+                args.port,
+                args.snapshot_out.as_deref(),
+            )
+            .await
+        }
         Mode::JsonOut => {
             let duration = batch_duration_seconds(&args);
             let path = args
                 .json_out
                 .as_deref()
                 .expect("json_out is present in JsonOut mode");
-            run_json_out(config, &args, duration, path.to_string()).await;
+            run_json_out(
+                config,
+                &args,
+                duration,
+                path.to_string(),
+                args.snapshot_out.as_deref(),
+            )
+            .await;
         }
     }
 }
 
-async fn run_tui(config: EmtConfig, pid: Option<u32>) {
+async fn run_tui(config: EmtConfig, pid: Option<u32>, snapshot_out: Option<&str>) {
+    let tick_rate = tui_render_interval(&config);
     let root_pids = pid.map(|p| vec![p]);
     let mut monitor = Monitor::new(config, root_pids);
 
@@ -398,32 +502,58 @@ async fn run_tui(config: EmtConfig, pid: Option<u32>) {
     let mut terminal = ratatui::Terminal::new(backend).expect("Failed to create terminal");
 
     let mut app = App::new(handle);
-    let tick_rate = std::time::Duration::from_millis(500);
+    let mut last_draw = std::time::Instant::now() - tick_rate;
     #[cfg(debug_assertions)]
     let force_panic_after_first_draw =
         std::env::var_os("EMT_TUI_FORCE_PANIC_AFTER_FIRST_DRAW").is_some();
 
     while !app.should_quit {
-        app.refresh();
-        terminal
-            .draw(|frame| tui::ui::render(frame, &app))
-            .expect("Failed to draw");
+        let mut should_draw = last_draw.elapsed() >= tick_rate;
 
-        #[cfg(debug_assertions)]
-        if force_panic_after_first_draw {
-            panic!("forced TUI panic smoke check");
+        if let Some(event) = tui::event::poll(TUI_INPUT_POLL_INTERVAL) {
+            match event {
+                tui::event::AppEvent::Quit => {
+                    app.quit();
+                    should_draw = true;
+                }
+                tui::event::AppEvent::CycleSortMode => {
+                    app.cycle_sort_mode();
+                    should_draw = true;
+                }
+                tui::event::AppEvent::ResetDisplay => {
+                    app.reset_display();
+                    should_draw = true;
+                }
+                tui::event::AppEvent::SelectPrevious => {
+                    app.select_previous();
+                    should_draw = true;
+                }
+                tui::event::AppEvent::SelectNext => {
+                    app.select_next();
+                    should_draw = true;
+                }
+                tui::event::AppEvent::ExpandSelected => {
+                    app.expand_selected();
+                    should_draw = true;
+                }
+                tui::event::AppEvent::CollapseSelected => {
+                    app.collapse_selected();
+                    should_draw = true;
+                }
+                tui::event::AppEvent::Tick => {}
+            }
         }
 
-        if let Some(event) = tui::event::poll(tick_rate) {
-            match event {
-                tui::event::AppEvent::Quit => app.quit(),
-                tui::event::AppEvent::CycleSortMode => app.cycle_sort_mode(),
-                tui::event::AppEvent::ResetDisplay => app.reset_display(),
-                tui::event::AppEvent::SelectPrevious => app.select_previous(),
-                tui::event::AppEvent::SelectNext => app.select_next(),
-                tui::event::AppEvent::ExpandSelected => app.expand_selected(),
-                tui::event::AppEvent::CollapseSelected => app.collapse_selected(),
-                tui::event::AppEvent::Tick => {}
+        if should_draw {
+            app.refresh();
+            terminal
+                .draw(|frame| tui::ui::render(frame, &app))
+                .expect("Failed to draw");
+            last_draw = std::time::Instant::now();
+
+            #[cfg(debug_assertions)]
+            if force_panic_after_first_draw {
+                panic!("forced TUI panic smoke check");
             }
         }
     }
@@ -439,9 +569,17 @@ async fn run_tui(config: EmtConfig, pid: Option<u32>) {
     if let Err(e) = monitor.shutdown().await {
         eprintln!("Warning: Shutdown error: {e}");
     }
+    app.refresh();
+    write_snapshot_if_requested(snapshot_out, &app.snapshot());
 }
 
-async fn run_json_out(config: EmtConfig, args: &Args, duration_secs: u64, output_path: String) {
+async fn run_json_out(
+    config: EmtConfig,
+    args: &Args,
+    duration_secs: u64,
+    output_path: String,
+    snapshot_out: Option<&str>,
+) {
     let measurement_units = config.measurement_units.clone();
     let root_pids = args.pid.map(|p| vec![p]);
     let mut monitor = Monitor::new(config, root_pids);
@@ -461,6 +599,7 @@ async fn run_json_out(config: EmtConfig, args: &Args, duration_secs: u64, output
     }
 
     let snapshot = handle.snapshot();
+    write_snapshot_if_requested(snapshot_out, &snapshot);
     let duration = duration_secs as f64;
     let cli_output = build_cli_output(args, duration, &snapshot, &measurement_units);
 
@@ -472,7 +611,13 @@ async fn run_json_out(config: EmtConfig, args: &Args, duration_secs: u64, output
     eprintln!("JSON results written to: {output_path}");
 }
 
-async fn run_prometheus_export(config: EmtConfig, pid: Option<u32>, bind: IpAddr, port: u16) {
+async fn run_prometheus_export(
+    config: EmtConfig,
+    pid: Option<u32>,
+    bind: IpAddr,
+    port: u16,
+    snapshot_out: Option<&str>,
+) {
     let update_interval = Duration::from_secs_f64((1.0 / config.collection.rate_hz).max(0.1));
     let root_pids = pid.map(|p| vec![p]);
     let mut monitor = Monitor::new(config, root_pids);
@@ -505,7 +650,7 @@ async fn run_prometheus_export(config: EmtConfig, pid: Option<u32>, bind: IpAddr
 
     let update_task = tokio::spawn(update_prometheus_sink_loop(
         Arc::clone(&sink),
-        handle,
+        handle.clone(),
         update_interval,
     ));
     let serve_result = axum::serve(listener, app)
@@ -518,6 +663,7 @@ async fn run_prometheus_export(config: EmtConfig, pid: Option<u32>, bind: IpAddr
     if let Err(e) = monitor.shutdown().await {
         eprintln!("Warning: Shutdown error: {e}");
     }
+    write_snapshot_if_requested(snapshot_out, &handle.snapshot());
 
     if let Err(e) = serve_result {
         eprintln!("Prometheus exporter error: {e}");
@@ -540,6 +686,24 @@ fn update_prometheus_sink(sink: &SharedPrometheusSink, snapshot: &MetricsSnapsho
     sink.lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .update(snapshot);
+}
+
+fn write_snapshot_if_requested(path: Option<&str>, snapshot: &MetricsSnapshot) {
+    let Some(path) = path else {
+        return;
+    };
+
+    let result: Result<(), Box<dyn std::error::Error>> = (|| {
+        let mut file = File::create(path)?;
+        serde_json::to_writer_pretty(&mut file, snapshot)?;
+        file.write_all(b"\n")?;
+        Ok(())
+    })();
+
+    match result {
+        Ok(()) => eprintln!("Raw snapshot written to: {path}"),
+        Err(e) => eprintln!("Warning: failed to write raw snapshot to {path}: {e}"),
+    }
 }
 
 async fn shutdown_signal() {

--- a/src/metrics_sink.rs
+++ b/src/metrics_sink.rs
@@ -621,6 +621,7 @@ mod tests {
             workloads,
             unattributed: DeviceEnergy::default(),
             tracked_pids: vec![123],
+            ..MetricsSnapshot::default()
         }
     }
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -7,8 +7,9 @@ use crate::process::{
 use crate::process_aggregation::{aggregate_energy_records, percentage_of_system};
 use crate::utils::errors::MonitoringError;
 use crate::utils::psutils::{ProcessRoot, walk_child_pids};
+use serde::Serialize;
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use tokio::sync::Mutex;
@@ -17,7 +18,7 @@ use tokio::task::JoinHandle;
 // ─── MetricsSnapshot data structures ────────────────────────────────────────
 
 /// Energy breakdown by device type (CPU, DRAM, GPU).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct DeviceEnergy {
     pub cpu_joules: f64,
     pub dram_joules: f64,
@@ -41,7 +42,7 @@ impl DeviceEnergy {
 }
 
 /// Per-process energy and power snapshot nested under a workload group.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ProcessEnergySnapshot {
     pub pid: u32,
     pub name: String,
@@ -50,7 +51,7 @@ pub struct ProcessEnergySnapshot {
 }
 
 /// Per-workload (root process) energy and power snapshot.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct WorkloadSnapshot {
     pub root_pid: u32,
     pub group_id: String,
@@ -64,7 +65,7 @@ pub struct WorkloadSnapshot {
 }
 
 /// Full metrics snapshot shared via MonitorHandle.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct MetricsSnapshot {
     pub timestamp: i64,
     pub gpu_available: bool,
@@ -72,6 +73,15 @@ pub struct MetricsSnapshot {
     pub workloads: Vec<WorkloadSnapshot>,
     pub unattributed: DeviceEnergy,
     pub tracked_pids: Vec<u32>,
+    pub diagnostics: MonitorDiagnostics,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct MonitorDiagnostics {
+    pub collection_ticks: u64,
+    pub process_scans: u64,
+    pub process_groups: usize,
+    pub tracked_pids: usize,
 }
 
 // ─── Snapshot helpers ───────────────────────────────────────────────────────
@@ -421,6 +431,8 @@ pub struct Monitor {
     last_pid_to_group: Arc<RwLock<HashMap<u32, String>>>,
     /// First tick timestamp for average-power calculations.
     start_timestamp: Arc<RwLock<i64>>,
+    /// Number of process discovery scans completed in monitor-all mode.
+    process_scan_count: Arc<AtomicU64>,
     /// Internal task handles
     tick_handle: Option<JoinHandle<()>>,
     scan_handle: Option<JoinHandle<()>>,
@@ -467,6 +479,7 @@ impl Monitor {
             known_groups: Arc::new(RwLock::new(HashMap::new())),
             last_pid_to_group: Arc::new(RwLock::new(HashMap::new())),
             start_timestamp: Arc::new(RwLock::new(0)),
+            process_scan_count: Arc::new(AtomicU64::new(0)),
             tick_handle: None,
             scan_handle: None,
             snapshot: Arc::new(RwLock::new(MetricsSnapshot {
@@ -490,6 +503,7 @@ impl Monitor {
         *self.known_groups.write().unwrap() = HashMap::new();
         *self.last_pid_to_group.write().unwrap() = HashMap::new();
         *self.start_timestamp.write().unwrap() = 0;
+        self.process_scan_count.store(0, Ordering::SeqCst);
         *self.snapshot.write().unwrap() = MetricsSnapshot {
             gpu_available: self.gpu_group.is_some(),
             ..MetricsSnapshot::default()
@@ -508,6 +522,7 @@ impl Monitor {
 
         if self.root_pids.is_none() {
             *self.discovered_groups.write().unwrap() = initial_groups.clone();
+            self.process_scan_count.store(1, Ordering::SeqCst);
         }
 
         {
@@ -713,13 +728,16 @@ impl Monitor {
         let known_groups = Arc::clone(&self.known_groups);
         let last_pid_to_group = Arc::clone(&self.last_pid_to_group);
         let start_timestamp = Arc::clone(&self.start_timestamp);
+        let process_scan_count = Arc::clone(&self.process_scan_count);
         let snapshot = Arc::clone(&self.snapshot);
         let is_running = Arc::clone(&self.is_running);
 
         self.tick_handle = Some(tokio::spawn(async move {
             let mut tick_state = TickState::default();
+            let mut collection_ticks = 0_u64;
 
             while is_running.load(Ordering::SeqCst) {
+                collection_ticks += 1;
                 let groups = if let Some(ref pids) = root_pids {
                     let cached_groups = {
                         let known = known_groups.read().unwrap();
@@ -820,6 +838,12 @@ impl Monitor {
                     snap.workloads = workloads;
                     snap.unattributed = cumulative_unattributed;
                     snap.tracked_pids = expanded_pids;
+                    snap.diagnostics = MonitorDiagnostics {
+                        collection_ticks,
+                        process_scans: process_scan_count.load(Ordering::SeqCst),
+                        process_groups: groups.len(),
+                        tracked_pids: snap.tracked_pids.len(),
+                    };
                 }
                 *last_pid_to_group.write().unwrap() = current_pid_to_group;
 
@@ -833,6 +857,7 @@ impl Monitor {
     fn spawn_scan_task(&mut self) {
         let interval = Duration::from_secs_f64(self.config.discovery.scan_interval_secs);
         let discovered_groups = Arc::clone(&self.discovered_groups);
+        let process_scan_count = Arc::clone(&self.process_scan_count);
         let is_running = Arc::clone(&self.is_running);
 
         self.scan_handle = Some(tokio::spawn(async move {
@@ -841,6 +866,7 @@ impl Monitor {
                     .await
                     .unwrap_or_default();
                 *discovered_groups.write().unwrap() = groups;
+                process_scan_count.fetch_add(1, Ordering::SeqCst);
                 tokio::time::sleep(interval).await;
             }
         }));
@@ -1150,6 +1176,10 @@ mod tests {
         assert!(snap.workloads.is_empty());
         assert_eq!(snap.unattributed.total(), 0.0);
         assert!(snap.tracked_pids.is_empty());
+        assert_eq!(snap.diagnostics.collection_ticks, 0);
+        assert_eq!(snap.diagnostics.process_scans, 0);
+        assert_eq!(snap.diagnostics.process_groups, 0);
+        assert_eq!(snap.diagnostics.tracked_pids, 0);
     }
 
     #[test]
@@ -1233,6 +1263,12 @@ mod tests {
         let snapshot = handle.snapshot();
         // Should have discovered some PIDs via scan
         assert!(!snapshot.tracked_pids.is_empty());
+        assert!(snapshot.diagnostics.collection_ticks > 0);
+        assert!(snapshot.diagnostics.process_scans > 0);
+        assert_eq!(
+            snapshot.diagnostics.tracked_pids,
+            snapshot.tracked_pids.len()
+        );
 
         monitor.shutdown().await.unwrap();
     }

--- a/src/process.rs
+++ b/src/process.rs
@@ -2,13 +2,14 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::path::Path;
 
-use sysinfo::{Process, System};
 use users::{Users, UsersCache};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProcessInfo {
     pub pid: u32,
     pub parent_pid: Option<u32>,
+    pub process_group_id: Option<u32>,
+    pub session_id: Option<u32>,
     pub command: String,
     pub user: String,
     pub cgroup_path: String,
@@ -33,11 +34,21 @@ pub struct CgroupGrouping;
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ParentLineageGrouping;
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ProcessGroupIdGrouping;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct CgroupLabel {
     key: String,
     name: String,
     priority: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ProcStatIds {
+    parent_pid: Option<u32>,
+    process_group_id: Option<u32>,
+    session_id: Option<u32>,
 }
 
 impl GroupingStrategy for CgroupGrouping {
@@ -94,21 +105,64 @@ impl GroupingStrategy for ParentLineageGrouping {
     }
 }
 
-pub fn scan_processes() -> Vec<ProcessInfo> {
-    let system = System::new_all();
-    let users_cache = UsersCache::new();
-    let mut processes: Vec<ProcessInfo> = system
-        .processes()
-        .iter()
-        .map(|(pid, process)| {
-            let pid = pid.as_u32();
-            ProcessInfo {
-                pid,
-                parent_pid: process.parent().map(|parent| parent.as_u32()),
-                command: process_command(process),
-                user: process_user(process, &users_cache),
-                cgroup_path: read_cgroup_path(pid).unwrap_or_default(),
+impl GroupingStrategy for ProcessGroupIdGrouping {
+    fn group(&self, processes: &[ProcessInfo]) -> Vec<ProcessGroup> {
+        let mut groups: BTreeMap<u32, Vec<&ProcessInfo>> = BTreeMap::new();
+
+        for process in processes {
+            if process.pid == 1 || process.pid == 2 {
+                continue;
             }
+
+            let group_id = process.process_group_id.unwrap_or(process.pid);
+            groups.entry(group_id).or_default().push(process);
+        }
+
+        groups
+            .into_iter()
+            .filter_map(|(group_id, processes)| {
+                let representative_pid = processes
+                    .iter()
+                    .find(|process| process.pid == group_id)
+                    .map(|process| process.pid)
+                    .or_else(|| processes.first().map(|process| process.pid));
+                let name = representative_pid
+                    .and_then(|pid| {
+                        processes
+                            .iter()
+                            .find(|process| process.pid == pid)
+                            .map(|process| command_name(&process.command, process.pid))
+                    })
+                    .unwrap_or_else(|| format!("process group {group_id}"));
+                build_group(
+                    format!("pgrp:{group_id}"),
+                    name,
+                    &processes,
+                    representative_pid,
+                )
+            })
+            .collect()
+    }
+}
+
+pub fn scan_processes() -> Vec<ProcessInfo> {
+    let users_cache = UsersCache::new();
+    let mut processes: Vec<ProcessInfo> = fs::read_dir("/proc")
+        .ok()
+        .into_iter()
+        .flat_map(|entries| entries.flatten())
+        .filter_map(|entry| {
+            let pid = entry.file_name().to_str()?.parse::<u32>().ok()?;
+            let stat_ids = read_proc_stat_ids(pid);
+            Some(ProcessInfo {
+                pid,
+                parent_pid: stat_ids.and_then(|ids| ids.parent_pid),
+                process_group_id: stat_ids.and_then(|ids| ids.process_group_id),
+                session_id: stat_ids.and_then(|ids| ids.session_id),
+                command: read_process_command(pid),
+                user: read_process_user(pid, &users_cache),
+                cgroup_path: read_cgroup_path(pid).unwrap_or_default(),
+            })
         })
         .collect();
 
@@ -135,6 +189,11 @@ pub fn group_processes(processes: &[ProcessInfo]) -> Vec<ProcessGroup> {
         if !lineage_groups.is_empty() {
             return lineage_groups;
         }
+    }
+
+    let split_groups = split_low_signal_cgroup_groups(processes, &cgroup_groups);
+    if let Some(groups) = split_groups {
+        return groups;
     }
 
     cgroup_groups
@@ -202,27 +261,65 @@ fn parse_cgroup_line(line: &str) -> Option<String> {
     }
 }
 
-fn process_command(process: &Process) -> String {
-    let command = process
-        .cmd()
-        .iter()
-        .map(|part| part.to_string_lossy())
-        .filter(|part| !part.is_empty())
-        .collect::<Vec<_>>()
-        .join(" ");
-
-    if command.is_empty() {
-        process.name().to_string_lossy().to_string()
-    } else {
-        command
-    }
+fn read_proc_stat_ids(pid: u32) -> Option<ProcStatIds> {
+    let contents = fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    parse_proc_stat_ids(&contents)
 }
 
-fn process_user(process: &Process, users_cache: &UsersCache) -> String {
-    process
-        .user_id()
-        .map(|uid| resolve_username(**uid, users_cache))
+#[cfg(test)]
+fn parse_parent_pid_from_stat(contents: &str) -> Option<u32> {
+    parse_proc_stat_ids(contents).and_then(|ids| ids.parent_pid)
+}
+
+fn parse_proc_stat_ids(contents: &str) -> Option<ProcStatIds> {
+    let comm_end = contents.rfind(')')?;
+    let fields: Vec<&str> = contents[comm_end + 2..].split_whitespace().collect();
+    Some(ProcStatIds {
+        parent_pid: fields.get(1).and_then(|value| value.parse().ok()),
+        process_group_id: fields.get(2).and_then(|value| value.parse().ok()),
+        session_id: fields.get(3).and_then(|value| value.parse().ok()),
+    })
+}
+
+fn read_process_command(pid: u32) -> String {
+    let command = fs::read(format!("/proc/{pid}/cmdline"))
+        .ok()
+        .map(|contents| command_from_cmdline(&contents))
+        .unwrap_or_default();
+    if !command.is_empty() {
+        return command;
+    }
+
+    fs::read_to_string(format!("/proc/{pid}/comm"))
+        .map(|name| name.trim().to_string())
+        .unwrap_or_else(|_| format!("pid {pid}"))
+}
+
+fn command_from_cmdline(contents: &[u8]) -> String {
+    contents
+        .split(|byte| *byte == 0)
+        .filter(|part| !part.is_empty())
+        .map(|part| String::from_utf8_lossy(part).into_owned())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn read_process_user(pid: u32, users_cache: &UsersCache) -> String {
+    fs::read_to_string(format!("/proc/{pid}/status"))
+        .ok()
+        .and_then(|contents| parse_uid_from_status(&contents))
+        .map(|uid| resolve_username(uid, users_cache))
         .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn parse_uid_from_status(contents: &str) -> Option<u32> {
+    contents.lines().find_map(|line| {
+        let mut fields = line.split_whitespace();
+        if fields.next()? != "Uid:" {
+            return None;
+        }
+        fields.next()?.parse().ok()
+    })
 }
 
 fn resolve_username(uid: u32, users_cache: &UsersCache) -> String {
@@ -266,6 +363,70 @@ fn cgroup_grouping_is_degenerate(processes: &[ProcessInfo], groups: &[ProcessGro
     }
 
     unique_paths.len() <= 1 && ParentLineageGrouping.group(processes).len() > 1
+}
+
+fn split_low_signal_cgroup_groups(
+    processes: &[ProcessInfo],
+    groups: &[ProcessGroup],
+) -> Option<Vec<ProcessGroup>> {
+    let by_pid: HashMap<u32, &ProcessInfo> = processes
+        .iter()
+        .map(|process| (process.pid, process))
+        .collect();
+    let mut split_any = false;
+    let mut output = Vec::new();
+
+    for group in groups {
+        let group_processes: Vec<ProcessInfo> = group
+            .pids
+            .iter()
+            .filter_map(|pid| by_pid.get(pid).map(|process| (*process).clone()))
+            .collect();
+
+        if cgroup_group_should_split_by_process_group(&group_processes) {
+            let process_group_groups = ProcessGroupIdGrouping.group(&group_processes);
+            if process_group_groups.len() > 1 {
+                split_any = true;
+                output.extend(process_group_groups);
+                continue;
+            }
+        }
+
+        output.push(group.clone());
+    }
+
+    if split_any {
+        output.sort_by(|left, right| left.id.cmp(&right.id));
+        Some(output)
+    } else {
+        None
+    }
+}
+
+fn cgroup_group_should_split_by_process_group(processes: &[ProcessInfo]) -> bool {
+    if processes.len() <= 1 {
+        return false;
+    }
+
+    let labels: Vec<CgroupLabel> = processes
+        .iter()
+        .filter_map(|process| cgroup_label(&process.cgroup_path))
+        .collect();
+    if labels.is_empty() || !labels.iter().all(cgroup_label_is_low_signal) {
+        return false;
+    }
+
+    ProcessGroupIdGrouping.group(processes).len() > 1
+}
+
+fn cgroup_label_is_low_signal(label: &CgroupLabel) -> bool {
+    label.priority < 3 || is_interactive_user_scope_name(&label.name)
+}
+
+fn is_interactive_user_scope_name(name: &str) -> bool {
+    let stem = name.strip_suffix(".scope").unwrap_or(name);
+    const PREFIXES: [&str; 4] = ["app-", "session-", "vte-spawn-", "tmux-spawn-"];
+    PREFIXES.iter().any(|prefix| stem.starts_with(prefix))
 }
 
 fn cgroup_label(path: &str) -> Option<CgroupLabel> {
@@ -519,6 +680,27 @@ mod tests {
         ProcessInfo {
             pid,
             parent_pid,
+            process_group_id: Some(pid),
+            session_id: Some(pid),
+            command: command.to_string(),
+            user: user.to_string(),
+            cgroup_path: cgroup_path.to_string(),
+        }
+    }
+
+    fn process_with_process_group(
+        pid: u32,
+        parent_pid: Option<u32>,
+        process_group_id: u32,
+        command: &str,
+        user: &str,
+        cgroup_path: &str,
+    ) -> ProcessInfo {
+        ProcessInfo {
+            pid,
+            parent_pid,
+            process_group_id: Some(process_group_id),
+            session_id: Some(process_group_id),
             command: command.to_string(),
             user: user.to_string(),
             cgroup_path: cgroup_path.to_string(),
@@ -633,6 +815,26 @@ mod tests {
     }
 
     #[test]
+    fn group_processes_splits_low_signal_tmux_scope_by_process_group() {
+        let cgroup = "/user.slice/user-1000.slice/user@1000.service/app.slice/tmux-spawn-c62b4263-07fc-4c42-9cc5-4dda073993ce.scope";
+        let processes = vec![
+            process_with_process_group(100, Some(1), 100, "zsh", "alice", cgroup),
+            process_with_process_group(200, Some(100), 200, "emt --tui", "alice", cgroup),
+            process_with_process_group(201, Some(200), 200, "emt helper", "alice", cgroup),
+            process_with_process_group(300, Some(100), 300, "python workload.py", "alice", cgroup),
+        ];
+
+        let groups = group_processes(&processes);
+        let ids: Vec<&str> = groups.iter().map(|group| group.id.as_str()).collect();
+
+        assert_eq!(ids, vec!["pgrp:100", "pgrp:200", "pgrp:300"]);
+        assert_eq!(groups[1].name, "emt");
+        assert_eq!(groups[1].pids, vec![200, 201]);
+        assert_eq!(groups[2].name, "python");
+        assert_eq!(groups[2].pids, vec![300]);
+    }
+
+    #[test]
     fn scanner_cgroup_parser_prefers_specific_systemd_path() {
         let contents = "\
 12:memory:/
@@ -652,6 +854,44 @@ mod tests {
             .name,
             "app-firefox.scope"
         );
+    }
+
+    #[test]
+    fn scanner_stat_parser_reads_parent_pid_after_comm() {
+        let stat = "123 (python worker) S 42 1 1 0 0 0";
+
+        assert_eq!(parse_parent_pid_from_stat(stat), Some(42));
+    }
+
+    #[test]
+    fn scanner_stat_parser_reads_process_group_and_session_ids() {
+        let stat = "123 (python worker) S 42 200 300 0 0 0";
+
+        assert_eq!(
+            parse_proc_stat_ids(stat),
+            Some(ProcStatIds {
+                parent_pid: Some(42),
+                process_group_id: Some(200),
+                session_id: Some(300),
+            })
+        );
+    }
+
+    #[test]
+    fn scanner_cmdline_parser_joins_nul_separated_args() {
+        let cmdline = b"/usr/bin/python\0script.py\0--flag\0";
+
+        assert_eq!(
+            command_from_cmdline(cmdline),
+            "/usr/bin/python script.py --flag"
+        );
+    }
+
+    #[test]
+    fn scanner_status_parser_reads_real_uid() {
+        let status = "Name:\tpython\nUid:\t1000\t1000\t1000\t1000\n";
+
+        assert_eq!(parse_uid_from_status(status), Some(1000));
     }
 
     #[test]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -492,6 +492,7 @@ mod tests {
                 gpu_joules: 0.0,
             },
             tracked_pids: vec![123, 124],
+            ..MetricsSnapshot::default()
         };
         let power_history = PowerHistorySnapshot {
             cpu: vec![5.0],
@@ -549,6 +550,7 @@ mod tests {
                 gpu_joules: 30.0,
             },
             tracked_pids: Vec::new(),
+            ..MetricsSnapshot::default()
         };
         let power_history = PowerHistorySnapshot {
             cpu: vec![5.0],
@@ -616,6 +618,7 @@ mod tests {
             }],
             unattributed: DeviceEnergy::default(),
             tracked_pids: vec![123],
+            ..MetricsSnapshot::default()
         };
         let power_history = PowerHistorySnapshot::default();
         let expanded = HashSet::from(["pid:123".to_string()]);
@@ -681,6 +684,7 @@ mod tests {
             }],
             unattributed: DeviceEnergy::default(),
             tracked_pids: vec![123],
+            ..MetricsSnapshot::default()
         };
 
         let rows = workload_table_rows(&snapshot, 0, &HashSet::new(), &HashMap::new());
@@ -743,6 +747,7 @@ mod tests {
             ],
             unattributed: DeviceEnergy::default(),
             tracked_pids: vec![100],
+            ..MetricsSnapshot::default()
         };
         let expanded = HashSet::from(["pid:200".to_string()]);
 
@@ -791,6 +796,7 @@ mod tests {
             }],
             unattributed: DeviceEnergy::default(),
             tracked_pids: vec![1, 2, 3],
+            ..MetricsSnapshot::default()
         };
         let expanded = HashSet::from(["pid:1".to_string()]);
         let child_scroll_offsets = HashMap::from([("pid:1".to_string(), 1)]);

--- a/tests/test_burst_attribution_benchmark.py
+++ b/tests/test_burst_attribution_benchmark.py
@@ -1,0 +1,243 @@
+from scripts import benchmark_burst_attribution as burst
+
+
+def test_expected_processes_extracts_root_and_child_lifetimes():
+    events = [
+        {"event": "process_start", "role": "root", "pid": 100},
+        {
+            "event": "child_spawned",
+            "role": "child_over_interval",
+            "pid": 101,
+            "expected_runtime_seconds": 6.0,
+            "sweep_start_offset_seconds": 10.0,
+        },
+        {
+            "event": "process_end",
+            "role": "child_over_interval",
+            "pid": 101,
+            "runtime_seconds": 6.0,
+            "self_cpu_ticks_delta": 12,
+        },
+        {
+            "event": "process_end",
+            "role": "root",
+            "pid": 100,
+            "runtime_seconds": 20.0,
+            "self_cpu_ticks_delta": 1,
+        },
+    ]
+
+    expected = burst.expected_processes(events)
+
+    assert expected == [
+        burst.ExpectedProcess(
+            pid=100,
+            role="root",
+            expected_runtime_seconds=20.0,
+            sweep_repetition=None,
+            sweep_start_offset_seconds=None,
+            self_reported_cpu_ticks_delta=1,
+        ),
+        burst.ExpectedProcess(
+            pid=101,
+            role="child_over_interval",
+            expected_runtime_seconds=6.0,
+            sweep_repetition=None,
+            sweep_start_offset_seconds=10.0,
+            self_reported_cpu_ticks_delta=12,
+        ),
+    ]
+
+
+def test_build_findings_marks_discovered_and_attributed_process_with_cpu_evidence():
+    snapshot = {
+        "workloads": [
+            {
+                "root_pid": 100,
+                "group_id": "lineage:100",
+                "energy": {"cpu_joules": 1.0, "dram_joules": 0.0, "gpu_joules": 0.0},
+                "processes": [
+                    {
+                        "pid": 101,
+                        "energy": {
+                            "cpu_joules": 0.5,
+                            "dram_joules": 0.25,
+                            "gpu_joules": 0.0,
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+    expected = [
+        burst.ExpectedProcess(
+            pid=101,
+            role="child_over_interval",
+            expected_runtime_seconds=6.0,
+            sweep_repetition=None,
+            sweep_start_offset_seconds=None,
+            self_reported_cpu_ticks_delta=20,
+        )
+    ]
+    cpu_evidence = {
+        101: burst.ProcCpuEvidence(
+            pid=101,
+            sample_count=3,
+            first_cpu_ticks=10,
+            last_cpu_ticks=25,
+            observed_cpu_ticks=15,
+            externally_observed=True,
+        )
+    }
+
+    findings = burst.build_findings(snapshot, expected, cpu_evidence)
+
+    assert findings == [
+        burst.ProcessFinding(
+            pid=101,
+            role="child_over_interval",
+            expected_runtime_seconds=6.0,
+            sweep_repetition=None,
+            sweep_start_offset_seconds=None,
+            discovered=True,
+            attributed=True,
+            energy_joules=0.75,
+            group_id="lineage:100",
+            group_energy_joules=1.0,
+            proc_cpu_ticks_observed=15,
+            proc_cpu_sample_count=3,
+            self_reported_cpu_ticks_delta=20,
+            failure_mode="attributed",
+        )
+    ]
+
+
+def test_build_findings_classifies_cpu_active_process_missed_by_snapshot():
+    expected = [
+        burst.ExpectedProcess(
+            pid=101,
+            role="child_under_interval",
+            expected_runtime_seconds=1.0,
+            sweep_repetition=None,
+            sweep_start_offset_seconds=None,
+            self_reported_cpu_ticks_delta=10,
+        )
+    ]
+
+    findings = burst.build_findings({}, expected, {})
+
+    assert findings[0].failure_mode == "not_discovered_before_exit_or_grouped_elsewhere"
+    assert findings[0].attributed is False
+
+
+def test_compact_group_evidence_keeps_expected_and_top_energy_groups():
+    snapshot = {
+        "workloads": [
+            {
+                "root_pid": 100,
+                "group_id": "lineage:100",
+                "energy": {"cpu_joules": 1.0, "dram_joules": 0.0, "gpu_joules": 0.0},
+                "processes": [{"pid": 101, "energy": {"cpu_joules": 0.5}}],
+            },
+            {
+                "root_pid": 200,
+                "group_id": "lineage:200",
+                "energy": {"cpu_joules": 10.0, "dram_joules": 0.0, "gpu_joules": 0.0},
+                "processes": [],
+            },
+        ]
+    }
+
+    evidence = burst.compact_group_evidence(snapshot, {101}, top_limit=1)
+
+    assert [group.group_id for group in evidence] == ["lineage:200", "lineage:100"]
+    assert evidence[0].evidence_reason == "top_energy_group"
+    assert evidence[1].evidence_reason == "expected_pid_intersection"
+
+
+def test_lifetime_sweep_summary_requires_all_repetitions_reliable():
+    reliable = burst.ProcessFinding(
+        pid=101,
+        role="sweep_child_52.0s",
+        expected_runtime_seconds=52.0,
+        sweep_repetition=1,
+        sweep_start_offset_seconds=10.0,
+        discovered=True,
+        attributed=True,
+        energy_joules=1.0,
+        group_id="lineage:100",
+        group_energy_joules=1.0,
+        proc_cpu_ticks_observed=5,
+        proc_cpu_sample_count=2,
+        self_reported_cpu_ticks_delta=7,
+        failure_mode="attributed",
+    )
+    missed = burst.ProcessFinding(
+        pid=102,
+        role="sweep_child_20.0s",
+        expected_runtime_seconds=20.0,
+        sweep_repetition=1,
+        sweep_start_offset_seconds=10.0,
+        discovered=True,
+        attributed=False,
+        energy_joules=0.0,
+        group_id="lineage:100",
+        group_energy_joules=1.0,
+        proc_cpu_ticks_observed=5,
+        proc_cpu_sample_count=2,
+        self_reported_cpu_ticks_delta=7,
+        failure_mode="discovered_without_energy_exit_accounting_or_sample_gap",
+    )
+    result = burst.PatternResult(
+        pattern="lifetime_sweep",
+        monitor_duration_seconds=90.0,
+        workload_duration_seconds=60.0,
+        collection_rate_hz=0.1,
+        scan_interval_secs=30.0,
+        attribution_refresh_secs=10.0,
+        expected_processes=[],
+        findings=[reliable, missed],
+        proc_cpu_evidence=[],
+        group_evidence=[],
+        snapshot_group_count=0,
+        snapshot_group_energy_joules=0.0,
+        workload_events=[],
+        unattributed_joules=0.0,
+        system_total_joules=1.0,
+        recommendation="",
+    )
+
+    summary = burst.summarize([result])
+
+    assert summary["minimum_reliable_lifetime_seconds"] == 52.0
+    assert summary["lifetime_sweep"][0]["runtime_seconds"] == 20.0
+    assert summary["lifetime_sweep"][0]["start_offsets_seconds"] == [10.0]
+    assert summary["lifetime_sweep"][0]["reliable"] is False
+    assert summary["patterns"]["lifetime_sweep"]["non_root_expected"] == 2
+    assert summary["patterns"]["lifetime_sweep"]["non_root_attributed"] == 1
+
+
+def test_recommendation_distinguishes_sub_interval_misses():
+    findings = [
+        burst.ProcessFinding(
+            pid=101,
+            role="child_under_interval",
+            expected_runtime_seconds=0.5,
+            sweep_repetition=None,
+            sweep_start_offset_seconds=None,
+            discovered=False,
+            attributed=False,
+            energy_joules=0.0,
+            group_id=None,
+            group_energy_joules=0.0,
+            proc_cpu_ticks_observed=3,
+            proc_cpu_sample_count=2,
+            self_reported_cpu_ticks_delta=4,
+            failure_mode="not_discovered_before_exit_or_grouped_elsewhere",
+        )
+    ]
+
+    recommendation = burst.recommendation_for("child_under_interval", findings, 1.0)
+
+    assert "Sub-interval processes" in recommendation
+    assert "re-benchmarked" in recommendation

--- a/tests/test_overhead_benchmark.py
+++ b/tests/test_overhead_benchmark.py
@@ -1,0 +1,179 @@
+from scripts import benchmark_emt_overhead as overhead
+
+
+def test_rapl_delta_handles_counter_wrap():
+    before = {
+        "zone": {
+            "name": "package-0",
+            "energy_uj": 900,
+            "max_energy_uj": 1000,
+        }
+    }
+    after = {
+        "zone": {
+            "name": "package-0",
+            "energy_uj": 100,
+            "max_energy_uj": 1000,
+        }
+    }
+
+    total, zones = overhead.rapl_delta_joules(before, after)
+
+    assert total == 0.0002
+    assert zones == [{"path": "zone", "name": "package-0", "delta_joules": 0.0002}]
+
+
+def test_snapshot_diagnostics_finds_emt_group_and_workload_groups():
+    snapshot = {
+        "tracked_pids": [10, 11, 20],
+        "workloads": [
+            {
+                "root_pid": 10,
+                "group_id": "lineage:10",
+                "percentage_of_system": 0.4,
+                "energy": {"cpu_joules": 1.0, "dram_joules": 0.5, "gpu_joules": 0.0},
+                "processes": [{"pid": 11, "energy": {"cpu_joules": 0.2}}],
+            },
+            {
+                "root_pid": 20,
+                "group_id": "lineage:20",
+                "percentage_of_system": 99.6,
+                "energy": {"cpu_joules": 20.0, "dram_joules": 0.0, "gpu_joules": 0.0},
+                "processes": [],
+            },
+        ],
+        "diagnostics": {
+            "collection_ticks": 7,
+            "process_scans": 3,
+            "process_groups": 2,
+        },
+    }
+
+    diagnostics = overhead.snapshot_diagnostics(
+        snapshot,
+        {10, 11},
+        [20],
+    )
+
+    assert diagnostics["emt_group_found"] is True
+    assert diagnostics["emt_group_ids"] == ["lineage:10"]
+    assert diagnostics["emt_percentage"] == 0.4
+    assert diagnostics["emt_energy_joules"] == 1.5
+    assert diagnostics["workload_groups_found"] == 1
+    assert diagnostics["workload_group_ids"] == ["lineage:20"]
+    assert diagnostics["groups_distinct"] is True
+    assert diagnostics["tracked_pid_count"] == 3
+    assert diagnostics["collection_tick_count"] == 7
+    assert diagnostics["process_scan_count"] == 3
+    assert diagnostics["process_group_count"] == 2
+
+
+def test_snapshot_diagnostics_flags_merged_emt_and_workload_group():
+    snapshot = {
+        "tracked_pids": [10, 20],
+        "workloads": [
+            {
+                "root_pid": 10,
+                "group_id": "cgroup:merged",
+                "percentage_of_system": 100.0,
+                "energy": {"cpu_joules": 10.0, "dram_joules": 0.0, "gpu_joules": 0.0},
+                "processes": [{"pid": 20, "energy": {"cpu_joules": 5.0}}],
+            }
+        ],
+    }
+
+    diagnostics = overhead.snapshot_diagnostics(snapshot, {10}, [20])
+
+    assert diagnostics["groups_distinct"] is False
+
+
+def run_result(
+    workload: str, iteration: int, overhead_percent: float
+) -> overhead.RunResult:
+    return overhead.RunResult(
+        mode="tui",
+        workload=workload,
+        iteration=iteration,
+        duration_seconds=60.0,
+        emt_pid=10,
+        workload_pids=[20],
+        raw_package_dram_joules=100.0,
+        emt_cpu_seconds=0.1,
+        system_active_cpu_seconds=100.0,
+        emt_cpu_share=0.001,
+        external_estimated_emt_joules=0.1,
+        external_overhead_percent=overhead_percent,
+        peak_rss_bytes=1024,
+        rss_samples_bytes=[1000, 1024],
+        process_sample_count=2,
+        min_process_count=1,
+        max_process_count=2,
+        pids_seen=[10],
+        tracked_pid_count=5,
+        collection_tick_count=7,
+        process_scan_count=3,
+        snapshot_process_group_count=2,
+        snapshot_emt_group_found=True,
+        snapshot_emt_group_ids=["lineage:10"],
+        snapshot_emt_percentage=overhead_percent,
+        snapshot_emt_energy_joules=0.1,
+        snapshot_workload_groups_found=1,
+        snapshot_workload_group_ids=["lineage:20"],
+        snapshot_groups_distinct=True,
+        displayed_vs_external_delta_percent=0.0,
+        displayed_external_agree=True,
+        displayed_attribution_diagnostic="display_agrees_with_external_estimate",
+        collection_rate_hz=0.1,
+        scan_interval_secs=30.0,
+        render_interval_millis=2000,
+        rapl_zones=[],
+    )
+
+
+def test_overhead_summary_requires_three_non_idle_runs():
+    summary = overhead.summarize(
+        [
+            run_result("single_cpu", 1, 0.1),
+            run_result("multi_cpu", 1, 0.2),
+        ]
+    )
+
+    assert summary["acceptance"]["tui_non_idle_overhead_passed"] is False
+
+
+def test_overhead_summary_enforces_tui_non_idle_thresholds():
+    results = [
+        run_result("single_cpu", 1, 0.1),
+        run_result("single_cpu", 2, 0.2),
+        run_result("single_cpu", 3, 0.3),
+        run_result("multi_cpu", 1, 0.1),
+        run_result("multi_cpu", 2, 0.2),
+        run_result("multi_cpu", 3, 0.3),
+    ]
+
+    summary = overhead.summarize(results)
+
+    assert summary["acceptance"]["tui_non_idle_overhead_passed"] is True
+    assert summary["tui"]["single_cpu"]["grouping_distinct"] is True
+    assert summary["tui"]["single_cpu"]["max_visible_emt_percent"] == 0.3
+    assert (
+        summary["tui"]["single_cpu"]["median_displayed_vs_external_delta_percent"]
+        == 0.0
+    )
+
+
+def test_overhead_summary_rejects_visible_tui_percentage_over_one_percent():
+    results = [
+        run_result("single_cpu", 1, 0.1),
+        run_result("single_cpu", 2, 0.2),
+        run_result("single_cpu", 3, 0.3),
+        run_result("multi_cpu", 1, 0.1),
+        run_result("multi_cpu", 2, 0.2),
+        run_result("multi_cpu", 3, 0.3),
+    ]
+    results[0].snapshot_emt_percentage = 1.01
+
+    summary = overhead.summarize(results)
+
+    assert summary["acceptance"]["tui_non_idle_overhead_passed"] is False
+    assert summary["tui"]["single_cpu"]["max_visible_emt_percent"] == 1.01


### PR DESCRIPTION
## Summary

- Add low-overhead monitor-all TUI defaults and CLI overrides for collection rate, process scan interval, render cadence, and snapshot export.
- Replace hot-path process and memory accounting with direct `/proc` reads, normalize attribution fractions, and preserve unallocated RAPL energy as reserved unattributed records.
- Add fixed-window EMT overhead and burst-attribution benchmark harnesses with tests and evidence capture.
- Improve process grouping by splitting low-signal interactive cgroups, including tmux-style scopes, by Unix process group.

## Why

ENE-43 found that the Rust TUI itself could dominate demo energy readings. ENE-44 investigated whether lowering collection cadence would hide short-lived workload energy. This PR keeps the existing TUI interaction model while reducing monitor-all overhead and adds the benchmark evidence needed to make the tradeoff explicit.

## Impact

- `emt --tui` monitor-all mode now defaults to a low-overhead cadence intended for demos.
- PID-scoped/default modes keep the normal collection cadence unless the caller overrides it.
- Snapshot diagnostics now expose collection ticks, process scans, process groups, and tracked PIDs for benchmark validation.
- Short-lived process misses are quantified rather than silently treated as fully attributed.

## Evidence

- ENE-43 acceptance artifact: `.artifacts/emt_overhead_tui_acceptance_visible_fixed.json`
- ENE-43 comparison artifact: `.artifacts/emt_overhead_mode_comparison_fair_visible_fixed.json`
- ENE-44 attribution artifact: `.artifacts/burst_attribution_low_overhead_phase_accounting_fixed.json`

## Validation

- `cargo fmt --check`
- `cargo test` - 122 library tests, 14 binary tests passed; 1 doctest ignored
- `uv run pytest` - 104 passed
- `uv run black --check scripts/benchmark_emt_overhead.py scripts/burst_attribution_workload.py scripts/benchmark_burst_attribution.py tests/test_overhead_benchmark.py tests/test_burst_attribution_benchmark.py`

Related Linear issues: ENE-43, ENE-44.