### PR TITLE
ENE-52 ENE-53 fix Prometheus power cadence

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -17,4 +17,19 @@ Unlike tools such as EnergyMeter, which are limited to bare-metal environments, 
 
 While Kepler and Scaphandre also export Prometheus metrics, EMT emphasizes low-cardinality labeling and robust integration for both container and VM monitoring, reducing the risk of performance bottlenecks in large-scale deployments.
 
+Before demos or exporter changes on a Linux host with readable RAPL
+`/sys/class/powercap` counters, run the local power-cadence probe against a
+fresh release binary:
+
+```bash
+cargo build --release
+.venv/bin/python scripts/probe_prometheus_power_cadence.py
+```
+
+The probe starts a short CPU workload and the headless Prometheus exporter at
+the demo cadence, samples `/metrics` faster than the collection rate, and fails
+if either system or workload CPU energy increases while `emt_power_watts` falls
+back to zero. If the probe fails before energy increases, check host permissions
+and hardware counter availability before treating it as a cadence regression.
+
 *See [Virtualization Challenges](virtualization_challenges.md) for more details on technical hurdles.*

--- a/scripts/probe_prometheus_power_cadence.py
+++ b/scripts/probe_prometheus_power_cadence.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""Probe headless Prometheus power cadence for ENE-53.
+
+The probe starts `emt --headless --export prometheus`, samples raw `/metrics`
+faster than the collection cadence, and fails if CPU package energy increases
+while the corresponding power gauge repeatedly falls back to zero.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_EMT_BIN = PROJECT_ROOT / "target" / "release" / "emt"
+ENERGY_EPSILON = 1e-9
+POWER_EPSILON = 1e-6
+METRIC_RE = re.compile(
+    r"^(?P<name>[a-zA-Z_:][a-zA-Z0-9_:]*)(?:\{(?P<labels>[^}]*)\})?\s+"
+    r"(?P<value>[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)$"
+)
+LABEL_RE = re.compile(r'([a-zA-Z_][a-zA-Z0-9_]*)="((?:\\.|[^"\\])*)"')
+
+
+@dataclass(frozen=True)
+class PowerReading:
+    energy_joules: float = 0.0
+    power_watts: float = 0.0
+    name: str = ""
+
+
+@dataclass(frozen=True)
+class MetricsSample:
+    index: int
+    system_cpu: PowerReading
+    workload_cpu: dict[str, PowerReading]
+
+
+def parse_labels(text: str) -> dict[str, str]:
+    return {
+        key: value.replace(r"\"", '"').replace(r"\\", "\\")
+        for key, value in LABEL_RE.findall(text)
+    }
+
+
+def read_metrics(url: str) -> tuple[PowerReading, dict[str, PowerReading]]:
+    with urllib.request.urlopen(url, timeout=2.0) as response:
+        text = response.read().decode("utf-8", errors="replace")
+
+    energy: float | None = None
+    power: float | None = None
+    workloads: dict[str, PowerReading] = {}
+    for raw_line in text.splitlines():
+        match = METRIC_RE.match(raw_line.strip())
+        if not match:
+            continue
+        labels = parse_labels(match.group("labels") or "")
+        if labels.get("device") != "cpu":
+            continue
+
+        value = float(match.group("value"))
+        name = match.group("name")
+        scope = labels.get("scope")
+        if scope == "system":
+            if name == "emt_energy_joules_total":
+                energy = value
+            elif name == "emt_power_watts":
+                power = value
+        elif scope == "workload":
+            workload_id = labels.get("workload")
+            if not workload_id:
+                continue
+            current = workloads.get(workload_id, PowerReading())
+            if name == "emt_energy_joules_total":
+                workloads[workload_id] = PowerReading(
+                    energy_joules=value,
+                    power_watts=current.power_watts,
+                    name=labels.get("workload_name", current.name),
+                )
+            elif name == "emt_power_watts":
+                workloads[workload_id] = PowerReading(
+                    energy_joules=current.energy_joules,
+                    power_watts=value,
+                    name=labels.get("workload_name", current.name),
+                )
+
+    if energy is None or power is None:
+        raise RuntimeError("missing system CPU energy or power metric")
+    return PowerReading(energy, power), workloads
+
+
+def read_cpu_system_metrics(url: str) -> tuple[float, float]:
+    system_cpu, _ = read_metrics(url)
+    return system_cpu.energy_joules, system_cpu.power_watts
+
+
+def process_failure(process: subprocess.Popen[str] | None) -> str | None:
+    if process is None or process.poll() is None:
+        return None
+    stderr = ""
+    if process.stderr is not None:
+        stderr = process.stderr.read().strip()
+    return f"exporter exited with code {process.returncode}: {stderr}"
+
+
+def assert_endpoint_unused(url: str) -> None:
+    try:
+        with urllib.request.urlopen(url, timeout=0.3):
+            pass
+    except (OSError, urllib.error.URLError):
+        return
+    raise RuntimeError(
+        f"{url} already responds before this probe starts; choose a free port "
+        "so the probe cannot pass against a stale exporter"
+    )
+
+
+def wait_for_metrics(
+    url: str,
+    timeout_seconds: float,
+    process: subprocess.Popen[str] | None,
+) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        failure = process_failure(process)
+        if failure:
+            raise RuntimeError(failure)
+        try:
+            read_cpu_system_metrics(url)
+            return
+        except (RuntimeError, OSError, urllib.error.URLError) as exc:
+            last_error = exc
+            time.sleep(0.2)
+    raise RuntimeError(f"metrics endpoint did not become ready: {last_error}")
+
+
+def start_exporter(args: argparse.Namespace) -> subprocess.Popen[str]:
+    command = [
+        str(args.emt_bin),
+        "--headless",
+        "--export",
+        "prometheus",
+        "--bind",
+        args.host,
+        "--port",
+        str(args.port),
+        "--rate",
+        str(args.rate),
+        "--scan-interval",
+        str(args.scan_interval),
+    ]
+    print("$ " + " ".join(command))
+    return subprocess.Popen(
+        command,
+        cwd=PROJECT_ROOT,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+
+
+def start_workload(duration_seconds: float) -> subprocess.Popen[str]:
+    code = f"""
+import math
+import time
+
+deadline = time.monotonic() + {duration_seconds!r}
+value = 0.0
+while time.monotonic() < deadline:
+    for i in range(20_000):
+        value += math.sqrt((i % 97) + 1.0)
+print(value)
+"""
+    return subprocess.Popen(
+        [sys.executable, "-c", code],
+        cwd=PROJECT_ROOT,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+def stop_exporter(process: subprocess.Popen[str] | None) -> None:
+    if process is None or process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
+
+
+def collect_samples(
+    url: str,
+    count: int,
+    interval_seconds: float,
+    process: subprocess.Popen[str] | None,
+) -> list[MetricsSample]:
+    samples: list[MetricsSample] = []
+    for index in range(count):
+        failure = process_failure(process)
+        if failure:
+            raise RuntimeError(failure)
+        system_cpu, workload_cpu = read_metrics(url)
+        samples.append(MetricsSample(index, system_cpu, workload_cpu))
+        if index + 1 < count:
+            time.sleep(interval_seconds)
+    return samples
+
+
+def select_workload(samples: list[MetricsSample]) -> str | None:
+    workload_ids = {
+        workload_id for sample in samples for workload_id in sample.workload_cpu
+    }
+    best_id: str | None = None
+    best_delta = 0.0
+    for workload_id in workload_ids:
+        series = [
+            sample.workload_cpu.get(workload_id, PowerReading()) for sample in samples
+        ]
+        delta = series[-1].energy_joules - series[0].energy_joules
+        if delta > best_delta:
+            best_delta = delta
+            best_id = workload_id
+    return best_id
+
+
+def print_samples(samples: list[MetricsSample], workload_id: str | None) -> None:
+    print(
+        "idx,"
+        "system_cpu_energy_joules,system_cpu_power_watts,"
+        "workload_id,workload_cpu_energy_joules,workload_cpu_power_watts"
+    )
+    for sample in samples:
+        system_marker = " *" if sample.system_cpu.power_watts > POWER_EPSILON else ""
+        workload = (
+            sample.workload_cpu.get(workload_id, PowerReading())
+            if workload_id is not None
+            else PowerReading()
+        )
+        workload_marker = " *" if workload.power_watts > POWER_EPSILON else ""
+        print(
+            f"{sample.index:02d},"
+            f"{sample.system_cpu.energy_joules:.9f},"
+            f"{sample.system_cpu.power_watts:.9f}{system_marker},"
+            f"{workload_id or '-'},"
+            f"{workload.energy_joules:.9f},"
+            f"{workload.power_watts:.9f}{workload_marker}"
+        )
+
+
+def evaluate_series(
+    name: str,
+    series: list[PowerReading],
+    *,
+    min_energy_changes: int,
+    min_post_power_samples: int,
+) -> tuple[bool, str]:
+    energy_changes = sum(
+        1
+        for previous, current in zip(series, series[1:])
+        if current.energy_joules > previous.energy_joules + ENERGY_EPSILON
+    )
+    total_energy_delta = series[-1].energy_joules - series[0].energy_joules
+    first_nonzero_power = next(
+        (
+            index
+            for index, sample in enumerate(series)
+            if sample.power_watts > POWER_EPSILON
+        ),
+        None,
+    )
+    zero_after_nonzero = 0
+    if first_nonzero_power is not None:
+        zero_after_nonzero = sum(
+            1
+            for sample in series[first_nonzero_power + 1 :]
+            if sample.power_watts <= POWER_EPSILON
+        )
+    post_power_samples = (
+        0 if first_nonzero_power is None else len(series) - first_nonzero_power - 1
+    )
+
+    summary = (
+        f"{name}: energy_changes={energy_changes} "
+        f"total_energy_delta={total_energy_delta:.6f} "
+        f"post_power_samples={post_power_samples} "
+        f"zero_after_nonzero={zero_after_nonzero}"
+    )
+    if total_energy_delta <= ENERGY_EPSILON:
+        return False, f"{name} energy did not increase; {summary}"
+    if energy_changes < min_energy_changes:
+        return False, f"{name} had too few energy-changing samples; {summary}"
+    if first_nonzero_power is None:
+        return (
+            False,
+            f"{name} power never became nonzero while energy increased; {summary}",
+        )
+    if post_power_samples < min_post_power_samples:
+        return False, f"{name} had too few samples after first nonzero power; {summary}"
+    if zero_after_nonzero > 0:
+        return False, f"{name} power reset to zero after a nonzero sample; {summary}"
+    return True, summary
+
+
+def evaluate(
+    samples: list[MetricsSample],
+    workload_id: str | None,
+    *,
+    min_energy_changes: int,
+    min_post_power_samples: int,
+) -> tuple[bool, list[str]]:
+    results: list[str] = []
+    system_ok, system_summary = evaluate_series(
+        "system_cpu",
+        [sample.system_cpu for sample in samples],
+        min_energy_changes=min_energy_changes,
+        min_post_power_samples=min_post_power_samples,
+    )
+    results.append(system_summary)
+    if not system_ok:
+        return False, results
+
+    if workload_id is None:
+        results.append("workload_cpu: no workload CPU series was exported")
+        return False, results
+
+    workload_ok, workload_summary = evaluate_series(
+        f"workload_cpu[{workload_id}]",
+        [sample.workload_cpu.get(workload_id, PowerReading()) for sample in samples],
+        min_energy_changes=min_energy_changes,
+        min_post_power_samples=min_post_power_samples,
+    )
+    results.append(workload_summary)
+    return workload_ok, results
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--emt-bin", type=Path, default=DEFAULT_EMT_BIN)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=19104)
+    parser.add_argument("--rate", type=float, default=4.0)
+    parser.add_argument("--scan-interval", type=float, default=1.0)
+    parser.add_argument("--samples", type=int, default=50)
+    parser.add_argument("--interval", type=float, default=0.1)
+    parser.add_argument("--warmup", type=float, default=1.5)
+    parser.add_argument("--startup-timeout", type=float, default=8.0)
+    parser.add_argument("--min-energy-changes", type=int, default=3)
+    parser.add_argument("--min-post-power-samples", type=int, default=3)
+    parser.add_argument(
+        "--url",
+        help="Probe an already-running exporter instead of starting one.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.samples < 3:
+        raise SystemExit("--samples must be at least 3")
+    if args.interval <= 0:
+        raise SystemExit("--interval must be positive")
+    if args.warmup < 0:
+        raise SystemExit("--warmup must be non-negative")
+    if args.min_energy_changes < 1:
+        raise SystemExit("--min-energy-changes must be at least 1")
+    if args.min_post_power_samples < 1:
+        raise SystemExit("--min-post-power-samples must be at least 1")
+
+    process: subprocess.Popen[str] | None = None
+    workload: subprocess.Popen[str] | None = None
+    url = args.url or f"http://{args.host}:{args.port}/metrics"
+    try:
+        workload_duration = (
+            args.startup_timeout + args.warmup + args.samples * args.interval + 2.0
+        )
+        workload = start_workload(workload_duration)
+        if args.url is None:
+            if not args.emt_bin.exists():
+                raise SystemExit(f"EMT binary not found: {args.emt_bin}")
+            assert_endpoint_unused(url)
+            process = start_exporter(args)
+        wait_for_metrics(url, args.startup_timeout, process)
+        if args.warmup:
+            time.sleep(args.warmup)
+        samples = collect_samples(url, args.samples, args.interval, process)
+        workload_id = select_workload(samples)
+        print_samples(samples, workload_id)
+        ok, summaries = evaluate(
+            samples,
+            workload_id,
+            min_energy_changes=args.min_energy_changes,
+            min_post_power_samples=args.min_post_power_samples,
+        )
+        for summary in summaries:
+            print(summary)
+        if not ok:
+            return 1
+        print("Prometheus power cadence probe passed.")
+        return 0
+    finally:
+        stop_exporter(process)
+        stop_exporter(workload)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/energy_group.rs
+++ b/src/energy_group.rs
@@ -200,6 +200,11 @@ impl<T: EnergyCollector> EnergyGroup<T> {
         self.is_running.load(Ordering::SeqCst)
     }
 
+    #[cfg(test)]
+    pub(crate) fn batch_size(&self) -> usize {
+        self.batch_size
+    }
+
     /// Background monitoring task that collects data at a specified rate and sends batches
     async fn run_monitoring_loop<C: EnergyCollector>(
         collector: Arc<C>,

--- a/src/metrics_sink.rs
+++ b/src/metrics_sink.rs
@@ -7,7 +7,7 @@ use axum::routing::get;
 use prometheus::core::{Collector, Desc};
 use prometheus::proto::{Counter, Gauge, LabelPair, Metric, MetricFamily, MetricType};
 use prometheus::{Encoder, Registry, TextEncoder};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, MutexGuard};
 
 const SOCKET_LABEL: &str = "0";
@@ -109,11 +109,23 @@ struct PrometheusState {
 
 impl PrometheusState {
     fn update(&mut self, snapshot: &MetricsSnapshot) {
-        let previous = self.previous.as_ref();
-
         self.energy_samples = energy_samples(snapshot);
-        self.power_samples = power_samples(snapshot, previous);
-        self.previous = Some(PreviousSnapshot::from(snapshot));
+
+        let Some(previous) = self.previous.as_ref() else {
+            self.power_samples = zero_power_samples(snapshot);
+            self.previous = Some(PreviousSnapshot::from(snapshot));
+            return;
+        };
+
+        if snapshot_has_energy_change(snapshot, previous) && snapshot.timestamp > previous.timestamp
+        {
+            let mut power_samples = power_samples(snapshot, Some(previous));
+            zero_non_live_workload_power_samples(snapshot, &mut power_samples);
+            self.power_samples = power_samples;
+            self.previous = Some(PreviousSnapshot::from(snapshot));
+        } else {
+            self.power_samples = preserve_power_samples(snapshot, &self.power_samples);
+        }
     }
 
     fn collect(&self) -> Vec<MetricFamily> {
@@ -270,6 +282,104 @@ fn zero_power_samples(snapshot: &MetricsSnapshot) -> Vec<MetricSample> {
     }
 
     samples
+}
+
+fn preserve_power_samples(
+    snapshot: &MetricsSnapshot,
+    previous_samples: &[MetricSample],
+) -> Vec<MetricSample> {
+    let previous_values = previous_samples
+        .iter()
+        .map(|sample| (power_sample_key(sample), sample.value))
+        .collect::<HashMap<_, _>>();
+    let non_live_workloads = snapshot
+        .workloads
+        .iter()
+        .filter(|workload| !workload.is_live)
+        .map(workload_key)
+        .collect::<HashSet<_>>();
+
+    let mut samples = zero_power_samples(snapshot);
+    for sample in &mut samples {
+        if sample_is_non_live_workload(sample, &non_live_workloads) {
+            continue;
+        }
+
+        if let Some(value) = previous_values.get(&power_sample_key(sample)) {
+            sample.value = *value;
+        }
+    }
+    samples
+}
+
+fn zero_non_live_workload_power_samples(snapshot: &MetricsSnapshot, samples: &mut [MetricSample]) {
+    let non_live_workloads = snapshot
+        .workloads
+        .iter()
+        .filter(|workload| !workload.is_live)
+        .map(workload_key)
+        .collect::<HashSet<_>>();
+
+    for sample in samples {
+        if sample_is_non_live_workload(sample, &non_live_workloads) {
+            sample.value = 0.0;
+        }
+    }
+}
+
+fn sample_is_non_live_workload(
+    sample: &MetricSample,
+    non_live_workloads: &HashSet<String>,
+) -> bool {
+    sample_label(sample, "scope") == Some("workload")
+        && sample_label(sample, "workload")
+            .is_some_and(|workload| non_live_workloads.contains(workload))
+}
+
+fn snapshot_has_energy_change(snapshot: &MetricsSnapshot, previous: &PreviousSnapshot) -> bool {
+    if device_energy_changed(&snapshot.system_total, &previous.system_total) {
+        return true;
+    }
+
+    for workload in &snapshot.workloads {
+        let key = workload_key(workload);
+        let Some(previous_energy) = previous.workloads.get(&key) else {
+            return workload.energy.total() > f64::EPSILON;
+        };
+        if device_energy_changed(&workload.energy, previous_energy) {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn device_energy_changed(left: &DeviceEnergy, right: &DeviceEnergy) -> bool {
+    (left.cpu_joules - right.cpu_joules).abs() > f64::EPSILON
+        || (left.dram_joules - right.dram_joules).abs() > f64::EPSILON
+        || (left.gpu_joules - right.gpu_joules).abs() > f64::EPSILON
+}
+
+fn power_sample_key(sample: &MetricSample) -> (String, String, String, Option<String>) {
+    (
+        sample_label(sample, "scope")
+            .unwrap_or_default()
+            .to_string(),
+        sample_label(sample, "device")
+            .unwrap_or_default()
+            .to_string(),
+        sample_label(sample, "socket")
+            .unwrap_or_default()
+            .to_string(),
+        sample_label(sample, "workload").map(ToString::to_string),
+    )
+}
+
+fn sample_label<'a>(sample: &'a MetricSample, name: &str) -> Option<&'a str> {
+    sample
+        .labels
+        .iter()
+        .find_map(|(label_name, value)| (*label_name == name).then_some(value.as_str()))
 }
 
 fn device_power_samples(
@@ -575,6 +685,114 @@ mod tests {
             "{exposition}"
         );
         assert!(!exposition.contains("workload=\"python\""));
+    }
+
+    #[test]
+    fn prometheus_sink_preserves_power_for_unchanged_energy_snapshots() {
+        let mut sink = PrometheusSink::new().unwrap();
+        sink.update(&snapshot(
+            1_000,
+            energy(10.0, 0.0, 0.0),
+            energy(4.0, 0.0, 0.0),
+        ));
+        sink.update(&snapshot(
+            2_000,
+            energy(18.0, 0.0, 0.0),
+            energy(9.0, 0.0, 0.0),
+        ));
+
+        let exposition = sink.encode_text().unwrap();
+        assert!(
+            exposition.contains("emt_power_watts{device=\"cpu\",scope=\"system\",socket=\"0\"} 8"),
+            "{exposition}"
+        );
+        assert!(
+            exposition.contains(
+                "emt_power_watts{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"group-a\",workload_name=\"render\"} 5"
+            ),
+            "{exposition}"
+        );
+
+        sink.update(&snapshot(
+            2_250,
+            energy(18.0, 0.0, 0.0),
+            energy(9.0, 0.0, 0.0),
+        ));
+
+        let exposition = sink.encode_text().unwrap();
+        assert!(
+            exposition.contains("emt_power_watts{device=\"cpu\",scope=\"system\",socket=\"0\"} 8"),
+            "{exposition}"
+        );
+        assert!(
+            exposition.contains(
+                "emt_power_watts{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"group-a\",workload_name=\"render\"} 5"
+            ),
+            "{exposition}"
+        );
+    }
+
+    #[test]
+    fn prometheus_sink_zeros_power_for_non_live_workloads_without_new_energy() {
+        let mut sink = PrometheusSink::new().unwrap();
+        sink.update(&snapshot(
+            1_000,
+            energy(10.0, 0.0, 0.0),
+            energy(4.0, 0.0, 0.0),
+        ));
+        sink.update(&snapshot(
+            2_000,
+            energy(18.0, 0.0, 0.0),
+            energy(9.0, 0.0, 0.0),
+        ));
+
+        let mut dead_workload = workload("group-a", "render", energy(9.0, 0.0, 0.0));
+        dead_workload.is_live = false;
+        sink.update(
+            &multi_workload_snapshot(2_250, vec![dead_workload])
+                .with_system_total(energy(18.0, 0.0, 0.0)),
+        );
+
+        let exposition = sink.encode_text().unwrap();
+        assert!(
+            exposition.contains("emt_power_watts{device=\"cpu\",scope=\"system\",socket=\"0\"} 8"),
+            "{exposition}"
+        );
+        assert!(
+            exposition.contains(
+                "emt_power_watts{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"group-a\",workload_name=\"render\"} 0"
+            ),
+            "{exposition}"
+        );
+    }
+
+    #[test]
+    fn prometheus_sink_zeros_power_for_non_live_workloads_with_new_energy() {
+        let mut sink = PrometheusSink::new().unwrap();
+        sink.update(&snapshot(
+            1_000,
+            energy(10.0, 0.0, 0.0),
+            energy(4.0, 0.0, 0.0),
+        ));
+
+        let mut dead_workload = workload("group-a", "render", energy(9.0, 0.0, 0.0));
+        dead_workload.is_live = false;
+        sink.update(
+            &multi_workload_snapshot(2_000, vec![dead_workload])
+                .with_system_total(energy(18.0, 0.0, 0.0)),
+        );
+
+        let exposition = sink.encode_text().unwrap();
+        assert!(
+            exposition.contains("emt_power_watts{device=\"cpu\",scope=\"system\",socket=\"0\"} 8"),
+            "{exposition}"
+        );
+        assert!(
+            exposition.contains(
+                "emt_power_watts{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"group-a\",workload_name=\"render\"} 0"
+            ),
+            "{exposition}"
+        );
     }
 
     #[tokio::test]

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -505,8 +505,9 @@ impl Monitor {
     /// to discover all root processes on the system.
     pub fn new(config: EmtConfig, root_pids: Option<Vec<u32>>) -> Self {
         let rate = config.collection.rate_hz;
-        // Batch size = rate (flush once per second for responsive snapshots)
-        let batch_size = Some(rate.ceil() as usize);
+        // Live monitors publish every collection tick. Batching remains available
+        // at the lower EnergyGroup layer for explicit callers.
+        let batch_size = Some(1);
         let rapl = Rapl::default();
         let mut sources = rapl.device_sources();
         let mut rapl_group = EnergyGroup::new(rapl, rate, batch_size);
@@ -1266,6 +1267,19 @@ mod tests {
     }
 
     #[test]
+    fn monitor_live_collectors_flush_every_collection_tick() {
+        let mut config = EmtConfig::default();
+        config.collection.rate_hz = 4.0;
+        let monitor = Monitor::new(config, Some(vec![std::process::id()]));
+
+        assert_eq!(monitor.rapl_group.try_lock().unwrap().batch_size(), 1);
+
+        if let Some(gpu_group) = &monitor.gpu_group {
+            assert_eq!(gpu_group.try_lock().unwrap().batch_size(), 1);
+        }
+    }
+
+    #[test]
     fn metrics_snapshot_serializes_device_sources() {
         let snapshot = MetricsSnapshot {
             sources: DeviceSources {
@@ -1309,8 +1323,7 @@ mod tests {
         let mut monitor = Monitor::new(config, Some(vec![std::process::id()]));
 
         let handle = monitor.commence().await.unwrap();
-        // Wait long enough for at least one batch to flush (batch_size = rate = 10,
-        // so 1 second of collection plus margin for scheduling).
+        // Wait long enough for at least one collection tick plus scheduling margin.
         tokio::time::sleep(Duration::from_secs(3)).await;
 
         // On a RAPL-capable host with readable counters, should have some energy.


### PR DESCRIPTION
## Summary

- Stop deriving Monitor-owned collector batch size from collection rate; live Monitor paths now flush every collection tick.
- Preserve Prometheus power gauges across unchanged energy snapshots so sub-cadence scrapes do not reset power to zero.
- Explicitly zero non-live workload power samples.
- Add a local Prometheus cadence probe that validates both system and workload CPU power against raw /metrics.

## Verification

- cargo test
- cargo build --release
- .venv/bin/python -m pytest
- .venv/bin/black --check .
- .venv/bin/python scripts/probe_prometheus_power_cadence.py --port 19104 --samples 50 --interval 0.1

Final live probe evidence:

- system_cpu: energy_changes=20, zero_after_nonzero=0
- workload_cpu: energy_changes=20, zero_after_nonzero=0

## Independent review

- Rust semantics review: no issues found after inspecting Monitor batch size and Prometheus power preservation/zeroing behavior.
- Probe/docs review: initial findings were fixed; final re-review found no functional issue after removing the misleading workload bypass option.

Resolves ENE-52 and ENE-53.