### PR TITLE
ENE-49 ENE-50 expose DRAM provenance

### DIFF
--- a/emt/energy_monitor.py
+++ b/emt/energy_monitor.py
@@ -310,6 +310,13 @@ class EnergyMonitor:
         return {}
 
     @property
+    def device_sources(self) -> Mapping[str, str]:
+        """Per-device energy source/provenance metadata when available."""
+        if hasattr(self, "_rust_backend") and self._rust_backend is not None:
+            return self._rust_backend.device_sources
+        return {}
+
+    @property
     def trace_recorders(self):
         """Expose trace recorders for backwards compatibility."""
         if hasattr(self, "energy_meter") and self.energy_meter is not None:

--- a/src/collectors/rapl.rs
+++ b/src/collectors/rapl.rs
@@ -1,4 +1,5 @@
 use crate::energy_group::{EnergyCollector, EnergyRecord};
+use crate::monitor::{DeviceSource, DeviceSources};
 use async_trait::async_trait;
 use chrono::Utc;
 use log::warn;
@@ -160,8 +161,8 @@ impl ProcessCpuTracker {
 pub struct Rapl {
     /// Per-socket readers organized by socket ID
     socket_readers: Vec<SocketReaders>,
-    /// System-level DRAM energy reader (off-package)
-    dram_reader: Option<DeltaReader>,
+    /// DRAM energy readers discovered from RAPL subdomains
+    dram_readers: Vec<DeltaReader>,
     /// System-level PSYS energy reader (platform/system-wide power)
     psys_reader: Option<DeltaReader>,
     /// Tracked process PIDs for per-process energy attribution
@@ -237,7 +238,7 @@ impl SystemCpuTracker {
 impl Rapl {
     pub fn new(rapl_path: Option<String>) -> Self {
         let rapl_dir = rapl_path.unwrap_or_else(|| "/sys/class/powercap".to_string());
-        let (socket_readers, dram_reader, psys_reader) = Self::scan_powercap_entries(&rapl_dir);
+        let (socket_readers, dram_readers, psys_reader) = Self::scan_powercap_entries(&rapl_dir);
 
         // Initialize CPU trackers with a warmup call
         let mut system_cpu_tracker = SystemCpuTracker::default();
@@ -245,7 +246,7 @@ impl Rapl {
 
         Self {
             socket_readers,
-            dram_reader,
+            dram_readers,
             psys_reader,
             tracked_pids: Arc::new(Mutex::new(Vec::new())),
             cpu_count: logical_cpu_count(),
@@ -255,18 +256,41 @@ impl Rapl {
         }
     }
 
-    /// Discovers all RAPL sockets and their energy components in a single pass
-    /// Returns socket readers and system-level DRAM/PSYS readers
+    pub fn device_sources(&self) -> DeviceSources {
+        let has_package_reader = self
+            .socket_readers
+            .iter()
+            .any(|socket| socket.package_reader.is_some());
+
+        DeviceSources {
+            cpu: if has_package_reader {
+                DeviceSource::MeasuredPackage
+            } else {
+                DeviceSource::Unavailable
+            },
+            dram: if !self.dram_readers.is_empty() {
+                DeviceSource::Measured
+            } else if has_package_reader {
+                DeviceSource::IncludedInPackage
+            } else {
+                DeviceSource::Unavailable
+            },
+            gpu: DeviceSource::Unavailable,
+        }
+    }
+
+    /// Discovers all RAPL sockets and their energy components in a single pass.
+    /// Returns socket readers, all separate DRAM readers, and an optional PSYS reader.
     fn scan_powercap_entries(
         rapl_dir: &str,
-    ) -> (Vec<SocketReaders>, Option<DeltaReader>, Option<DeltaReader>) {
+    ) -> (Vec<SocketReaders>, Vec<DeltaReader>, Option<DeltaReader>) {
         let mut socket_map: BTreeMap<u32, SocketReaders> = BTreeMap::new();
-        let mut dram_reader: Option<DeltaReader> = None;
+        let mut dram_readers: Vec<DeltaReader> = Vec::new();
         let mut psys_reader: Option<DeltaReader> = None;
 
         let Ok(entries) = fs::read_dir(rapl_dir) else {
             warn!("Failed to read RAPL directory: {}", rapl_dir);
-            return (Vec::new(), None, None);
+            return (Vec::new(), Vec::new(), None);
         };
 
         for entry in entries.flatten() {
@@ -282,7 +306,7 @@ impl Rapl {
 
             // Handle PSYS (system-wide power) separately
             if name.contains("psys") {
-                if fs::metadata(path.join("energy_uj")).is_ok() {
+                if energy_counter_is_readable(&path.join("energy_uj")) {
                     psys_reader = Some(DeltaReader::new(path.clone()));
                 }
                 continue;
@@ -294,8 +318,8 @@ impl Rapl {
                 // Socket-level entry: rapl:N (package energy at root level)
                 1 => {
                     if let Some(socket_id) = Self::parse_socket_id(name) {
-                        // Check if this socket has energy_uj (package energy)
-                        if fs::metadata(path.join("energy_uj")).is_ok() {
+                        // Check if this socket has readable energy_uj (package energy)
+                        if energy_counter_is_readable(&path.join("energy_uj")) {
                             let package_reader = DeltaReader::new(path.clone());
 
                             // Insert or update socket with package reader
@@ -316,6 +340,15 @@ impl Rapl {
                 // Component-level entry: rapl:N:M (core, uncore, etc.)
                 2 => {
                     if let Some(reader) = Self::parse_component(&path, name) {
+                        let Some(component_name) = Self::component_name(&path) else {
+                            continue;
+                        };
+
+                        if Self::is_dram_component(&component_name) {
+                            dram_readers.push(reader);
+                            continue;
+                        }
+
                         if let Some(socket_id) = Self::parse_socket_id(name) {
                             // Ensure socket exists before assigning component
                             // Use or_insert_with to avoid overwriting existing entry
@@ -329,11 +362,15 @@ impl Rapl {
                                 });
                             // Now get mutable reference and assign
                             if let Some(socket) = socket_map.get_mut(&socket_id) {
-                                Self::assign_socket_component(socket, reader, &path);
+                                Self::assign_socket_component(socket, reader, &component_name);
                             }
                         } else {
                             // System-level component (e.g., DRAM without socket association)
-                            Self::assign_system_component(&mut dram_reader, reader, &path);
+                            Self::assign_system_component(
+                                &mut dram_readers,
+                                reader,
+                                &component_name,
+                            );
                         }
                     }
                 }
@@ -341,7 +378,11 @@ impl Rapl {
             }
         }
 
-        (socket_map.into_values().collect(), dram_reader, psys_reader)
+        (
+            socket_map.into_values().collect(),
+            dram_readers,
+            psys_reader,
+        )
     }
 
     /// Extracts socket ID from RAPL socket entry name (e.g., "intel-rapl:0" -> 0)
@@ -351,31 +392,39 @@ impl Rapl {
 
     /// Parses a component entry and returns a delta reader if valid
     fn parse_component(path: &Path, _name: &str) -> Option<DeltaReader> {
-        // Verify energy_uj file exists
-        if fs::metadata(path.join("energy_uj")).is_err() {
+        // Verify energy_uj is readable, not just present.
+        if !energy_counter_is_readable(&path.join("energy_uj")) {
             return None;
         }
 
         Some(DeltaReader::new(path.to_path_buf()))
     }
 
-    /// Assigns a component reader to the appropriate socket field based on component name
-    fn assign_socket_component(socket: &mut SocketReaders, reader: DeltaReader, path: &Path) {
-        let Ok(component_name) = fs::read_to_string(path.join("name")) else {
-            warn!("Failed to read component name from: {:?}", path);
-            return;
-        };
+    fn component_name(path: &Path) -> Option<String> {
+        fs::read_to_string(path.join("name"))
+            .ok()
+            .map(|name| name.trim().to_lowercase())
+    }
 
-        let comp_name = component_name.trim().to_lowercase();
+    fn is_dram_component(component_name: &str) -> bool {
+        matches!(component_name, "dram" | "ram")
+    }
+
+    /// Assigns a component reader to the appropriate socket field based on component name
+    fn assign_socket_component(
+        socket: &mut SocketReaders,
+        reader: DeltaReader,
+        component_name: &str,
+    ) {
         log::debug!(
             "Assigning component '{}' to socket {}",
-            comp_name,
+            component_name,
             socket.socket_id
         );
 
         // Match RAPL domain names for socket sub-components (core, uncore)
         // Note: package energy is at the socket root level, not here
-        match comp_name.as_str() {
+        match component_name {
             "core" | "cores" => {
                 socket.core_reader = Some(reader);
                 log::debug!("Assigned core reader to socket {}", socket.socket_id);
@@ -386,29 +435,29 @@ impl Rapl {
             }
             _ => {
                 // Log unrecognized component for debugging
-                log::debug!("Unrecognized socket-level RAPL component: {}", comp_name);
+                log::debug!(
+                    "Unrecognized socket-level RAPL component: {}",
+                    component_name
+                );
             }
         }
     }
 
     /// Assigns a component reader to the system-level DRAM field based on component name
     fn assign_system_component(
-        dram_reader: &mut Option<DeltaReader>,
+        dram_readers: &mut Vec<DeltaReader>,
         reader: DeltaReader,
-        path: &Path,
+        component_name: &str,
     ) {
-        let Ok(component_name) = fs::read_to_string(path.join("name")) else {
-            return;
-        };
-
-        let comp_name = component_name.trim().to_lowercase();
-
         // Match RAPL domain names for system-level components
-        match comp_name.as_str() {
-            "dram" | "ram" => *dram_reader = Some(reader),
+        match component_name {
+            "dram" | "ram" => dram_readers.push(reader),
             _ => {
                 // Log unrecognized component for debugging
-                log::debug!("Unrecognized system-level RAPL component: {}", comp_name);
+                log::debug!(
+                    "Unrecognized system-level RAPL component: {}",
+                    component_name
+                );
             }
         }
     }
@@ -730,19 +779,21 @@ impl EnergyCollector for Rapl {
         // Collect system-level energy readings (DRAM and PSYS)
         log::debug!(
             "System: dram={}, psys={}",
-            self.dram_reader.is_some(),
+            !self.dram_readers.is_empty(),
             self.psys_reader.is_some()
         );
 
-        // Read DRAM energy (system-level, off-package)
-        let dram_energy = if let Some(reader) = &self.dram_reader {
-            reader.read_delta().unwrap_or_else(|e| {
-                warn!("Failed to read DRAM energy: {}", e);
-                0.0
+        // Read separately measured DRAM energy from every discovered DRAM domain.
+        let dram_energy = self
+            .dram_readers
+            .iter()
+            .map(|reader| {
+                reader.read_delta().unwrap_or_else(|e| {
+                    warn!("Failed to read DRAM energy: {}", e);
+                    0.0
+                })
             })
-        } else {
-            0.0
-        };
+            .sum::<f64>();
 
         // Read PSYS energy (platform/system-wide)
         let psys_energy = if let Some(reader) = &self.psys_reader {
@@ -765,7 +816,7 @@ impl EnergyCollector for Rapl {
                 .unwrap_or(0.0);
 
             // DRAM energy attributed by memory usage
-            if self.dram_reader.is_some() {
+            if !self.dram_readers.is_empty() {
                 let dram_attribution = dram_energy * normalized_mem;
                 attributed_dram_energy += dram_attribution;
                 records.push(EnergyRecord {
@@ -789,7 +840,7 @@ impl EnergyCollector for Rapl {
             }
         }
 
-        if self.dram_reader.is_some() {
+        if !self.dram_readers.is_empty() {
             let unattributed_dram_energy = (dram_energy - attributed_dram_energy).max(0.0);
             if unattributed_dram_energy > 0.0 {
                 records.push(EnergyRecord {
@@ -880,6 +931,13 @@ mod tests {
         fs::write(zone_dir.join("energy_uj"), "0").unwrap();
     }
 
+    fn write_unreadable_zone(root: &Path, entry_name: &str, zone_name: &str) {
+        let zone_dir = root.join(entry_name);
+        fs::create_dir_all(&zone_dir).unwrap();
+        fs::write(zone_dir.join("name"), zone_name).unwrap();
+        fs::create_dir(zone_dir.join("energy_uj")).unwrap();
+    }
+
     #[test]
     fn availability_requires_readable_energy_counter() {
         let rapl_dir = TempTestDir::new("availability");
@@ -938,10 +996,10 @@ mod tests {
         write_zone(&rapl_dir.path, "intel-rapl:1", "package-1");
         write_zone(&rapl_dir.path, "intel-rapl:1:0", "core");
 
-        let (socket_readers, dram_reader, psys_reader) =
+        let (socket_readers, dram_readers, psys_reader) =
             Rapl::scan_powercap_entries(rapl_dir.path.to_str().unwrap());
 
-        assert!(dram_reader.is_none());
+        assert!(dram_readers.is_empty());
         assert!(psys_reader.is_none());
         assert_eq!(socket_readers.len(), 2);
 
@@ -960,6 +1018,65 @@ mod tests {
         assert!(socket1.package_reader.is_some());
         assert!(socket1.core_reader.is_some());
         assert!(socket1.uncore_reader.is_none());
+    }
+
+    #[test]
+    fn scan_powercap_entries_detects_socket_dram_subdomains() {
+        let rapl_dir = TempTestDir::new("socket-dram");
+
+        write_zone(&rapl_dir.path, "intel-rapl:0", "package-0");
+        write_zone(&rapl_dir.path, "intel-rapl:0:0", "dram");
+        write_zone(&rapl_dir.path, "intel-rapl:1", "package-1");
+        write_zone(&rapl_dir.path, "intel-rapl:1:0", "ram");
+
+        let (socket_readers, dram_readers, psys_reader) =
+            Rapl::scan_powercap_entries(rapl_dir.path.to_str().unwrap());
+
+        assert_eq!(socket_readers.len(), 2);
+        assert_eq!(dram_readers.len(), 2);
+        assert!(psys_reader.is_none());
+    }
+
+    #[test]
+    fn scan_powercap_entries_ignores_unreadable_energy_counters() {
+        let rapl_dir = TempTestDir::new("unreadable-counters");
+
+        write_unreadable_zone(&rapl_dir.path, "intel-rapl:0", "package-0");
+        write_unreadable_zone(&rapl_dir.path, "intel-rapl:0:0", "dram");
+
+        let (socket_readers, dram_readers, psys_reader) =
+            Rapl::scan_powercap_entries(rapl_dir.path.to_str().unwrap());
+
+        assert!(socket_readers.is_empty());
+        assert!(dram_readers.is_empty());
+        assert!(psys_reader.is_none());
+    }
+
+    #[test]
+    fn device_sources_report_included_dram_when_only_package_is_measured() {
+        let rapl_dir = TempTestDir::new("sources-package-only");
+        write_zone(&rapl_dir.path, "intel-rapl:0", "package-0");
+
+        let rapl = Rapl::new(Some(rapl_dir.path.to_string_lossy().to_string()));
+        let sources = rapl.device_sources();
+
+        assert_eq!(sources.cpu, DeviceSource::MeasuredPackage);
+        assert_eq!(sources.dram, DeviceSource::IncludedInPackage);
+        assert_eq!(sources.gpu, DeviceSource::Unavailable);
+    }
+
+    #[test]
+    fn device_sources_report_measured_dram_when_dram_domain_exists() {
+        let rapl_dir = TempTestDir::new("sources-dram");
+        write_zone(&rapl_dir.path, "intel-rapl:0", "package-0");
+        write_zone(&rapl_dir.path, "intel-rapl:0:0", "dram");
+
+        let rapl = Rapl::new(Some(rapl_dir.path.to_string_lossy().to_string()));
+        let sources = rapl.device_sources();
+
+        assert_eq!(sources.cpu, DeviceSource::MeasuredPackage);
+        assert_eq!(sources.dram, DeviceSource::Measured);
+        assert_eq!(sources.gpu, DeviceSource::Unavailable);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 use clap::{Parser, ValueEnum};
 use emt::config::{EmtConfig, MeasurementUnitsConfig};
 use emt::metrics_sink::{MetricsSink, PrometheusSink, SharedPrometheusSink, prometheus_router};
-use emt::monitor::{DeviceEnergy, MetricsSnapshot, Monitor, MonitorHandle};
+use emt::monitor::{
+    DeviceEnergy, DeviceSources, MetricsSnapshot, Monitor, MonitorDiagnostics, MonitorHandle,
+};
 use emt::tui::{self, App};
 use serde::Serialize;
 use std::fs::File;
@@ -102,7 +104,9 @@ fn batch_duration_seconds(args: &Args) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use emt::monitor::WorkloadSnapshot;
+    use emt::monitor::{
+        DeviceEnergy, DeviceSource, DeviceSources, ProcessEnergySnapshot, WorkloadSnapshot,
+    };
 
     #[test]
     fn cli_output_uses_configured_units_and_unit_neutral_fields() {
@@ -126,6 +130,11 @@ mod tests {
         let snapshot = MetricsSnapshot {
             timestamp: 0,
             gpu_available: false,
+            sources: DeviceSources {
+                cpu: DeviceSource::MeasuredPackage,
+                dram: DeviceSource::Measured,
+                gpu: DeviceSource::Unavailable,
+            },
             system_total: DeviceEnergy {
                 cpu_joules: 2_700.0,
                 dram_joules: 900.0,
@@ -158,7 +167,7 @@ mod tests {
         assert!((output.total_energy - 0.001).abs() < 1e-9);
         assert!((output.power - 360_000.0).abs() < 1e-9);
         assert!((output.devices.cpu - 0.00075).abs() < 1e-9);
-        assert!((output.devices.dram - 0.00025).abs() < 1e-9);
+        assert!((output.devices.dram.unwrap() - 0.00025).abs() < 1e-9);
         assert_eq!(output.workloads[0].root_pid, 123);
         assert_eq!(output.workloads[0].group_id, "pid:123");
         assert_eq!(output.workloads[0].name, "work");
@@ -166,6 +175,124 @@ mod tests {
         assert!((output.workloads[0].energy - 0.001).abs() < 1e-9);
         assert!((output.workloads[0].power - 360_000.0).abs() < 1e-9);
         assert!((output.workloads[0].percentage_of_system - 100.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn cli_output_omits_dram_device_when_dram_is_included_in_package() {
+        let args = Args {
+            pid: Some(123),
+            duration: Some(10),
+            rate: None,
+            scan_interval: None,
+            snapshot_out: None,
+            tui: false,
+            headless: false,
+            export: None,
+            port: DEFAULT_PROMETHEUS_PORT,
+            bind: "0.0.0.0".parse().unwrap(),
+            json_out: Some("results.json".to_string()),
+        };
+        let snapshot = MetricsSnapshot {
+            sources: DeviceSources {
+                cpu: DeviceSource::MeasuredPackage,
+                dram: DeviceSource::IncludedInPackage,
+                gpu: DeviceSource::Unavailable,
+            },
+            system_total: DeviceEnergy {
+                cpu_joules: 42.0,
+                dram_joules: 0.0,
+                gpu_joules: 0.0,
+            },
+            ..MetricsSnapshot::default()
+        };
+
+        let output = build_cli_output(&args, 10.0, &snapshot, &MeasurementUnitsConfig::default());
+        let json = serde_json::to_string(&output).unwrap();
+
+        assert!(output.devices.dram.is_none());
+        assert!(json.contains("\"cpu\""));
+        assert!(!json.contains("\"dram\""));
+    }
+
+    #[test]
+    fn snapshot_output_omits_dram_joules_when_dram_is_not_measured() {
+        let snapshot = MetricsSnapshot {
+            sources: DeviceSources {
+                cpu: DeviceSource::MeasuredPackage,
+                dram: DeviceSource::IncludedInPackage,
+                gpu: DeviceSource::Unavailable,
+            },
+            system_total: DeviceEnergy {
+                cpu_joules: 42.0,
+                dram_joules: 99.0,
+                gpu_joules: 0.0,
+            },
+            workloads: vec![WorkloadSnapshot {
+                root_pid: 123,
+                group_id: "pid:123".to_string(),
+                name: "work".to_string(),
+                user: "user".to_string(),
+                processes: vec![ProcessEnergySnapshot {
+                    pid: 123,
+                    name: "work".to_string(),
+                    energy: DeviceEnergy {
+                        cpu_joules: 4.0,
+                        dram_joules: 9.0,
+                        gpu_joules: 0.0,
+                    },
+                    power_watts: 2.0,
+                }],
+                is_live: true,
+                energy: DeviceEnergy {
+                    cpu_joules: 4.0,
+                    dram_joules: 9.0,
+                    gpu_joules: 0.0,
+                },
+                power_watts: 2.0,
+                percentage_of_system: 10.0,
+            }],
+            unattributed: DeviceEnergy {
+                cpu_joules: 38.0,
+                dram_joules: 90.0,
+                gpu_joules: 0.0,
+            },
+            tracked_pids: vec![123],
+            ..MetricsSnapshot::default()
+        };
+
+        let value = serde_json::to_value(build_snapshot_output(&snapshot)).unwrap();
+
+        assert_eq!(value["sources"]["dram"], "included_in_package");
+        assert!(value["system_total"].get("dram_joules").is_none());
+        assert!(value["unattributed"].get("dram_joules").is_none());
+        assert!(value["workloads"][0]["energy"].get("dram_joules").is_none());
+        assert!(
+            value["workloads"][0]["processes"][0]["energy"]
+                .get("dram_joules")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn snapshot_output_keeps_dram_joules_when_dram_is_measured() {
+        let snapshot = MetricsSnapshot {
+            sources: DeviceSources {
+                cpu: DeviceSource::MeasuredPackage,
+                dram: DeviceSource::Measured,
+                gpu: DeviceSource::Unavailable,
+            },
+            system_total: DeviceEnergy {
+                cpu_joules: 42.0,
+                dram_joules: 9.0,
+                gpu_joules: 0.0,
+            },
+            ..MetricsSnapshot::default()
+        };
+
+        let value = serde_json::to_value(build_snapshot_output(&snapshot)).unwrap();
+
+        assert_eq!(value["sources"]["dram"], "measured");
+        assert_eq!(value["system_total"]["dram_joules"], 9.0);
     }
 
     #[test]
@@ -325,7 +452,8 @@ struct CliOutput {
 #[derive(Serialize)]
 struct DeviceBreakdown {
     cpu: f64,
-    dram: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dram: Option<f64>,
     gpu: f64,
 }
 
@@ -340,13 +468,106 @@ struct WorkloadOutput {
     percentage_of_system: f64,
 }
 
+#[derive(Serialize)]
+struct SnapshotOutput<'a> {
+    timestamp: i64,
+    gpu_available: bool,
+    sources: &'a DeviceSources,
+    system_total: SnapshotDeviceEnergy,
+    workloads: Vec<SnapshotWorkloadOutput<'a>>,
+    unattributed: SnapshotDeviceEnergy,
+    tracked_pids: &'a [u32],
+    diagnostics: &'a MonitorDiagnostics,
+}
+
+#[derive(Serialize)]
+struct SnapshotDeviceEnergy {
+    cpu_joules: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dram_joules: Option<f64>,
+    gpu_joules: f64,
+}
+
+#[derive(Serialize)]
+struct SnapshotWorkloadOutput<'a> {
+    root_pid: u32,
+    group_id: &'a str,
+    name: &'a str,
+    user: &'a str,
+    processes: Vec<SnapshotProcessOutput<'a>>,
+    is_live: bool,
+    energy: SnapshotDeviceEnergy,
+    power_watts: f64,
+    percentage_of_system: f64,
+}
+
+#[derive(Serialize)]
+struct SnapshotProcessOutput<'a> {
+    pid: u32,
+    name: &'a str,
+    energy: SnapshotDeviceEnergy,
+    power_watts: f64,
+}
+
 impl DeviceBreakdown {
-    fn from_energy(de: &DeviceEnergy, units: &MeasurementUnitsConfig) -> Self {
+    fn from_snapshot(snapshot: &MetricsSnapshot, units: &MeasurementUnitsConfig) -> Self {
         Self {
-            cpu: units.convert_energy_from_joules(de.cpu_joules),
-            dram: units.convert_energy_from_joules(de.dram_joules),
-            gpu: units.convert_energy_from_joules(de.gpu_joules),
+            cpu: units.convert_energy_from_joules(snapshot.system_total.cpu_joules),
+            dram: snapshot
+                .sources
+                .reports_dram_energy()
+                .then(|| units.convert_energy_from_joules(snapshot.system_total.dram_joules)),
+            gpu: units.convert_energy_from_joules(snapshot.system_total.gpu_joules),
         }
+    }
+}
+
+impl SnapshotDeviceEnergy {
+    fn from_energy(energy: &DeviceEnergy, sources: &DeviceSources) -> Self {
+        Self {
+            cpu_joules: energy.cpu_joules,
+            dram_joules: sources.reports_dram_energy().then_some(energy.dram_joules),
+            gpu_joules: energy.gpu_joules,
+        }
+    }
+}
+
+fn build_snapshot_output(snapshot: &MetricsSnapshot) -> SnapshotOutput<'_> {
+    let sources = &snapshot.sources;
+    let workloads = snapshot
+        .workloads
+        .iter()
+        .map(|workload| SnapshotWorkloadOutput {
+            root_pid: workload.root_pid,
+            group_id: workload.group_id.as_str(),
+            name: workload.name.as_str(),
+            user: workload.user.as_str(),
+            processes: workload
+                .processes
+                .iter()
+                .map(|process| SnapshotProcessOutput {
+                    pid: process.pid,
+                    name: process.name.as_str(),
+                    energy: SnapshotDeviceEnergy::from_energy(&process.energy, sources),
+                    power_watts: process.power_watts,
+                })
+                .collect(),
+            is_live: workload.is_live,
+            energy: SnapshotDeviceEnergy::from_energy(&workload.energy, sources),
+            power_watts: workload.power_watts,
+            percentage_of_system: workload.percentage_of_system,
+        })
+        .collect();
+
+    SnapshotOutput {
+        timestamp: snapshot.timestamp,
+        gpu_available: snapshot.gpu_available,
+        sources,
+        system_total: SnapshotDeviceEnergy::from_energy(&snapshot.system_total, sources),
+        workloads,
+        unattributed: SnapshotDeviceEnergy::from_energy(&snapshot.unattributed, sources),
+        tracked_pids: &snapshot.tracked_pids,
+        diagnostics: &snapshot.diagnostics,
     }
 }
 
@@ -388,7 +609,7 @@ fn build_cli_output(
         energy_unit: units.energy.clone(),
         power: units.convert_power_from_watts(power_watts),
         power_unit: units.power.clone(),
-        devices: DeviceBreakdown::from_energy(&snapshot.system_total, units),
+        devices: DeviceBreakdown::from_snapshot(snapshot, units),
         workloads,
     }
 }
@@ -695,14 +916,15 @@ fn write_snapshot_if_requested(path: Option<&str>, snapshot: &MetricsSnapshot) {
 
     let result: Result<(), Box<dyn std::error::Error>> = (|| {
         let mut file = File::create(path)?;
-        serde_json::to_writer_pretty(&mut file, snapshot)?;
+        let output = build_snapshot_output(snapshot);
+        serde_json::to_writer_pretty(&mut file, &output)?;
         file.write_all(b"\n")?;
         Ok(())
     })();
 
     match result {
-        Ok(()) => eprintln!("Raw snapshot written to: {path}"),
-        Err(e) => eprintln!("Warning: failed to write raw snapshot to {path}: {e}"),
+        Ok(()) => eprintln!("Snapshot written to: {path}"),
+        Err(e) => eprintln!("Warning: failed to write snapshot to {path}: {e}"),
     }
 }
 

--- a/src/metrics_sink.rs
+++ b/src/metrics_sink.rs
@@ -1,4 +1,4 @@
-use crate::monitor::{DeviceEnergy, MetricsSnapshot, WorkloadSnapshot};
+use crate::monitor::{DeviceEnergy, DeviceSources, MetricsSnapshot, WorkloadSnapshot};
 use axum::Router;
 use axum::extract::State;
 use axum::http::{StatusCode, header};
@@ -187,7 +187,13 @@ impl<T> LockUnpoisoned<T> for Mutex<T> {
 }
 
 fn energy_samples(snapshot: &MetricsSnapshot) -> Vec<MetricSample> {
-    let mut samples = device_samples("system", None, None, &snapshot.system_total);
+    let mut samples = device_samples(
+        "system",
+        None,
+        None,
+        &snapshot.system_total,
+        &snapshot.sources,
+    );
 
     for workload in &snapshot.workloads {
         let key = workload_key(workload);
@@ -196,6 +202,7 @@ fn energy_samples(snapshot: &MetricsSnapshot) -> Vec<MetricSample> {
             Some(key.as_str()),
             workload_name(workload),
             &workload.energy,
+            &snapshot.sources,
         ));
     }
 
@@ -216,7 +223,14 @@ fn power_samples(
     }
 
     let system_power = snapshot.system_total.saturating_sub(&previous.system_total);
-    let mut samples = device_power_samples("system", None, None, &system_power, elapsed_seconds);
+    let mut samples = device_power_samples(
+        "system",
+        None,
+        None,
+        &system_power,
+        elapsed_seconds,
+        &snapshot.sources,
+    );
 
     for workload in &snapshot.workloads {
         let key = workload_key(workload);
@@ -232,6 +246,7 @@ fn power_samples(
             workload_name(workload),
             &power,
             elapsed_seconds,
+            &snapshot.sources,
         ));
     }
 
@@ -240,7 +255,7 @@ fn power_samples(
 
 fn zero_power_samples(snapshot: &MetricsSnapshot) -> Vec<MetricSample> {
     let zero = DeviceEnergy::default();
-    let mut samples = device_power_samples("system", None, None, &zero, 1.0);
+    let mut samples = device_power_samples("system", None, None, &zero, 1.0, &snapshot.sources);
 
     for workload in &snapshot.workloads {
         let key = workload_key(workload);
@@ -250,6 +265,7 @@ fn zero_power_samples(snapshot: &MetricsSnapshot) -> Vec<MetricSample> {
             workload_name(workload),
             &zero,
             1.0,
+            &snapshot.sources,
         ));
     }
 
@@ -262,6 +278,7 @@ fn device_power_samples(
     workload_name: Option<&str>,
     energy_delta: &DeviceEnergy,
     elapsed_seconds: f64,
+    sources: &DeviceSources,
 ) -> Vec<MetricSample> {
     device_samples(
         scope,
@@ -272,6 +289,7 @@ fn device_power_samples(
             dram_joules: energy_delta.dram_joules / elapsed_seconds,
             gpu_joules: energy_delta.gpu_joules / elapsed_seconds,
         },
+        sources,
     )
 }
 
@@ -280,18 +298,32 @@ fn device_samples(
     workload_id: Option<&str>,
     workload_name: Option<&str>,
     energy: &DeviceEnergy,
+    sources: &DeviceSources,
 ) -> Vec<MetricSample> {
-    vec![
-        metric_sample(scope, workload_id, workload_name, "cpu", energy.cpu_joules),
-        metric_sample(
+    let mut samples = vec![metric_sample(
+        scope,
+        workload_id,
+        workload_name,
+        "cpu",
+        energy.cpu_joules,
+    )];
+    if sources.reports_dram_energy() {
+        samples.push(metric_sample(
             scope,
             workload_id,
             workload_name,
             "dram",
             energy.dram_joules,
-        ),
-        metric_sample(scope, workload_id, workload_name, "gpu", energy.gpu_joules),
-    ]
+        ));
+    }
+    samples.push(metric_sample(
+        scope,
+        workload_id,
+        workload_name,
+        "gpu",
+        energy.gpu_joules,
+    ));
+    samples
 }
 
 fn metric_sample(
@@ -387,6 +419,7 @@ fn label_pairs(labels: &[(&'static str, String)]) -> Vec<LabelPair> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::monitor::DeviceSource;
     use axum::body::{Body, to_bytes};
     use axum::http::Request;
     use tower::ServiceExt;
@@ -479,6 +512,22 @@ mod tests {
             ),
             "{exposition}"
         );
+    }
+
+    #[test]
+    fn prometheus_sink_omits_dram_samples_when_dram_is_not_separately_measured() {
+        let mut sink = PrometheusSink::new().unwrap();
+        let mut snapshot = multi_workload_snapshot(
+            1_000,
+            vec![workload("group-a", "render", energy(5.0, 0.0, 0.0))],
+        );
+        snapshot.sources.dram = DeviceSource::IncludedInPackage;
+
+        sink.update(&snapshot);
+
+        let exposition = sink.encode_text().unwrap();
+        assert!(!exposition.contains("device=\"dram\""), "{exposition}");
+        assert!(exposition.contains("device=\"cpu\""), "{exposition}");
     }
 
     #[test]
@@ -617,6 +666,19 @@ mod tests {
         MetricsSnapshot {
             timestamp,
             gpu_available: system_total.gpu_joules > 0.0,
+            sources: DeviceSources {
+                cpu: DeviceSource::MeasuredPackage,
+                dram: if system_total.dram_joules > 0.0 {
+                    DeviceSource::Measured
+                } else {
+                    DeviceSource::IncludedInPackage
+                },
+                gpu: if system_total.gpu_joules > 0.0 {
+                    DeviceSource::Measured
+                } else {
+                    DeviceSource::Unavailable
+                },
+            },
             system_total,
             workloads,
             unattributed: DeviceEnergy::default(),

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -17,6 +17,61 @@ use tokio::task::JoinHandle;
 
 // ─── MetricsSnapshot data structures ────────────────────────────────────────
 
+/// Energy source/provenance for a device in public outputs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeviceSource {
+    /// Energy is measured by a dedicated device/domain counter.
+    Measured,
+    /// CPU/package energy is measured from package-level RAPL.
+    MeasuredPackage,
+    /// The device has no separate counter but is included in package energy.
+    IncludedInPackage,
+    /// No usable measurement source is available.
+    Unavailable,
+}
+
+impl Default for DeviceSource {
+    fn default() -> Self {
+        Self::Unavailable
+    }
+}
+
+impl DeviceSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Measured => "measured",
+            Self::MeasuredPackage => "measured_package",
+            Self::IncludedInPackage => "included_in_package",
+            Self::Unavailable => "unavailable",
+        }
+    }
+}
+
+/// Device source/provenance metadata attached to monitor snapshots.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DeviceSources {
+    pub cpu: DeviceSource,
+    pub dram: DeviceSource,
+    pub gpu: DeviceSource,
+}
+
+impl Default for DeviceSources {
+    fn default() -> Self {
+        Self {
+            cpu: DeviceSource::Unavailable,
+            dram: DeviceSource::Unavailable,
+            gpu: DeviceSource::Unavailable,
+        }
+    }
+}
+
+impl DeviceSources {
+    pub fn reports_dram_energy(&self) -> bool {
+        self.dram == DeviceSource::Measured
+    }
+}
+
 /// Energy breakdown by device type (CPU, DRAM, GPU).
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct DeviceEnergy {
@@ -69,6 +124,7 @@ pub struct WorkloadSnapshot {
 pub struct MetricsSnapshot {
     pub timestamp: i64,
     pub gpu_available: bool,
+    pub sources: DeviceSources,
     pub system_total: DeviceEnergy,
     pub workloads: Vec<WorkloadSnapshot>,
     pub unattributed: DeviceEnergy,
@@ -433,6 +489,8 @@ pub struct Monitor {
     start_timestamp: Arc<RwLock<i64>>,
     /// Number of process discovery scans completed in monitor-all mode.
     process_scan_count: Arc<AtomicU64>,
+    /// Device source/provenance metadata for public outputs.
+    sources: DeviceSources,
     /// Internal task handles
     tick_handle: Option<JoinHandle<()>>,
     scan_handle: Option<JoinHandle<()>>,
@@ -449,7 +507,9 @@ impl Monitor {
         let rate = config.collection.rate_hz;
         // Batch size = rate (flush once per second for responsive snapshots)
         let batch_size = Some(rate.ceil() as usize);
-        let mut rapl_group = EnergyGroup::new(Rapl::default(), rate, batch_size);
+        let rapl = Rapl::default();
+        let mut sources = rapl.device_sources();
+        let mut rapl_group = EnergyGroup::new(rapl, rate, batch_size);
         rapl_group.set_trace_retention(config.collection.trace_retention_secs as i64);
         rapl_group.set_recorder_flush_interval(Duration::from_secs_f64(
             config.collection.trace_flush_interval_secs,
@@ -469,6 +529,11 @@ impl Monitor {
             };
 
         let gpu_available = gpu_group.is_some();
+        sources.gpu = if gpu_available {
+            DeviceSource::Measured
+        } else {
+            DeviceSource::Unavailable
+        };
 
         Self {
             config,
@@ -480,10 +545,12 @@ impl Monitor {
             last_pid_to_group: Arc::new(RwLock::new(HashMap::new())),
             start_timestamp: Arc::new(RwLock::new(0)),
             process_scan_count: Arc::new(AtomicU64::new(0)),
+            sources: sources.clone(),
             tick_handle: None,
             scan_handle: None,
             snapshot: Arc::new(RwLock::new(MetricsSnapshot {
                 gpu_available,
+                sources,
                 ..MetricsSnapshot::default()
             })),
             is_running: Arc::new(AtomicBool::new(false)),
@@ -506,6 +573,7 @@ impl Monitor {
         self.process_scan_count.store(0, Ordering::SeqCst);
         *self.snapshot.write().unwrap() = MetricsSnapshot {
             gpu_available: self.gpu_group.is_some(),
+            sources: self.sources.clone(),
             ..MetricsSnapshot::default()
         };
 
@@ -713,6 +781,7 @@ impl Monitor {
 
         snap.timestamp = current_timestamp;
         snap.gpu_available = self.gpu_group.is_some();
+        snap.sources = self.sources.clone();
         snap.workloads = workloads;
         snap.system_total = system_total;
     }
@@ -729,6 +798,7 @@ impl Monitor {
         let last_pid_to_group = Arc::clone(&self.last_pid_to_group);
         let start_timestamp = Arc::clone(&self.start_timestamp);
         let process_scan_count = Arc::clone(&self.process_scan_count);
+        let sources = self.sources.clone();
         let snapshot = Arc::clone(&self.snapshot);
         let is_running = Arc::clone(&self.is_running);
 
@@ -834,6 +904,7 @@ impl Monitor {
                     let mut snap = snapshot.write().unwrap();
                     snap.timestamp = current_timestamp;
                     snap.gpu_available = gpu_available;
+                    snap.sources = sources.clone();
                     snap.system_total = cumulative_system_total;
                     snap.workloads = workloads;
                     snap.unattributed = cumulative_unattributed;
@@ -1172,6 +1243,7 @@ mod tests {
         let snap = MetricsSnapshot::default();
         assert_eq!(snap.timestamp, 0);
         assert!(!snap.gpu_available);
+        assert_eq!(snap.sources, DeviceSources::default());
         assert_eq!(snap.system_total.total(), 0.0);
         assert!(snap.workloads.is_empty());
         assert_eq!(snap.unattributed.total(), 0.0);
@@ -1191,6 +1263,24 @@ mod tests {
         let snapshot = monitor.snapshot.read().unwrap();
 
         assert_eq!(snapshot.gpu_available, expected_gpu_available);
+    }
+
+    #[test]
+    fn metrics_snapshot_serializes_device_sources() {
+        let snapshot = MetricsSnapshot {
+            sources: DeviceSources {
+                cpu: DeviceSource::MeasuredPackage,
+                dram: DeviceSource::IncludedInPackage,
+                gpu: DeviceSource::Unavailable,
+            },
+            ..MetricsSnapshot::default()
+        };
+
+        let value = serde_json::to_value(&snapshot).unwrap();
+
+        assert_eq!(value["sources"]["cpu"], "measured_package");
+        assert_eq!(value["sources"]["dram"], "included_in_package");
+        assert_eq!(value["sources"]["gpu"], "unavailable");
     }
 
     #[tokio::test]

--- a/src/python.rs
+++ b/src/python.rs
@@ -343,9 +343,28 @@ impl PyRustMonitor {
             let snapshot = handle.snapshot();
             let mut result = HashMap::new();
             result.insert("cpu".to_string(), snapshot.system_total.cpu_joules);
-            result.insert("dram".to_string(), snapshot.system_total.dram_joules);
+            if snapshot.sources.reports_dram_energy() {
+                result.insert("dram".to_string(), snapshot.system_total.dram_joules);
+            }
             result.insert("gpu".to_string(), snapshot.system_total.gpu_joules);
             Ok(result)
+        })
+    }
+
+    #[getter]
+    fn device_sources(&self, py: Python<'_>) -> PyResult<HashMap<String, String>> {
+        let handle = self
+            .handle
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("Monitor not commenced"))?
+            .clone();
+        py.detach(move || {
+            let sources = handle.snapshot().sources;
+            Ok(HashMap::from([
+                ("cpu".to_string(), sources.cpu.as_str().to_string()),
+                ("dram".to_string(), sources.dram.as_str().to_string()),
+                ("gpu".to_string(), sources.gpu.as_str().to_string()),
+            ]))
         })
     }
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -45,7 +45,7 @@ fn render_snapshot(
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(8),
+            Constraint::Length(7),
             Constraint::Min(3),
             Constraint::Length(1),
         ])
@@ -133,7 +133,6 @@ fn render_header(
             Constraint::Length(3),
             Constraint::Length(1),
             Constraint::Length(1),
-            Constraint::Length(1),
         ])
         .split(inner);
 
@@ -141,8 +140,8 @@ fn render_header(
     if power_history.has_samples() {
         render_power_history(
             frame,
+            header_chunks[1],
             header_chunks[2],
-            header_chunks[3],
             power_history,
             snapshot.sources.dram,
             snapshot.gpu_available,
@@ -257,7 +256,6 @@ fn render_dram_power_history(
                 label_area,
                 disabled_dram_power_label(label_area.width, "in CPU"),
             );
-            render_disabled_sparkline(frame, sparkline_area);
         }
         DeviceSource::Unavailable => {
             render_disabled_power_label(
@@ -265,7 +263,6 @@ fn render_dram_power_history(
                 label_area,
                 disabled_dram_power_label(label_area.width, "unavailable"),
             );
-            render_disabled_sparkline(frame, sparkline_area);
         }
     }
 }
@@ -328,15 +325,6 @@ fn render_component_sparkline(frame: &mut Frame, area: Rect, samples: &[f64], co
         .max(max)
         .style(Style::default().fg(color));
     frame.render_widget(sparkline, area);
-}
-
-fn render_disabled_sparkline(frame: &mut Frame, area: Rect) {
-    if area.width == 0 || area.height == 0 {
-        return;
-    }
-
-    let chart = Paragraph::new("-".repeat(usize::from(area.width))).style(disabled_style());
-    frame.render_widget(chart, area);
 }
 
 fn sparkline_data(samples: &[f64]) -> Vec<u64> {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -45,7 +45,7 @@ fn render_snapshot(
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(7),
+            Constraint::Length(8),
             Constraint::Min(3),
             Constraint::Length(1),
         ])
@@ -133,6 +133,7 @@ fn render_header(
             Constraint::Length(3),
             Constraint::Length(1),
             Constraint::Length(1),
+            Constraint::Length(1),
         ])
         .split(inner);
 
@@ -140,8 +141,8 @@ fn render_header(
     if power_history.has_samples() {
         render_power_history(
             frame,
-            header_chunks[1],
             header_chunks[2],
+            header_chunks[3],
             power_history,
             snapshot.sources.dram,
             snapshot.gpu_available,
@@ -254,7 +255,7 @@ fn render_dram_power_history(
             render_disabled_power_label(
                 frame,
                 label_area,
-                disabled_dram_power_label(label_area.width, "included in CPU", "in CPU"),
+                disabled_dram_power_label(label_area.width, "in CPU"),
             );
             render_disabled_sparkline(frame, sparkline_area);
         }
@@ -262,7 +263,7 @@ fn render_dram_power_history(
             render_disabled_power_label(
                 frame,
                 label_area,
-                disabled_dram_power_label(label_area.width, "unavailable", "unavailable"),
+                disabled_dram_power_label(label_area.width, "unavailable"),
             );
             render_disabled_sparkline(frame, sparkline_area);
         }
@@ -294,7 +295,7 @@ fn render_power_label(
         .map(|watts| format!("{watts:.2} W"))
         .unwrap_or_else(|| "--".to_string());
     let label = Paragraph::new(Line::from(vec![Span::styled(
-        format!("Interval {label}: {value}"),
+        format!("{label}: {value}"),
         Style::default().fg(color),
     )]));
     frame.render_widget(label, area);
@@ -305,21 +306,11 @@ fn render_disabled_power_label(frame: &mut Frame, area: Rect, text: String) {
     frame.render_widget(label, area);
 }
 
-fn disabled_dram_power_label(width: u16, detail: &str, compact_detail: &str) -> String {
+fn disabled_dram_power_label(width: u16, detail: &str) -> String {
     let width = usize::from(width);
-    let full = format!("Interval DRAM: -- ({detail})");
-    if full.len() <= width {
-        return full;
-    }
-
-    let without_interval = format!("DRAM: -- ({detail})");
-    if without_interval.len() <= width {
-        return without_interval;
-    }
-
-    let compact = format!("DRAM: -- ({compact_detail})");
-    if compact.len() <= width {
-        return compact;
+    let label = format!("DRAM: -- ({detail})");
+    if label.len() <= width {
+        return label;
     }
 
     "DRAM: --".to_string()
@@ -634,10 +625,10 @@ mod tests {
 
         let screen = terminal.backend().to_string();
         assert!(screen.contains("Avg Power: 4.00 W"));
-        assert!(screen.contains("Interval CPU: 5.00 W"));
-        assert!(screen.contains("Interval DRAM: 1.50 W"));
+        assert!(screen.contains("CPU: 5.00 W"));
+        assert!(screen.contains("DRAM: 1.50 W"));
         assert!(!screen.contains("GPU:"));
-        assert!(!screen.contains("Interval GPU"));
+        assert!(!screen.contains("GPU: 3.00 W"));
         assert!(screen.contains("Avg Power (W)"));
         assert!(screen.contains("2.50"));
         assert!(screen.contains("python workload.py"));
@@ -691,9 +682,9 @@ mod tests {
 
         let screen = terminal.backend().to_string();
         assert!(screen.contains("DRAM: -- (included in CPU)"));
-        assert!(screen.contains("Interval DRAM: -- (included in CPU)"));
+        assert!(screen.contains("DRAM: -- (in CPU)"));
         assert!(!screen.contains("DRAM: 0.0000 J"));
-        assert!(!screen.contains("Interval DRAM: 1.50 W"));
+        assert!(!screen.contains("DRAM: 1.50 W"));
         assert!(!screen.contains("DRAM unavailable"));
     }
 
@@ -742,9 +733,8 @@ mod tests {
 
         let screen = terminal.backend().to_string();
         assert!(screen.contains("DRAM: -- (unavailable)"));
-        assert!(screen.contains("Interval DRAM: -- (unavailable)"));
         assert!(!screen.contains("DRAM: 0.0000 J"));
-        assert!(!screen.contains("Interval DRAM: 1.50 W"));
+        assert!(!screen.contains("DRAM: 1.50 W"));
         assert!(!screen.contains("DRAM included in package energy"));
     }
 
@@ -794,7 +784,7 @@ mod tests {
 
         let screen = terminal.backend().to_string();
         assert!(screen.contains("GPU: 30.0000 J"));
-        assert!(screen.contains("Interval GPU: 3.00 W"));
+        assert!(screen.contains("GPU: 3.00 W"));
     }
 
     #[test]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -115,7 +115,7 @@ fn render_header(
         ]),
         Line::from(device_line),
         Line::from(vec![
-            Span::styled("Uptime: ", Style::default().fg(Color::Green)),
+            Span::styled("  Uptime: ", Style::default().fg(Color::Green)),
             Span::raw(format!("{mins:02}:{secs:02}")),
             Span::raw(format!("    Tracked PIDs: {}", snapshot.tracked_pids.len())),
         ]),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -160,10 +160,10 @@ fn append_dram_header(device_line: &mut Vec<Span>, source: DeviceSource, dram_jo
             ]);
         }
         DeviceSource::IncludedInPackage | DeviceSource::MeasuredPackage => {
-            device_line.extend(disabled_dram_spans("-- (included in CPU)"));
+            device_line.extend(disabled_dram_spans("[included in CPU]"));
         }
         DeviceSource::Unavailable => {
-            device_line.extend(disabled_dram_spans("-- (unavailable)"));
+            device_line.extend(disabled_dram_spans("[unavailable]"));
         }
     }
 }
@@ -251,18 +251,10 @@ fn render_dram_power_history(
             render_component_sparkline(frame, sparkline_area, &power_history.dram, Color::Magenta);
         }
         DeviceSource::IncludedInPackage | DeviceSource::MeasuredPackage => {
-            render_disabled_power_label(
-                frame,
-                label_area,
-                disabled_dram_power_label(label_area.width, "in CPU"),
-            );
+            render_disabled_power_label(frame, label_area, "DRAM: --");
         }
         DeviceSource::Unavailable => {
-            render_disabled_power_label(
-                frame,
-                label_area,
-                disabled_dram_power_label(label_area.width, "unavailable"),
-            );
+            render_disabled_power_label(frame, label_area, "DRAM: --");
         }
     }
 }
@@ -298,19 +290,9 @@ fn render_power_label(
     frame.render_widget(label, area);
 }
 
-fn render_disabled_power_label(frame: &mut Frame, area: Rect, text: String) {
+fn render_disabled_power_label(frame: &mut Frame, area: Rect, text: &'static str) {
     let label = Paragraph::new(Line::from(Span::styled(text, disabled_style())));
     frame.render_widget(label, area);
-}
-
-fn disabled_dram_power_label(width: u16, detail: &str) -> String {
-    let width = usize::from(width);
-    let label = format!("DRAM: -- ({detail})");
-    if label.len() <= width {
-        return label;
-    }
-
-    "DRAM: --".to_string()
 }
 
 fn render_component_sparkline(frame: &mut Frame, area: Rect, samples: &[f64], color: Color) {
@@ -669,8 +651,8 @@ mod tests {
             .unwrap();
 
         let screen = terminal.backend().to_string();
-        assert!(screen.contains("DRAM: -- (included in CPU)"));
-        assert!(screen.contains("DRAM: -- (in CPU)"));
+        assert!(screen.contains("DRAM: [included in CPU]"));
+        assert!(screen.contains("DRAM: --"));
         assert!(!screen.contains("DRAM: 0.0000 J"));
         assert!(!screen.contains("DRAM: 1.50 W"));
         assert!(!screen.contains("DRAM unavailable"));
@@ -720,7 +702,8 @@ mod tests {
             .unwrap();
 
         let screen = terminal.backend().to_string();
-        assert!(screen.contains("DRAM: -- (unavailable)"));
+        assert!(screen.contains("DRAM: [unavailable]"));
+        assert!(screen.contains("DRAM: --"));
         assert!(!screen.contains("DRAM: 0.0000 J"));
         assert!(!screen.contains("DRAM: 1.50 W"));
         assert!(!screen.contains("DRAM included in package energy"));

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -92,31 +92,11 @@ fn render_header(
         Span::styled("    CPU: ", Style::default().fg(Color::Yellow)),
         Span::raw(format!("{:.4} J", snapshot.system_total.cpu_joules)),
     ];
-    match snapshot.sources.dram {
-        DeviceSource::Measured => {
-            device_line.extend([
-                Span::raw("    "),
-                Span::styled("DRAM: ", Style::default().fg(Color::Yellow)),
-                Span::raw(format!("{:.4} J", snapshot.system_total.dram_joules)),
-            ]);
-        }
-        DeviceSource::IncludedInPackage => {
-            device_line.extend([
-                Span::raw("    "),
-                Span::styled(
-                    "DRAM included in package energy",
-                    Style::default().fg(Color::Magenta),
-                ),
-            ]);
-        }
-        DeviceSource::Unavailable => {
-            device_line.extend([
-                Span::raw("    "),
-                Span::styled("DRAM unavailable", Style::default().fg(Color::DarkGray)),
-            ]);
-        }
-        DeviceSource::MeasuredPackage => {}
-    }
+    append_dram_header(
+        &mut device_line,
+        snapshot.sources.dram,
+        snapshot.system_total.dram_joules,
+    );
     if snapshot.gpu_available {
         device_line.extend([
             Span::raw("    "),
@@ -163,10 +143,40 @@ fn render_header(
             header_chunks[1],
             header_chunks[2],
             power_history,
-            snapshot.sources.reports_dram_energy(),
+            snapshot.sources.dram,
             snapshot.gpu_available,
         );
     }
+}
+
+fn append_dram_header(device_line: &mut Vec<Span>, source: DeviceSource, dram_joules: f64) {
+    device_line.push(Span::raw("    "));
+
+    match source {
+        DeviceSource::Measured => {
+            device_line.extend([
+                Span::styled("DRAM: ", Style::default().fg(Color::Yellow)),
+                Span::raw(format!("{dram_joules:.4} J")),
+            ]);
+        }
+        DeviceSource::IncludedInPackage | DeviceSource::MeasuredPackage => {
+            device_line.extend(disabled_dram_spans("-- (included in CPU)"));
+        }
+        DeviceSource::Unavailable => {
+            device_line.extend(disabled_dram_spans("-- (unavailable)"));
+        }
+    }
+}
+
+fn disabled_dram_spans(value: &'static str) -> [Span<'static>; 2] {
+    [
+        Span::styled("DRAM: ", disabled_style()),
+        Span::styled(value, disabled_style()),
+    ]
+}
+
+fn disabled_style() -> Style {
+    Style::default().fg(Color::DarkGray)
 }
 
 fn render_power_history(
@@ -174,11 +184,11 @@ fn render_power_history(
     label_area: Rect,
     sparkline_area: Rect,
     power_history: &PowerHistorySnapshot,
-    dram_measured: bool,
+    dram_source: DeviceSource,
     gpu_available: bool,
 ) {
-    let label_chunks = split_power_columns(label_area, dram_measured, gpu_available);
-    let sparkline_chunks = split_power_columns(sparkline_area, dram_measured, gpu_available);
+    let label_chunks = split_power_columns(label_area, gpu_available);
+    let sparkline_chunks = split_power_columns(sparkline_area, gpu_available);
 
     let mut column = 0;
     render_power_label(
@@ -196,22 +206,14 @@ fn render_power_history(
     );
     column += 1;
 
-    if dram_measured {
-        render_power_label(
-            frame,
-            label_chunks[column],
-            "DRAM",
-            power_history.latest_dram(),
-            Color::Magenta,
-        );
-        render_component_sparkline(
-            frame,
-            sparkline_chunks[column],
-            &power_history.dram,
-            Color::Magenta,
-        );
-        column += 1;
-    }
+    render_dram_power_history(
+        frame,
+        label_chunks[column],
+        sparkline_chunks[column],
+        power_history,
+        dram_source,
+    );
+    column += 1;
 
     if gpu_available {
         render_power_label(
@@ -230,12 +232,45 @@ fn render_power_history(
     }
 }
 
-fn split_power_columns(
-    area: Rect,
-    dram_measured: bool,
-    gpu_available: bool,
-) -> std::rc::Rc<[Rect]> {
-    let column_count = 1 + usize::from(dram_measured) + usize::from(gpu_available);
+fn render_dram_power_history(
+    frame: &mut Frame,
+    label_area: Rect,
+    sparkline_area: Rect,
+    power_history: &PowerHistorySnapshot,
+    source: DeviceSource,
+) {
+    match source {
+        DeviceSource::Measured => {
+            render_power_label(
+                frame,
+                label_area,
+                "DRAM",
+                power_history.latest_dram(),
+                Color::Magenta,
+            );
+            render_component_sparkline(frame, sparkline_area, &power_history.dram, Color::Magenta);
+        }
+        DeviceSource::IncludedInPackage | DeviceSource::MeasuredPackage => {
+            render_disabled_power_label(
+                frame,
+                label_area,
+                disabled_dram_power_label(label_area.width, "included in CPU", "in CPU"),
+            );
+            render_disabled_sparkline(frame, sparkline_area);
+        }
+        DeviceSource::Unavailable => {
+            render_disabled_power_label(
+                frame,
+                label_area,
+                disabled_dram_power_label(label_area.width, "unavailable", "unavailable"),
+            );
+            render_disabled_sparkline(frame, sparkline_area);
+        }
+    }
+}
+
+fn split_power_columns(area: Rect, gpu_available: bool) -> std::rc::Rc<[Rect]> {
+    let column_count = 2 + usize::from(gpu_available);
     let percentage = 100 / column_count as u16;
     let mut constraints = vec![Constraint::Percentage(percentage); column_count];
     if let Some(last) = constraints.last_mut() {
@@ -265,6 +300,31 @@ fn render_power_label(
     frame.render_widget(label, area);
 }
 
+fn render_disabled_power_label(frame: &mut Frame, area: Rect, text: String) {
+    let label = Paragraph::new(Line::from(Span::styled(text, disabled_style())));
+    frame.render_widget(label, area);
+}
+
+fn disabled_dram_power_label(width: u16, detail: &str, compact_detail: &str) -> String {
+    let width = usize::from(width);
+    let full = format!("Interval DRAM: -- ({detail})");
+    if full.len() <= width {
+        return full;
+    }
+
+    let without_interval = format!("DRAM: -- ({detail})");
+    if without_interval.len() <= width {
+        return without_interval;
+    }
+
+    let compact = format!("DRAM: -- ({compact_detail})");
+    if compact.len() <= width {
+        return compact;
+    }
+
+    "DRAM: --".to_string()
+}
+
 fn render_component_sparkline(frame: &mut Frame, area: Rect, samples: &[f64], color: Color) {
     if samples.is_empty() {
         return;
@@ -277,6 +337,15 @@ fn render_component_sparkline(frame: &mut Frame, area: Rect, samples: &[f64], co
         .max(max)
         .style(Style::default().fg(color));
     frame.render_widget(sparkline, area);
+}
+
+fn render_disabled_sparkline(frame: &mut Frame, area: Rect) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+
+    let chart = Paragraph::new("-".repeat(usize::from(area.width))).style(disabled_style());
+    frame.render_widget(chart, area);
 }
 
 fn sparkline_data(samples: &[f64]) -> Vec<u64> {
@@ -578,7 +647,7 @@ mod tests {
     }
 
     #[test]
-    fn render_snapshot_notes_dram_included_in_package_without_dram_metric() {
+    fn render_snapshot_grays_dram_included_in_package_without_dram_metric() {
         let snapshot = MetricsSnapshot {
             timestamp: 1_000,
             gpu_available: false,
@@ -621,9 +690,10 @@ mod tests {
             .unwrap();
 
         let screen = terminal.backend().to_string();
-        assert!(screen.contains("DRAM included in package energy"));
+        assert!(screen.contains("DRAM: -- (included in CPU)"));
+        assert!(screen.contains("Interval DRAM: -- (included in CPU)"));
         assert!(!screen.contains("DRAM: 0.0000 J"));
-        assert!(!screen.contains("Interval DRAM"));
+        assert!(!screen.contains("Interval DRAM: 1.50 W"));
         assert!(!screen.contains("DRAM unavailable"));
     }
 
@@ -671,9 +741,10 @@ mod tests {
             .unwrap();
 
         let screen = terminal.backend().to_string();
-        assert!(screen.contains("DRAM unavailable"));
+        assert!(screen.contains("DRAM: -- (unavailable)"));
+        assert!(screen.contains("Interval DRAM: -- (unavailable)"));
         assert!(!screen.contains("DRAM: 0.0000 J"));
-        assert!(!screen.contains("Interval DRAM"));
+        assert!(!screen.contains("Interval DRAM: 1.50 W"));
         assert!(!screen.contains("DRAM included in package energy"));
     }
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -115,7 +115,7 @@ fn render_header(
         ]),
         Line::from(device_line),
         Line::from(vec![
-            Span::styled("  Uptime: ", Style::default().fg(Color::Green)),
+            Span::styled("    Uptime: ", Style::default().fg(Color::Green)),
             Span::raw(format!("{mins:02}:{secs:02}")),
             Span::raw(format!("    Tracked PIDs: {}", snapshot.tracked_pids.len())),
         ]),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,4 +1,4 @@
-use crate::monitor::MetricsSnapshot;
+use crate::monitor::{DeviceSource, MetricsSnapshot};
 use crate::tui::App;
 use crate::tui::app::{PowerHistorySnapshot, SortMode};
 use ratatui::Frame;
@@ -91,10 +91,32 @@ fn render_header(
     let mut device_line = vec![
         Span::styled("    CPU: ", Style::default().fg(Color::Yellow)),
         Span::raw(format!("{:.4} J", snapshot.system_total.cpu_joules)),
-        Span::raw("    "),
-        Span::styled("DRAM: ", Style::default().fg(Color::Yellow)),
-        Span::raw(format!("{:.4} J", snapshot.system_total.dram_joules)),
     ];
+    match snapshot.sources.dram {
+        DeviceSource::Measured => {
+            device_line.extend([
+                Span::raw("    "),
+                Span::styled("DRAM: ", Style::default().fg(Color::Yellow)),
+                Span::raw(format!("{:.4} J", snapshot.system_total.dram_joules)),
+            ]);
+        }
+        DeviceSource::IncludedInPackage => {
+            device_line.extend([
+                Span::raw("    "),
+                Span::styled(
+                    "DRAM included in package energy",
+                    Style::default().fg(Color::Magenta),
+                ),
+            ]);
+        }
+        DeviceSource::Unavailable => {
+            device_line.extend([
+                Span::raw("    "),
+                Span::styled("DRAM unavailable", Style::default().fg(Color::DarkGray)),
+            ]);
+        }
+        DeviceSource::MeasuredPackage => {}
+    }
     if snapshot.gpu_available {
         device_line.extend([
             Span::raw("    "),
@@ -141,6 +163,7 @@ fn render_header(
             header_chunks[1],
             header_chunks[2],
             power_history,
+            snapshot.sources.reports_dram_energy(),
             snapshot.gpu_available,
         );
     }
@@ -151,61 +174,73 @@ fn render_power_history(
     label_area: Rect,
     sparkline_area: Rect,
     power_history: &PowerHistorySnapshot,
+    dram_measured: bool,
     gpu_available: bool,
 ) {
-    let label_chunks = split_power_columns(label_area, gpu_available);
-    let sparkline_chunks = split_power_columns(sparkline_area, gpu_available);
+    let label_chunks = split_power_columns(label_area, dram_measured, gpu_available);
+    let sparkline_chunks = split_power_columns(sparkline_area, dram_measured, gpu_available);
 
+    let mut column = 0;
     render_power_label(
         frame,
-        label_chunks[0],
+        label_chunks[column],
         "CPU",
         power_history.latest_cpu(),
         Color::Yellow,
     );
-    render_power_label(
-        frame,
-        label_chunks[1],
-        "DRAM",
-        power_history.latest_dram(),
-        Color::Magenta,
-    );
-
     render_component_sparkline(
         frame,
-        sparkline_chunks[0],
+        sparkline_chunks[column],
         &power_history.cpu,
         Color::Yellow,
     );
-    render_component_sparkline(
-        frame,
-        sparkline_chunks[1],
-        &power_history.dram,
-        Color::Magenta,
-    );
+    column += 1;
+
+    if dram_measured {
+        render_power_label(
+            frame,
+            label_chunks[column],
+            "DRAM",
+            power_history.latest_dram(),
+            Color::Magenta,
+        );
+        render_component_sparkline(
+            frame,
+            sparkline_chunks[column],
+            &power_history.dram,
+            Color::Magenta,
+        );
+        column += 1;
+    }
 
     if gpu_available {
         render_power_label(
             frame,
-            label_chunks[2],
+            label_chunks[column],
             "GPU",
             power_history.latest_gpu(),
             Color::Green,
         );
-        render_component_sparkline(frame, sparkline_chunks[2], &power_history.gpu, Color::Green);
+        render_component_sparkline(
+            frame,
+            sparkline_chunks[column],
+            &power_history.gpu,
+            Color::Green,
+        );
     }
 }
 
-fn split_power_columns(area: Rect, gpu_available: bool) -> std::rc::Rc<[Rect]> {
-    let constraints = if gpu_available {
-        vec![
-            Constraint::Percentage(34),
-            Constraint::Percentage(33),
-            Constraint::Percentage(33),
-        ]
-    } else {
-        vec![Constraint::Percentage(50), Constraint::Percentage(50)]
-    };
+fn split_power_columns(
+    area: Rect,
+    dram_measured: bool,
+    gpu_available: bool,
+) -> std::rc::Rc<[Rect]> {
+    let column_count = 1 + usize::from(dram_measured) + usize::from(gpu_available);
+    let percentage = 100 / column_count as u16;
+    let mut constraints = vec![Constraint::Percentage(percentage); column_count];
+    if let Some(last) = constraints.last_mut() {
+        *last = Constraint::Percentage(100 - percentage * (column_count as u16 - 1));
+    }
 
     Layout::default()
         .direction(Direction::Horizontal)
@@ -444,9 +479,13 @@ fn table_body_capacity(area: Rect) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::monitor::{DeviceEnergy, WorkloadSnapshot};
+    use crate::monitor::{DeviceEnergy, DeviceSource, DeviceSources, WorkloadSnapshot};
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
+
+    fn sources(cpu: DeviceSource, dram: DeviceSource, gpu: DeviceSource) -> DeviceSources {
+        DeviceSources { cpu, dram, gpu }
+    }
 
     #[test]
     fn sparkline_data_uses_milliwatts_to_keep_sub_watt_values_visible() {
@@ -466,6 +505,11 @@ mod tests {
         let snapshot = MetricsSnapshot {
             timestamp: 1_000,
             gpu_available: false,
+            sources: sources(
+                DeviceSource::MeasuredPackage,
+                DeviceSource::Measured,
+                DeviceSource::Unavailable,
+            ),
             system_total: DeviceEnergy {
                 cpu_joules: 180.0,
                 dram_joules: 60.0,
@@ -531,6 +575,106 @@ mod tests {
         assert!(screen.contains("Tracked PIDs: 2"));
         assert!(screen.contains("sort energy"));
         assert!(screen.contains("reset"));
+    }
+
+    #[test]
+    fn render_snapshot_notes_dram_included_in_package_without_dram_metric() {
+        let snapshot = MetricsSnapshot {
+            timestamp: 1_000,
+            gpu_available: false,
+            sources: sources(
+                DeviceSource::MeasuredPackage,
+                DeviceSource::IncludedInPackage,
+                DeviceSource::Unavailable,
+            ),
+            system_total: DeviceEnergy {
+                cpu_joules: 180.0,
+                dram_joules: 0.0,
+                gpu_joules: 0.0,
+            },
+            tracked_pids: vec![123],
+            ..MetricsSnapshot::default()
+        };
+        let power_history = PowerHistorySnapshot {
+            cpu: vec![5.0],
+            dram: vec![1.5],
+            gpu: vec![],
+        };
+        let expanded = HashSet::new();
+        let child_scroll_offsets = HashMap::new();
+        let mut terminal = Terminal::new(TestBackend::new(80, 14)).unwrap();
+
+        terminal
+            .draw(|frame| {
+                render_snapshot(
+                    frame,
+                    &snapshot,
+                    60.0,
+                    60.0,
+                    &power_history,
+                    SortMode::Energy,
+                    0,
+                    &expanded,
+                    &child_scroll_offsets,
+                )
+            })
+            .unwrap();
+
+        let screen = terminal.backend().to_string();
+        assert!(screen.contains("DRAM included in package energy"));
+        assert!(!screen.contains("DRAM: 0.0000 J"));
+        assert!(!screen.contains("Interval DRAM"));
+        assert!(!screen.contains("DRAM unavailable"));
+    }
+
+    #[test]
+    fn render_snapshot_marks_unavailable_dram_without_dram_metric() {
+        let snapshot = MetricsSnapshot {
+            timestamp: 1_000,
+            gpu_available: false,
+            sources: sources(
+                DeviceSource::MeasuredPackage,
+                DeviceSource::Unavailable,
+                DeviceSource::Unavailable,
+            ),
+            system_total: DeviceEnergy {
+                cpu_joules: 180.0,
+                dram_joules: 0.0,
+                gpu_joules: 0.0,
+            },
+            tracked_pids: vec![123],
+            ..MetricsSnapshot::default()
+        };
+        let power_history = PowerHistorySnapshot {
+            cpu: vec![5.0],
+            dram: vec![1.5],
+            gpu: vec![],
+        };
+        let expanded = HashSet::new();
+        let child_scroll_offsets = HashMap::new();
+        let mut terminal = Terminal::new(TestBackend::new(80, 14)).unwrap();
+
+        terminal
+            .draw(|frame| {
+                render_snapshot(
+                    frame,
+                    &snapshot,
+                    60.0,
+                    60.0,
+                    &power_history,
+                    SortMode::Energy,
+                    0,
+                    &expanded,
+                    &child_scroll_offsets,
+                )
+            })
+            .unwrap();
+
+        let screen = terminal.backend().to_string();
+        assert!(screen.contains("DRAM unavailable"));
+        assert!(!screen.contains("DRAM: 0.0000 J"));
+        assert!(!screen.contains("Interval DRAM"));
+        assert!(!screen.contains("DRAM included in package energy"));
     }
 
     #[test]

--- a/tests/test_energy_meter.py
+++ b/tests/test_energy_meter.py
@@ -293,6 +293,11 @@ def test_enter_method_uses_rust_backend_without_python_thread(monkeypatch):
             self.shutdown_called = False
             self.total_consumed_energy = 12.5
             self.consumed_energy = {"cpu": 10.0, "dram": 2.5, "gpu": 0.0}
+            self.device_sources = {
+                "cpu": "measured_package",
+                "dram": "measured",
+                "gpu": "unavailable",
+            }
             instances.append(self)
 
         def commence(self):
@@ -327,6 +332,11 @@ def test_enter_method_uses_rust_backend_without_python_thread(monkeypatch):
     mock_thread.assert_not_called()
     assert monitor.total_consumed_energy == pytest.approx(12.5)
     assert monitor.consumed_energy == {"cpu": 10.0, "dram": 2.5, "gpu": 0.0}
+    assert monitor.device_sources == {
+        "cpu": "measured_package",
+        "dram": "measured",
+        "gpu": "unavailable",
+    }
 
     monitor.__exit__()
     assert instances[0].shutdown_called is True

--- a/tests/test_energy_monitor_rust_integration.py
+++ b/tests/test_energy_monitor_rust_integration.py
@@ -118,13 +118,19 @@ def test_energy_monitor_reports_energy_from_real_rust_backend(
 
     total_energy = monitor.total_consumed_energy
     consumed_energy = monitor.consumed_energy
+    device_sources = monitor.device_sources
 
     assert total_energy > 0.0, (
         "Rust-backed EnergyMonitor reported no energy for a CPU-bound workload "
         f"with readable RAPL counters: {[entry.name for entry in readable_rapl_entries]}"
     )
     assert consumed_energy
-    assert {"cpu", "dram", "gpu"}.issubset(consumed_energy)
+    assert {"cpu", "gpu"}.issubset(consumed_energy)
+    assert {"cpu", "dram", "gpu"}.issubset(device_sources)
+    if device_sources["dram"] == "measured":
+        assert "dram" in consumed_energy
+    else:
+        assert "dram" not in consumed_energy
     assert sum(consumed_energy.values()) == pytest.approx(
         total_energy, rel=1e-6, abs=1e-9
     )


### PR DESCRIPTION
## Summary

- Add CPU/DRAM/GPU source provenance to Rust monitor snapshots.
- Detect separate DRAM RAPL domains only when counters are readable; package-only hosts now report DRAM as included in package energy.
- Omit public DRAM numeric outputs when DRAM is not separately measured across JSON output, snapshot output, Python Rust backend, Prometheus, and TUI rendering.
- Clarify the TUI included-in-package state with a note instead of a disabled-looking DRAM metric.

## Linear

- ENE-49
- ENE-50

## Verification

- cargo test
- uv run maturin develop
- uv run pytest
- git diff --check
- cargo build --release
- EMT_DISABLE_GPU=1 .artifacts/emt-ene-49-50-dram-provenance --pid $$ --duration 1 --rate 20 --json-out .artifacts/ene49-release-smoke.json --snapshot-out .artifacts/ene49-release-snapshot.json

## Manual test binary

Built locally at:

`.artifacts/emt-ene-49-50-dram-provenance`

Smoke result on this host: `sources.dram == included_in_package`; public JSON omits `devices.dram`; snapshot output includes `sources` and omits non-measured `dram_joules` fields.