### PR TITLE
ENE-53 harden Prometheus cadence probe

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -26,10 +26,11 @@ cargo build --release
 .venv/bin/python scripts/probe_prometheus_power_cadence.py
 ```
 
-The probe starts a short CPU workload and the headless Prometheus exporter at
-the demo cadence, samples `/metrics` faster than the collection rate, and fails
-if either system or workload CPU energy increases while `emt_power_watts` falls
-back to zero. If the probe fails before energy increases, check host permissions
-and hardware counter availability before treating it as a cadence regression.
+The probe starts a short CPU workload, runs the headless Prometheus exporter
+against that workload PID at the demo cadence, samples `/metrics` faster than the
+collection rate, and fails if either system or workload CPU energy increases
+while `emt_power_watts` falls back to zero. If the probe fails before energy
+increases, check host permissions and hardware counter availability before
+treating it as a cadence regression.
 
 *See [Virtualization Challenges](virtualization_challenges.md) for more details on technical hurdles.*

--- a/scripts/probe_prometheus_power_cadence.py
+++ b/scripts/probe_prometheus_power_cadence.py
@@ -142,7 +142,14 @@ def wait_for_metrics(
     raise RuntimeError(f"metrics endpoint did not become ready: {last_error}")
 
 
-def start_exporter(args: argparse.Namespace) -> subprocess.Popen[str]:
+def workload_id_for_process(process: subprocess.Popen[str]) -> str:
+    return f"pid:{process.pid}"
+
+
+def start_exporter(
+    args: argparse.Namespace,
+    workload_pid: int | None,
+) -> subprocess.Popen[str]:
     command = [
         str(args.emt_bin),
         "--headless",
@@ -157,6 +164,8 @@ def start_exporter(args: argparse.Namespace) -> subprocess.Popen[str]:
         "--scan-interval",
         str(args.scan_interval),
     ]
+    if workload_pid is not None:
+        command.extend(["--pid", str(workload_pid)])
     print("$ " + " ".join(command))
     return subprocess.Popen(
         command,
@@ -218,7 +227,13 @@ def collect_samples(
     return samples
 
 
-def select_workload(samples: list[MetricsSample]) -> str | None:
+def select_workload(
+    samples: list[MetricsSample],
+    expected_workload_id: str | None,
+) -> str | None:
+    if expected_workload_id is not None:
+        return expected_workload_id
+
     workload_ids = {
         workload_id for sample in samples for workload_id in sample.workload_cpu
     }
@@ -386,16 +401,18 @@ def main() -> int:
             args.startup_timeout + args.warmup + args.samples * args.interval + 2.0
         )
         workload = start_workload(workload_duration)
+        expected_workload_id: str | None = None
         if args.url is None:
             if not args.emt_bin.exists():
                 raise SystemExit(f"EMT binary not found: {args.emt_bin}")
             assert_endpoint_unused(url)
-            process = start_exporter(args)
+            expected_workload_id = workload_id_for_process(workload)
+            process = start_exporter(args, workload.pid)
         wait_for_metrics(url, args.startup_timeout, process)
         if args.warmup:
             time.sleep(args.warmup)
         samples = collect_samples(url, args.samples, args.interval, process)
-        workload_id = select_workload(samples)
+        workload_id = select_workload(samples, expected_workload_id)
         print_samples(samples, workload_id)
         ok, summaries = evaluate(
             samples,

--- a/src/metrics_sink.rs
+++ b/src/metrics_sink.rs
@@ -534,6 +534,22 @@ mod tests {
     use axum::http::Request;
     use tower::ServiceExt;
 
+    fn assert_metric_value(exposition: &str, prefix: &str, expected: f64) {
+        let line = exposition
+            .lines()
+            .find(|line| line.starts_with(prefix))
+            .unwrap_or_else(|| panic!("missing metric line starting with {prefix}: {exposition}"));
+        let value = line
+            .rsplit_once(' ')
+            .and_then(|(_, value)| value.parse::<f64>().ok())
+            .unwrap_or_else(|| panic!("missing numeric metric value in {line}: {exposition}"));
+
+        assert!(
+            (value - expected).abs() <= f64::EPSILON,
+            "expected {prefix} to be {expected}, got {value}: {exposition}"
+        );
+    }
+
     #[test]
     fn prometheus_sink_exports_energy_and_power_for_system_and_workloads() {
         let mut sink = PrometheusSink::new().unwrap();
@@ -612,15 +628,15 @@ mod tests {
 
         let exposition = sink.encode_text().unwrap();
 
-        assert!(
-            exposition.contains("emt_power_watts{device=\"cpu\",scope=\"system\",socket=\"0\"} 0"),
-            "{exposition}"
+        assert_metric_value(
+            &exposition,
+            "emt_power_watts{device=\"cpu\",scope=\"system\",socket=\"0\"}",
+            0.0,
         );
-        assert!(
-            exposition.contains(
-                "emt_power_watts{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"group-a\",workload_name=\"render\"} 0"
-            ),
-            "{exposition}"
+        assert_metric_value(
+            &exposition,
+            "emt_power_watts{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"group-a\",workload_name=\"render\"}",
+            0.0,
         );
     }
 
@@ -702,15 +718,15 @@ mod tests {
         ));
 
         let exposition = sink.encode_text().unwrap();
-        assert!(
-            exposition.contains("emt_power_watts{device=\"cpu\",scope=\"system\",socket=\"0\"} 8"),
-            "{exposition}"
+        assert_metric_value(
+            &exposition,
+            "emt_power_watts{device=\"cpu\",scope=\"system\",socket=\"0\"}",
+            8.0,
         );
-        assert!(
-            exposition.contains(
-                "emt_power_watts{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"group-a\",workload_name=\"render\"} 5"
-            ),
-            "{exposition}"
+        assert_metric_value(
+            &exposition,
+            "emt_power_watts{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"group-a\",workload_name=\"render\"}",
+            5.0,
         );
 
         sink.update(&snapshot(
@@ -720,15 +736,15 @@ mod tests {
         ));
 
         let exposition = sink.encode_text().unwrap();
-        assert!(
-            exposition.contains("emt_power_watts{device=\"cpu\",scope=\"system\",socket=\"0\"} 8"),
-            "{exposition}"
+        assert_metric_value(
+            &exposition,
+            "emt_power_watts{device=\"cpu\",scope=\"system\",socket=\"0\"}",
+            8.0,
         );
-        assert!(
-            exposition.contains(
-                "emt_power_watts{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"group-a\",workload_name=\"render\"} 5"
-            ),
-            "{exposition}"
+        assert_metric_value(
+            &exposition,
+            "emt_power_watts{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"group-a\",workload_name=\"render\"}",
+            5.0,
         );
     }
 
@@ -754,15 +770,15 @@ mod tests {
         );
 
         let exposition = sink.encode_text().unwrap();
-        assert!(
-            exposition.contains("emt_power_watts{device=\"cpu\",scope=\"system\",socket=\"0\"} 8"),
-            "{exposition}"
+        assert_metric_value(
+            &exposition,
+            "emt_power_watts{device=\"cpu\",scope=\"system\",socket=\"0\"}",
+            8.0,
         );
-        assert!(
-            exposition.contains(
-                "emt_power_watts{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"group-a\",workload_name=\"render\"} 0"
-            ),
-            "{exposition}"
+        assert_metric_value(
+            &exposition,
+            "emt_power_watts{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"group-a\",workload_name=\"render\"}",
+            0.0,
         );
     }
 
@@ -783,15 +799,15 @@ mod tests {
         );
 
         let exposition = sink.encode_text().unwrap();
-        assert!(
-            exposition.contains("emt_power_watts{device=\"cpu\",scope=\"system\",socket=\"0\"} 8"),
-            "{exposition}"
+        assert_metric_value(
+            &exposition,
+            "emt_power_watts{device=\"cpu\",scope=\"system\",socket=\"0\"}",
+            8.0,
         );
-        assert!(
-            exposition.contains(
-                "emt_power_watts{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"group-a\",workload_name=\"render\"} 0"
-            ),
-            "{exposition}"
+        assert_metric_value(
+            &exposition,
+            "emt_power_watts{device=\"cpu\",scope=\"workload\",socket=\"0\",workload=\"group-a\",workload_name=\"render\"}",
+            0.0,
         );
     }
 

--- a/tests/test_verification_scripts.py
+++ b/tests/test_verification_scripts.py
@@ -2,9 +2,11 @@ import builtins
 import json
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+from scripts import probe_prometheus_power_cadence as cadence_probe
 from scripts import verification_workload
 from scripts import verify
 
@@ -363,3 +365,117 @@ def test_measure_method_catches_subprocess_errors(monkeypatch, capsys):
 
     assert results == []
     assert "subprocess failed" in capsys.readouterr().out
+
+
+def test_prometheus_probe_parses_system_and_workload_cpu_metrics(monkeypatch):
+    metrics_text = """
+# HELP emt_energy_joules_total Energy
+emt_energy_joules_total{device="cpu",scope="system",socket="0"} 12.5
+emt_power_watts{device="cpu",scope="system",socket="0"} 4.25
+emt_energy_joules_total{device="cpu",scope="workload",socket="0",workload="pid:123",workload_name="python"} 7.0
+emt_power_watts{device="cpu",scope="workload",socket="0",workload="pid:123",workload_name="python"} 3.5
+emt_energy_joules_total{device="gpu",scope="system",socket="0"} 99
+"""
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+        def read(self):
+            return metrics_text.encode("utf-8")
+
+    monkeypatch.setattr(
+        cadence_probe.urllib.request,
+        "urlopen",
+        lambda _url, timeout: FakeResponse(),
+    )
+
+    system_cpu, workloads = cadence_probe.read_metrics("http://example.test/metrics")
+
+    assert system_cpu.energy_joules == pytest.approx(12.5)
+    assert system_cpu.power_watts == pytest.approx(4.25)
+    assert workloads["pid:123"] == cadence_probe.PowerReading(7.0, 3.5, "python")
+
+
+def test_prometheus_probe_prefers_expected_workload_pid_over_busy_host_workload():
+    samples = [
+        cadence_probe.MetricsSample(
+            0,
+            cadence_probe.PowerReading(10.0, 0.0),
+            {
+                "pid:123": cadence_probe.PowerReading(1.0, 0.0),
+                "pgrp:busy": cadence_probe.PowerReading(10.0, 0.0),
+            },
+        ),
+        cadence_probe.MetricsSample(
+            1,
+            cadence_probe.PowerReading(12.0, 2.0),
+            {
+                "pid:123": cadence_probe.PowerReading(2.0, 1.0),
+                "pgrp:busy": cadence_probe.PowerReading(50.0, 40.0),
+            },
+        ),
+    ]
+
+    assert cadence_probe.select_workload(samples, "pid:123") == "pid:123"
+    assert cadence_probe.select_workload(samples, None) == "pgrp:busy"
+
+
+def test_prometheus_probe_starts_exporter_for_workload_pid(monkeypatch):
+    calls = []
+    args = SimpleNamespace(
+        emt_bin=Path("/tmp/emt"),
+        host="127.0.0.1",
+        port=19104,
+        rate=4.0,
+        scan_interval=1.0,
+    )
+
+    class FakeProcess:
+        pass
+
+    def fake_popen(command, **kwargs):
+        calls.append((command, kwargs))
+        return FakeProcess()
+
+    monkeypatch.setattr(cadence_probe.subprocess, "Popen", fake_popen)
+
+    cadence_probe.start_exporter(args, workload_pid=123)
+
+    command, kwargs = calls[0]
+    assert command[command.index("--pid") + 1] == "123"
+    assert kwargs["cwd"] == cadence_probe.PROJECT_ROOT
+    assert kwargs["start_new_session"] is True
+
+
+def test_prometheus_probe_evaluate_fails_on_power_reset_after_nonzero():
+    samples = [
+        cadence_probe.MetricsSample(
+            0,
+            cadence_probe.PowerReading(10.0, 0.0),
+            {"pid:123": cadence_probe.PowerReading(4.0, 0.0)},
+        ),
+        cadence_probe.MetricsSample(
+            1,
+            cadence_probe.PowerReading(12.0, 2.0),
+            {"pid:123": cadence_probe.PowerReading(5.0, 1.0)},
+        ),
+        cadence_probe.MetricsSample(
+            2,
+            cadence_probe.PowerReading(12.0, 0.0),
+            {"pid:123": cadence_probe.PowerReading(5.0, 0.0)},
+        ),
+    ]
+
+    ok, summaries = cadence_probe.evaluate(
+        samples,
+        "pid:123",
+        min_energy_changes=1,
+        min_post_power_samples=1,
+    )
+
+    assert ok is False
+    assert "power reset to zero" in summaries[0]


### PR DESCRIPTION

## Summary

Follow-up from the independent ENE-52/ENE-53 review.

- Run the Prometheus cadence probe exporter against the synthetic workload PID instead of monitor-all mode, so a busy host cannot satisfy the workload check with an unrelated process.
- Add Python unit coverage for probe metric parsing, workload selection, exporter command wiring, and nonzero-to-zero power regression detection.
- Harden Rust Prometheus sink assertions by parsing exact metric values instead of substring-matching zero-valued samples.
- Update the local probe docs to describe the workload-pinned behavior.

## Verification

- `cargo fmt --check`
- `.venv/bin/black --check .`
- `.venv/bin/python -m py_compile scripts/probe_prometheus_power_cadence.py`
- `git diff --check`
- `cargo test`
- `.venv/bin/python -m pytest`
- `cargo build --release`
- `.venv/bin/python scripts/probe_prometheus_power_cadence.py --port 19104 --samples 50 --interval 0.1`

Live probe result: system and workload CPU both had `zero_after_nonzero=0`; workload was explicitly monitored as `pid:<workload>`.

Refs ENE-53.
