### PR TITLE
[codex] ENE-49/ENE-50 preserve Rust-backed Python compatibility

### DIFF
--- a/emt/energy_monitor.py
+++ b/emt/energy_monitor.py
@@ -1,6 +1,7 @@
 import time
 import asyncio
 import logging
+import os
 import threading
 from threading import RLock
 from typing import Collection, Mapping, Optional
@@ -208,9 +209,10 @@ class EnergyMonitor:
         try:
             from emt._rust import RustMonitor
 
-            kwargs = {"name": self.context_name}
-            if self._pid is not None:
-                kwargs["pid"] = self._pid
+            kwargs = {
+                "name": self.context_name,
+                "pid": self._pid if self._pid is not None else os.getpid(),
+            }
             if self._rate is not None:
                 kwargs["rate"] = self._rate
             backend = RustMonitor(**kwargs)
@@ -273,7 +275,7 @@ class EnergyMonitor:
                 f"{self._rust_backend.total_consumed_energy:.2f} Joules"
             )
             logger.info(
-                f"{self.context_name}: Device energy: {self._rust_backend.consumed_energy}"
+                f"{self.context_name}: Power group energy consumptions: {self.consumed_energy}"
             )
             return
 
@@ -302,12 +304,25 @@ class EnergyMonitor:
 
     @property
     def consumed_energy(self) -> Mapping[str, float]:
-        """Per-device energy breakdown."""
+        """Per-power-group energy breakdown."""
         if hasattr(self, "_rust_backend") and self._rust_backend is not None:
-            return self._rust_backend.consumed_energy
+            return self._rust_consumed_energy_by_power_group()
         if hasattr(self, "energy_meter"):
             return self.energy_meter.consumed_energy
         return {}
+
+    def _rust_consumed_energy_by_power_group(self) -> Mapping[str, float]:
+        device_energy = dict(self._rust_backend.consumed_energy)
+        consumed_energy = {
+            "RAPLSoC": device_energy.get("cpu", 0.0) + device_energy.get("dram", 0.0)
+        }
+        gpu_energy = device_energy.get("gpu", 0.0)
+        gpu_available = bool(
+            getattr(self._rust_backend, "gpu_available", gpu_energy > 0.0)
+        )
+        if gpu_available or gpu_energy > 0.0:
+            consumed_energy["NvidiaGPU"] = gpu_energy
+        return consumed_energy
 
     @property
     def trace_recorders(self):

--- a/src/python.rs
+++ b/src/python.rs
@@ -350,6 +350,16 @@ impl PyRustMonitor {
     }
 
     #[getter]
+    fn gpu_available(&self, py: Python<'_>) -> PyResult<bool> {
+        let handle = self
+            .handle
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("Monitor not commenced"))?
+            .clone();
+        py.detach(move || Ok(handle.snapshot().gpu_available))
+    }
+
+    #[getter]
     fn is_running(&self) -> bool {
         self.running
     }

--- a/tests/test_energy_meter.py
+++ b/tests/test_energy_meter.py
@@ -1,5 +1,6 @@
 import pytest
 import asyncio
+import os
 import sys
 import types
 from collections import defaultdict
@@ -293,6 +294,7 @@ def test_enter_method_uses_rust_backend_without_python_thread(monkeypatch):
             self.shutdown_called = False
             self.total_consumed_energy = 12.5
             self.consumed_energy = {"cpu": 10.0, "dram": 2.5, "gpu": 0.0}
+            self.gpu_available = False
             instances.append(self)
 
         def commence(self):
@@ -326,10 +328,95 @@ def test_enter_method_uses_rust_backend_without_python_thread(monkeypatch):
     mock_get_available_pgs.assert_not_called()
     mock_thread.assert_not_called()
     assert monitor.total_consumed_energy == pytest.approx(12.5)
-    assert monitor.consumed_energy == {"cpu": 10.0, "dram": 2.5, "gpu": 0.0}
+    assert monitor.consumed_energy == {"RAPLSoC": 12.5}
 
     monitor.__exit__()
     assert instances[0].shutdown_called is True
+
+
+def test_rust_backend_defaults_to_current_pid_for_python_api(monkeypatch):
+    instances = []
+
+    class FakeRustMonitor:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.total_consumed_energy = 0.0
+            self.consumed_energy = {"cpu": 0.0, "dram": 0.0, "gpu": 0.0}
+            self.gpu_available = False
+            instances.append(self)
+
+        def commence(self):
+            pass
+
+        def shutdown(self):
+            pass
+
+    install_fake_rust_module(monkeypatch, FakeRustMonitor)
+    monitor = EnergyMonitor(name="DefaultPidContext", startup_delay_s=0.0)
+
+    with (
+        patch("emt.energy_monitor.get_available_pgs"),
+        patch("threading.Thread"),
+    ):
+        monitor.__enter__()
+
+    assert instances[0].kwargs == {
+        "name": "DefaultPidContext",
+        "pid": os.getpid(),
+    }
+
+
+def test_rust_backend_consumed_energy_preserves_python_power_group_names(monkeypatch):
+    class FakeRustMonitor:
+        def __init__(self, **_):
+            self.total_consumed_energy = 15.0
+            self.consumed_energy = {"cpu": 10.0, "dram": 2.0, "gpu": 3.0}
+            self.gpu_available = True
+
+        def commence(self):
+            pass
+
+        def shutdown(self):
+            pass
+
+    install_fake_rust_module(monkeypatch, FakeRustMonitor)
+    monitor = EnergyMonitor(startup_delay_s=0.0)
+
+    with (
+        patch("emt.energy_monitor.get_available_pgs"),
+        patch("threading.Thread"),
+    ):
+        monitor.__enter__()
+
+    assert monitor.consumed_energy == {"RAPLSoC": 12.0, "NvidiaGPU": 3.0}
+    assert sum(monitor.consumed_energy.values()) == pytest.approx(
+        monitor.total_consumed_energy
+    )
+
+
+def test_rust_backend_preserves_available_gpu_key_when_energy_is_zero(monkeypatch):
+    class FakeRustMonitor:
+        def __init__(self, **_):
+            self.total_consumed_energy = 12.0
+            self.consumed_energy = {"cpu": 10.0, "dram": 2.0, "gpu": 0.0}
+            self.gpu_available = True
+
+        def commence(self):
+            pass
+
+        def shutdown(self):
+            pass
+
+    install_fake_rust_module(monkeypatch, FakeRustMonitor)
+    monitor = EnergyMonitor(startup_delay_s=0.0)
+
+    with (
+        patch("emt.energy_monitor.get_available_pgs"),
+        patch("threading.Thread"),
+    ):
+        monitor.__enter__()
+
+    assert monitor.consumed_energy == {"RAPLSoC": 12.0, "NvidiaGPU": 0.0}
 
 
 def test_import_error_falls_back_to_python_backend(monkeypatch):

--- a/tests/test_energy_monitor_rust_integration.py
+++ b/tests/test_energy_monitor_rust_integration.py
@@ -70,6 +70,11 @@ def rust_module():
             "emt._rust imported but does not expose RustMonitor; rebuild the PyO3 "
             "extension from current sources."
         )
+    if not hasattr(module.RustMonitor, "gpu_available"):
+        pytest.fail(
+            "emt._rust.RustMonitor does not expose gpu_available; rebuild the PyO3 "
+            "extension from current sources."
+        )
     return module
 
 
@@ -124,7 +129,10 @@ def test_energy_monitor_reports_energy_from_real_rust_backend(
         f"with readable RAPL counters: {[entry.name for entry in readable_rapl_entries]}"
     )
     assert consumed_energy
-    assert {"cpu", "dram", "gpu"}.issubset(consumed_energy)
+    assert "RAPLSoC" in consumed_energy
+    assert "cpu" not in consumed_energy
+    assert "dram" not in consumed_energy
+    assert "gpu" not in consumed_energy
     assert sum(consumed_energy.values()) == pytest.approx(
         total_energy, rel=1e-6, abs=1e-9
     )


### PR DESCRIPTION
## Summary

- Preserve `EnergyMonitor()` default Python semantics on the Rust-backed path by passing the current process PID when the caller does not provide `pid`.
- Map Rust device-level energy totals back to the legacy Python `consumed_energy` power-group shape (`RAPLSoC`, `NvidiaGPU`).
- Expose `RustMonitor.gpu_available` through PyO3 so Python keeps the `NvidiaGPU` key when the GPU collector is active but reports `0.0` energy.
- Add regression coverage for default PID semantics, legacy energy keys, zero-energy GPU key preservation, and stale PyO3 extension detection.

## Acceptance Checklist

- [x] `from emt import EnergyMonitor` remains the public import.
- [x] `with EnergyMonitor() as monitor:` remains the public context-manager workflow.
- [x] `monitor.total_consumed_energy` remains a `float`.
- [x] Rust-backed `monitor.consumed_energy` no longer leaks lower-level `cpu` / `dram` / `gpu` device keys through the Python facade.
- [x] Default `EnergyMonitor(pid=None)` monitors the current Python process rather than Rust monitor-all mode.
- [x] Python trace recorders still force the Python fallback path.
- [x] `emt._rust` remains built by maturin/PyO3; no subprocess or setuptools-rust wrapper was added.
- [x] New release binary was built for local testing.

## Validation

- `uv run black --check emt/energy_monitor.py tests/test_energy_meter.py tests/test_energy_monitor_rust_integration.py`
- `cargo fmt --check`
- `uv run pytest tests/test_energy_meter.py -q` - 16 passed
- `uv run pytest tests/test_energy_monitor_rust_integration.py -q` - 1 passed
- `cargo test` - 122 lib + 14 bin tests passed; 1 doctest ignored
- `cargo test --features pyo3` - 122 lib + 14 bin tests passed; 1 doctest ignored
- `uv run pytest` - 107 passed
- `cargo build --release`
- `maturin build --release --strip --out .artifacts/ene-49-50-wheel-final`
- Fresh venv wheel smoke from outside the repository: imported `emt._rust`, confirmed `RustMonitor.gpu_available`, and exercised `EnergyMonitor()` context-manager API.
- `./target/release/emt --help`
- `./target/release/emt --json-out .artifacts/ene-49-50-cli-smoke-final.json --snapshot-out .artifacts/ene-49-50-snapshot-smoke-final.json --duration 1 --rate 1 --scan-interval 1`
- `git diff --check`

## Independent Review

- Python API compatibility review: initial high finding on default PID semantics resolved; follow-up review found no blocking findings.
- Rust/PyO3 packaging review: initial medium finding on `gpu_available` coverage resolved; follow-up review found no blocking findings.

## Artifacts

- Test binary: `target/release/emt`
- Built wheel: `.artifacts/ene-49-50-wheel-final/emt-0.1.0a1-cp312-cp312-manylinux_2_34_x86_64.whl`
- CLI smoke JSON: `.artifacts/ene-49-50-cli-smoke-final.json`
- CLI smoke snapshot: `.artifacts/ene-49-50-snapshot-smoke-final.json`

## Linear

Related Linear issues: ENE-49, ENE-50.

Linear MCP currently returns OAuth authorization required, so I could not read/update Linear issue status or comments from this session. The PR covers the explicit compatibility objective available in the thread.
